### PR TITLE
Fix lowestRate

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -400,7 +400,7 @@ module.exports = function (apiKey, options) {
                 continue;
             }
 
-            if (lowestRate === null || lowestRate.rate > this.rates[i].rate) {
+            if (lowestRate === null || +lowestRate.rate > +this.rates[i].rate) {
                 lowestRate = this.rates[i];
             }
         }


### PR DESCRIPTION
The rates are strings, and JavaScript compares them character by character rather than numerically. So, e.g. `'27.50' < '5.50'`. This converts them to numbers before comparing so the actual lowest rate is returned.
