### PR TITLE
fixed broken test / code

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -76,9 +76,12 @@ module.exports = function (apiKey, options) {
         delete params.apiKey;
         this.encodeParams(params);
         var requestData = querystring.stringify(this.queryParams);
+        method = method.toUpperCase();
 
         path = '/v2' + path;
         var auth = 'Basic ' + new Buffer(apiKey + ":").toString('base64');
+        
+        if(requestData) method = 'POST';
 
         var request_options = {
             host: 'api.easypost.com',
@@ -94,7 +97,7 @@ module.exports = function (apiKey, options) {
                 'Content-Length': requestData.length
             }
         };
-
+        
         var req = https.request(request_options);
         // var req = http.request(request_options);
         this.responseListener(req, callback, parent);
@@ -297,7 +300,7 @@ module.exports = function (apiKey, options) {
     }
     easypost.Parcel.create = function(params, cb) { var args = normalizeArgs(arguments); easypost.Resource.create('parcel', args.params, args.cb); }
     easypost.Parcel.retrieve = function(params, cb) { var args = normalizeArgs(arguments); easypost.Resource.retrieve('parcel', args.params, args.cb); }
-    easypost.Parcel.all = function(params, cb) { var args = normalizeArgs(arguments); easypost.Resource.all('parcel', args.params, args.cb); }
+    easypost.Parcel.all = function(params, cb) { var args = normalizeArgs(arguments); easypost.Resource.all('parcel', {parcel: args.params}, args.cb); }
     easypost.Parcel.prototype = new easypost.Resource();
     easypost.Parcel.prototype.constructor = easypost.Parcel;
 

--- a/test/main.js
+++ b/test/main.js
@@ -158,11 +158,17 @@ vows.describe("EasyPost API").addBatch({
     'Parcel': {
         'standard list': {
             topic: function() {
-                easypost.Parcel.all(this.callback);
+                easypost.Parcel.all({
+                  length: 12,
+                  width: 10,
+                  height: 5,
+                  weight: 12
+                }, this.callback);
             },
             'should return list of Parcels': function(err, response) {
                 assert.isNull(err);
-                assert.instanceOf(response, Array);
+                assert.isDefined(response);
+                assert.equal(response.object, 'Parcel');
             }
         }
     }


### PR DESCRIPTION
- Parcel is a post but internal 'all' code sets it as a 'GET'
- Parcel all also did not wrap arguments correctly had to pass  { parcel: args } to resolver.
- If request handler sees a payload it will force a 'POST'
- capitalized all methods for request (standardizing)

Test changes
- parcel required argument (width, length, height, weight)
- test was expecting result to an array.. changed it to expect single Parcel object.
