### PR TITLE
Add Meteor package support

### DIFF
--- a/meteor/README.md
+++ b/meteor/README.md
@@ -1,0 +1,13 @@
+Meteor package wrapper for https://github.com/EasyPost/easypost-node
+
+The Meteor package version will match the original npm package version.
+
+Usage:
+
+```
+var easypost = Easypost('<your API key here>');
+```
+
+# Maintainer instructions: 
+
+Simply bump the app version in `package.json` to match the npm package, then run `meteor publish` in this folder.

--- a/meteor/easypost-tests.js
+++ b/meteor/easypost-tests.js
@@ -1,0 +1,4 @@
+//Easypost = Npm.require('node-easypost');
+Tinytest.add('npm module required', function (test) {
+  return true;
+});

--- a/meteor/easypost.js
+++ b/meteor/easypost.js
@@ -1,0 +1,1 @@
+Easypost = Npm.require('node-easypost');

--- a/meteor/package.js
+++ b/meteor/package.js
@@ -1,0 +1,28 @@
+Package.describe({
+  name: 'easypost:easypost',
+  version: '2.0.7',
+  // Brief, one-line summary of the package.
+  summary: 'Meteor version of node-easypost',
+  // URL to the Git repository containing the source code for this package.
+  git: 'https://github.com/Easyport/easypost-node.git',
+  // By default, Meteor will default to using README.md for documentation.
+  // To avoid submitting documentation, set this field to null.
+  documentation: 'README.md'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.0.3.1');
+  api.export('Easypost', 'server');
+  api.addFiles('easypost.js', 'server');
+});
+
+Package.onTest(function(api) {
+  api.use('tinytest');
+  api.use('easypost');
+  api.addFiles('easypost-tests.js');
+});
+
+Npm.depends({
+  // update this version with each npm package release
+  'node-easypost': "2.0.7"
+});


### PR DESCRIPTION
You will need to create a Meteor Developer Account named 'easypost' on https://atmospherejs.com/ (or an organization - I can help with that).

Tests are not included in this version, but could be easily hooked up to run the existing easypost-node test suite.

Please let me know if you have any other questions related to this package.

If the PR gets accepted and you publish under the `easypost` namespace on AtmosphereJS, I'll go ahead and flag [adyus:easypost](https://atmospherejs.com/adyus/easypost) as obsolete and point devs to `easypost:easypost` in the Readme.

Thanks,
Andrei
