### PR TITLE
Add timeout option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var https = require('https');
-// var http = require('http');
 var querystring = require('querystring');
 
 module.exports = function (apiKey, options) {
@@ -76,7 +75,7 @@ module.exports = function (apiKey, options) {
     var Requestor = function(myApiKey) {
         this.apiKey = myApiKey || apiKey;
         this.queryParams = {};
-
+        this.timeout = options.timeout || 120000;
     }
     Requestor.prototype.request = function(method, path, params, callback, parent) {
         var pather = require('path')
@@ -111,15 +110,12 @@ module.exports = function (apiKey, options) {
         var request_options = {
             host: 'api.easypost.com',
             port: '443',
-            // host: 'localhost',
-            // port: '5000',
             path: path,
             method: method,
             headers: headers
         };
 
         var req = https.request(request_options);
-        // var req = http.request(request_options);
         this.responseListener(req, callback, parent);
         req.write(requestData);
         req.end();
@@ -160,6 +156,14 @@ module.exports = function (apiKey, options) {
             throw new easypost.Error("Requestor requires a callback to handle response.");
         }
 
+        var timeout = this.timeout;
+        req.setTimeout(timeout, function() {
+            req._isAborted = true;
+            req.abort();
+            var timeoutErr = new easypost.Error('Request has been aborted because it did not respond within the timeout limit of ' + timeout + 'ms.', 'ETIMEDOUT');
+            cb(timeoutErr);
+        });
+
         req.on('response', function(res) {
             var response = '';
             res.setEncoding('utf8');
@@ -199,6 +203,9 @@ module.exports = function (apiKey, options) {
             });
         });
         req.on('error', function(err) {
+            if (req._isAborted) {
+                return; // its already been handled
+            }
             cb(err);
         });
     }

--- a/test/main.js
+++ b/test/main.js
@@ -1,12 +1,10 @@
 var vows = require('vows'),
-    assert = require('assert'),
-    sys = require('sys');
+    assert = require('assert');
 
-// var apiKey = 'LKpiBIk6tqKeh0q8GLN3RA';
 var apiKey = 'cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi';
 
 if (!apiKey) {
-    sys.puts('API key required.');
+    console.error('API key required.');
     process.exit(2);
 }
 
@@ -486,6 +484,25 @@ vows.describe("EasyPost API").addBatch({
                         }
                     }
                 }
+            }
+        }
+    }
+}).addBatch({
+    'Requestor': {
+        'request': {
+            topic: function() {
+                timeoutEasypost = require('./../lib/main.js')(apiKey, {timeout: 1});
+                timeoutEasypost.Address.create({
+                	name: 'Dr. Steve Brule',
+                	street1: '179 N Harbor Dr',
+                	city: 'Redondo Beach',
+                	state: 'CA',
+                	zip: '90277',
+                	country: 'US'}, this.callback)
+            },
+            'should timeout': function(err, response) {
+                assert.equal(err.param, 'ETIMEDOUT');
+                assert.equal(err.message, 'Request has been aborted because it did not respond within the timeout limit of 1ms.');
             }
         }
     }


### PR DESCRIPTION
This commit adds an optional timeout param into the easypost library.
This gives users the ability to specify what timeout value they would
like to use when making requests to the Easypost API.

If a timeout is not passed in, a default timeout of 120000ms is used.