### PR TITLE
/scan_forms endpoint (api.ScanForm)

### DIFF
--- a/src/easypost.js
+++ b/src/easypost.js
@@ -15,6 +15,7 @@ import Order from './resources/order';
 import Parcel from './resources/parcel';
 import PaymentLogReport from './resources/payment_log_report';
 import Pickup from './resources/pickup';
+import ScanForm from './resources/scan_form';
 import Shipment from './resources/shipment';
 import ShipmentReport from './resources/shipment_report';
 import Tracker from './resources/tracker';
@@ -67,6 +68,7 @@ export const RESOURCES = {
   Parcel,
   PaymentLogReport,
   Pickup,
+  ScanForm,
   Shipment,
   ShipmentReport,
   Tracker,

--- a/src/resources/scan_form.js
+++ b/src/resources/scan_form.js
@@ -1,0 +1,39 @@
+import T from 'proptypes';
+import base from './base';
+import address from './address';
+
+export default (api) => {
+  const Address = address(api);
+
+  return class ScanForm extends base(api) {
+    static _name = 'ScanForm';
+    static url = 'scan_forms';
+
+    static propTypes = {
+      id: T.string,
+      object: T.string,
+      status: T.string,
+      message: T.string,
+      address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
+      tracking_codes: T.arrayOf(T.string),
+      form_url: T.string,
+      form_file_type: T.string,
+      batch_id: T.string,
+      created_at: T.object,
+      updated_at: T.object,
+    }
+
+    static delete() {
+      return this.notImplemented('delete');
+    }
+
+    static wrapJSON(json) {
+      return json;
+    }
+
+    toJSON() {
+      if (this.shipments) return { shipments: this.shipments };
+      return super.toJSON();
+    }
+  };
+};

--- a/test/resources/scan_form.js
+++ b/test/resources/scan_form.js
@@ -1,0 +1,50 @@
+import apiStub from '../helpers/apiStub';
+import NotImplementedError from '../../src/errors/notImplemented';
+
+import scanForm from '../../src/resources/scan_form';
+
+describe('ScanForm Resource', () => {
+  it('exists', () => {
+    expect(scanForm).to.not.be.undefined;
+    expect(scanForm).to.be.a('function');
+  });
+
+  it('unwraps array responses', () => {
+    const ScanForm = scanForm(apiStub());
+    const data = [new ScanForm()];
+    expect(ScanForm.unwrapAll({ scan_forms: data })).to.deep.equal(data);
+  });
+
+  it('throws on delete', () => {
+    const ScanForm = scanForm(apiStub());
+    ScanForm.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
+  describe('toJSON', () => {
+    let ScanForm;
+    let stub;
+
+    beforeEach(() => {
+      stub = apiStub();
+      ScanForm = scanForm(stub);
+    });
+
+    it('returns the shipments if available', () => {
+      const shipments = { shipments: [{ id: 'shp_123' }] };
+      const sf = new ScanForm(shipments);
+      expect(sf.toJSON()).to.deep.equal(shipments);
+    });
+
+    it('wrapJSON returns the json', () => {
+      const json = { foo: 'bar' };
+      expect(ScanForm.wrapJSON(json)).to.deep.equal(json);
+    });
+
+    it('returns and empty object if there\'s no shipments', () => {
+      const sf = new ScanForm();
+      expect(sf.toJSON()).to.deep.equal({});
+    });
+  });
+});


### PR DESCRIPTION
@ajacksified object creation doesn't match the objects that are returned.

curl:
`curl -X POST https://api.easypost.com/api/v2/scan_forms -u <api_key>: -d '{"shipments":[{"id":"shp_59515f02dfb84fbe972c94f69bbb2aec"}]}' -H 'Content-Type: application/json'`

Few questions:
Do I need `jsonIdKeys`? What is that field for?

Should I be overriding `toJSON` so that `new api.ScanForm({shipments: [{id: "shp_59515f02dfb84fbe972c94f69bbb2aec"}]})` works?