### PR TITLE
proptype T.any should be T.oneOfType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-easypost",
   "description": "EasyPost Node Client Library",
-  "version": "3.0.0-rc.7",
+  "version": "3.0.0-rc.8",
   "author": "Easypost Engineering <support@easypost.com>",
   "homepage": "https://easypost.com",
   "repository": {

--- a/src/resources/carrierAccount.js
+++ b/src/resources/carrierAccount.js
@@ -18,8 +18,8 @@ export default api => (
       readable: T.string,
       credentials: T.object,
       test_credentials: T.object,
-      created_at: T.any(T.object, T.string),
-      updated_at: T.any(T.object, T.string),
+      created_at: T.oneOfType([T.object, T.string]),
+      updated_at: T.oneOfType([T.object, T.string]),
     }
 
     static retrieve() {

--- a/src/resources/tracker.js
+++ b/src/resources/tracker.js
@@ -22,8 +22,8 @@ export default api => (
       carrier_detail: T.object,
       public_url: T.string,
       fees: T.array,
-      created_at: T.object,
-      updated_at: T.object,
+      created_at: T.oneOfType([T.object, T.string]),
+      updated_at: T.oneOfType([T.object, T.string]),
     }
 
     static delete() {

--- a/src/resources/user.js
+++ b/src/resources/user.js
@@ -17,11 +17,11 @@ export default api => (
       children: T.array,
 
       // api sends back numbers as strings, even though we want numbers
-      balance: T.any(T.number, T.string),
-      price_per_shipment: T.any(T.number, T.string),
-      recharge_amount: T.any(T.number, T.string),
-      secondary_recharge_amount: T.any(T.number, T.string),
-      recharge_threshold: T.any(T.number, T.string),
+      balance: T.oneOfType([T.object, T.string]),
+      price_per_shipment: T.oneOfType([T.object, T.string]),
+      recharge_amount: T.oneOfType([T.object, T.string]),
+      secondary_recharge_amount: T.oneOfType([T.object, T.string]),
+      recharge_threshold: T.oneOfType([T.object, T.string]),
     }
 
     static all() {


### PR DESCRIPTION
Can't seem to find any docs/usage of `T.any()` https://facebook.github.io/react/docs/typechecking-with-proptypes.html. 

I came across this error when trying to create a Tracker:

    const tracker = new api.Tracker({tracking_code: '9405510200793925708347'})
    tracker.save().then(console.log)
    {
      name: 'ValidationError',
      errors:
       { tracking_details: 'Error: Invalid prop `tracking_details` of type `array` supplied to `Tracker`, expected `object`.',
         created_at: 'Error: Invalid prop `created_at` of type `string` supplied to `Tracker`, expected `object`.',
         updated_at: 'Error: Invalid prop `updated_at` of type `string` supplied to `Tracker`, expected `object`.' },
      status: 422 }

at https://github.com/EasyPost/easypost-node/blob/master/src/resources/base.js#L77

    console.log(key) // 'created_at'
    console.log(this.constructor.propTypes[key]) // null