### PR TITLE
retrieve reports by id without needing to pass the type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@easypost/api",
   "description": "EasyPost Node Client Library",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "author": "Easypost Engineering <support@easypost.com>",
   "homepage": "https://easypost.com",
   "bin": {

--- a/src/resources/report.js
+++ b/src/resources/report.js
@@ -3,6 +3,8 @@ import base from './base';
 
 export default api => (
   class Report extends base(api) {
+    static _url = 'reports';
+
     static propTypes = {
       id: T.string,
       object: T.string,
@@ -26,10 +28,6 @@ export default api => (
 
     static constructUrl(type) {
       return `reports/${type}`;
-    }
-
-    static async retrieve(type, id) {
-      return super.retrieve(id, this.constructUrl(type));
     }
 
     static async all(type, query = {}) {


### PR DESCRIPTION
waiting on backend changes from @victoryftw to make this work (currently 404's because of a routing issue)