### PR TITLE
CustomsItem.value is a string

### DIFF
--- a/src/resources/customsItem.js
+++ b/src/resources/customsItem.js
@@ -15,7 +15,7 @@ export default api => (
       updated_at: T.oneOfType([T.object, T.string]),
       description: T.string,
       quantity: T.number,
-      value: T.number,
+      value: T.string, // decimal, so use as a string instead of a number
       weight: T.number,
       hs_tariff_number: T.string,
       code: T.string,
@@ -29,6 +29,24 @@ export default api => (
 
     static delete() {
       return this.notImplemented('delete');
+    }
+
+    constructor(data) {
+      let value = data.value;
+
+      if (value && typeof value !== 'string') {
+        value = value.toString();
+      }
+
+      super({ ...data, value });
+    }
+
+    async save() {
+      if (this.value && typeof this.value !== 'string') {
+        this.value = this.value.toString();
+      }
+
+      return super.save();
     }
   }
 );

--- a/test/resources/customsItem.js
+++ b/test/resources/customsItem.js
@@ -8,6 +8,23 @@ describe('Customs Item Resource', () => {
     expect(customsItem).to.be.a('function');
   });
 
+  it('converts number `value`s to strings', () => {
+    const CustomsItem = customsItem(apiStub());
+    const ci = new CustomsItem({ value: 20.7 });
+
+    expect(ci.value).to.equal('20.7');
+  });
+
+  it('converts number `value`s to strings on save', () => {
+    const CustomsItem = customsItem(apiStub());
+    const ci = new CustomsItem({ });
+    ci.value = 20.7;
+
+    ci.save();
+
+    expect(ci.value).to.equal('20.7');
+  });
+
   it('throws on all', () => {
     const CustomsItem = customsItem(apiStub());
     CustomsItem.all().then(() => {}, (err) => {


### PR DESCRIPTION
CustomsItem.value is a string in order to represent decimal values;
JSON and javascript only use low precision floats, so treat the value of
`value` like a string, as it comes in over the api.

For #76 