### PR TITLE
Added Rating Endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@easypost/api",
   "description": "EasyPost Node Client Library",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "author": "Easypost Engineering <support@easypost.com>",
   "homepage": "https://easypost.com",
   "bin": {
@@ -45,8 +45,8 @@
     "cross-env": "^4.0.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
-    "eslint-import-resolver-webpack": "^0.8.1",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-import-resolver-webpack": "^0.8.3",
+    "eslint-plugin-import": "^2.6.0",
     "json-loader": "^0.5.4",
     "mocha": "^3.3.0",
     "nyc": "^10.2.0",

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -119,7 +119,7 @@ export default class API {
     return this.baseUrl + path;
   }
 
-  async request(path = '', method = METHODS.GET, params, headers = {}) {
+  async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
     const {
       query,
       body,
@@ -133,8 +133,8 @@ export default class API {
 
     if (path === 'rating/v1/rates') {
       req.url = 'https://api.easypost.com/rating/v1/rates';
-      req['_header']['content-type'] = 'application/json';
-      req['header']['Content-Type'] = 'application/json';
+      req._header['content-type'] = 'application/json';
+      req.header['Content-Type'] = 'application/json';
     }
 
     if (body) { req.send(body); }

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -130,9 +130,9 @@ export default class API {
                 .set('Content-Type', 'application/json')
                 .set(API.buildHeaders(headers))
                 .auth(`${this.key}:`);
-                
+
     if (path === 'rating/v1/rates') {
-      req.url =  'https://api.easypost.com/rating/v1/rates';
+      req.url = 'https://api.easypost.com/rating/v1/rates';
       req['_header']['content-type'] = 'application/json';
       req['header']['Content-Type'] = 'application/json';
     }

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -26,7 +26,7 @@ import RequestError from './errors/request';
 
 export const MS_SECOND = 1000;
 export const DEFAULT_TIMEOUT = 120 * MS_SECOND;
-export const DEFAULT_BASE_URL = 'https://api.easypost.com/v2/';
+export const DEFAULT_BASE_URL = 'https://api.easypost.com/';
 
 export const UA_INFO = {
   client_version: pkg.version,
@@ -127,15 +127,10 @@ export default class API {
 
     const req = this.agent[method](this.buildPath(path))
                 .accept('json')
-                .set('Content-Type', 'application/json')
+                .type('json')
+                .set('content-type', 'application/json')
                 .set(API.buildHeaders(headers))
                 .auth(`${this.key}:`);
-
-    if (path === 'rating/v1/rates') {
-      req.url = 'https://api.easypost.com/rating/v1/rates';
-      req._header['content-type'] = 'application/json';
-      req.header['Content-Type'] = 'application/json';
-    }
 
     if (body) { req.send(body); }
 

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -14,6 +14,7 @@ import Insurance from './resources/insurance';
 import Order from './resources/order';
 import Parcel from './resources/parcel';
 import Pickup from './resources/pickup';
+import Rating from './resources/rating';
 import Report from './resources/report';
 import ScanForm from './resources/scan_form';
 import Shipment from './resources/shipment';
@@ -65,6 +66,7 @@ export const RESOURCES = {
   Order,
   Parcel,
   Pickup,
+  Rating,
   Report,
   ScanForm,
   Shipment,
@@ -76,6 +78,7 @@ export const RESOURCES = {
 export default class API {
   // Build request headers to be sent by default with each request, combined
   // (or overridden) by any additional headers
+
   static buildHeaders(additionalHeaders = {}) {
     const headers = {
       ...DEFAULT_HEADERS,
@@ -116,17 +119,22 @@ export default class API {
     return this.baseUrl + path;
   }
 
-  async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
+  async request(path = '', method = METHODS.GET, params, headers = {}) {
     const {
       query,
       body,
     } = params;
 
     const req = this.agent[method](this.buildPath(path))
-                  .accept('json')
-                  .set('Content-Type', 'application/json')
-                  .set(API.buildHeaders(headers))
-                  .auth(`${this.key}:`);
+                .accept('json')
+                .set('Content-Type', 'application/json')
+                .set(API.buildHeaders(headers))
+                .auth(`${this.key}:`);
+    if (path === "rating/v1/rates") {
+      req.url =  'https://api.easypost.com/rating/v1/rates';
+      req['_header']['content-type'] = 'application/json';
+      req['header']['Content-Type'] = 'application/json';
+    }
 
     if (body) { req.send(body); }
 
@@ -134,6 +142,8 @@ export default class API {
 
     try {
       const res = await req;
+      console.log("AFTER SUCCESFUL REQ");
+      //console.log(res.text);
       return res;
     } catch (e) {
       if (e.response && e.response.body) {

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -130,7 +130,8 @@ export default class API {
                 .set('Content-Type', 'application/json')
                 .set(API.buildHeaders(headers))
                 .auth(`${this.key}:`);
-    if (path === "rating/v1/rates") {
+                
+    if (path === 'rating/v1/rates') {
       req.url =  'https://api.easypost.com/rating/v1/rates';
       req['_header']['content-type'] = 'application/json';
       req['header']['Content-Type'] = 'application/json';
@@ -142,8 +143,6 @@ export default class API {
 
     try {
       const res = await req;
-      console.log("AFTER SUCCESFUL REQ");
-      //console.log(res.text);
       return res;
     } catch (e) {
       if (e.response && e.response.body) {

--- a/src/resources/address.js
+++ b/src/resources/address.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class Address extends base(api) {
     static _name = 'Address';
-    static _url = 'addresses';
+    static _url = 'v2/addresses';
     static key = 'address';
 
     static propTypes = {

--- a/src/resources/apiKey.js
+++ b/src/resources/apiKey.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class ApiKey extends base(api) {
     static _name = 'ApiKey';
-    static _url = 'api_keys';
+    static _url = 'v2/api_keys';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -5,6 +5,7 @@ export default api => (
   class Base {
     static _url = null;
     static _name = null;
+    static _collectionKey = null;
     static key = null;
     static propTypes = {};
     static jsonIdKeys = [];
@@ -55,7 +56,7 @@ export default api => (
 
     static unwrapAll(data) {
       if (Array.isArray(data)) return data;
-      return data[this._url];
+      return data[this._collectionKey];
     }
 
     _validationErrors = null;

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -101,8 +101,8 @@ export default api => (
     // have cross browser proxy support and do neat getter/setter things. For
     // now, just map it on the instance.
     mapProps(data) {
-      Object.keys(data).forEach((key) => {       
-          this[key] = data[key];
+      Object.keys(data).forEach((key) => {
+        this[key] = data[key];
       });
     }
 
@@ -154,21 +154,23 @@ export default api => (
         return Promise.reject(e);
       }
       try {
-        const data = this.constructor.wrapJSON(this.toJSON());      
+        const data = this.constructor.wrapJSON(this.toJSON());
+        let output;
         let res;
 
         if (this.id) {
           res = await api.put(`${this._url || this.constructor._url}/${this.id}`, { body: data });
+          output = this;
+        } else if (this.constructor._name === 'Rating') {
+          res = await api.post(this._url || this.constructor._url, { body: this.toJSON() });
+          output = res.body;
         } else {
-            if (this.constructor._name === 'Rating'){
-              res = await api.post(this._url || this.constructor._url, { body: this.toJSON()});
-              return res.body;
-            } else {
-              res = await api.post(this._url || this.constructor._url, { body: data });
-              this.mapProps(res.body);
-              return this;
-            }
+          res = await api.post(this._url || this.constructor._url, { body: data });
+          output = this;
         }
+
+        this.mapProps(res.body);
+        return output;
       } catch (e) {
         throw (e);
       }

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -101,8 +101,8 @@ export default api => (
     // have cross browser proxy support and do neat getter/setter things. For
     // now, just map it on the instance.
     mapProps(data) {
-      Object.keys(data).forEach((key) => {
-        this[key] = data[key];
+      Object.keys(data).forEach((key) => {       
+          this[key] = data[key];
       });
     }
 
@@ -153,10 +153,8 @@ export default api => (
       } catch (e) {
         return Promise.reject(e);
       }
-
       try {
-        const data = this.constructor.wrapJSON(this.toJSON());
-
+        const data = this.constructor.wrapJSON(this.toJSON());      
         let res;
 
         if (this.id) {
@@ -167,6 +165,35 @@ export default api => (
 
         this.mapProps(res.body);
         return this;
+      } catch (e) {
+        throw (e);
+      }
+    }
+
+    async ratings() { //used exclusively for accessing rating NOT ELEGANT AT ALL
+      //CANT ACCESS CLASS VARIABLES? BC LINE 177 IS THE ONLY THING THAT CHANGES
+       try {
+        this.validateProperties();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+
+      try {
+        let res;
+
+        res = await api.post(this._url || this.constructor._url, { body: JSON.stringify(this)});
+        // console.log(res.text);
+        // console.log(JSON.parse(res.text));
+        // console.log(res.body.ratings[0].rates);
+        // console.log(res.body.ratings.length);
+        //console.log(JSON.parse(res.text));
+        this.mapProps(res.body);
+        // var output = res.body;
+        // for (var x = 0; x < res.body.ratings.length ; x++){
+        //   output.ratings[x].rates = res.body.ratings[x].rates;
+        // }
+        // console.log(output);
+        return res.body;
       } catch (e) {
         throw (e);
       }
@@ -187,7 +214,6 @@ export default api => (
 
     toJSON() {
       const idKeys = this.constructor.jsonIdKeys;
-
       return Object.keys(this.constructor.propTypes).reduce((json, key) => {
         if (this[key]) {
           if (idKeys.includes(key) && typeof this[key] !== 'object') {

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -160,40 +160,15 @@ export default api => (
         if (this.id) {
           res = await api.put(`${this._url || this.constructor._url}/${this.id}`, { body: data });
         } else {
-          res = await api.post(this._url || this.constructor._url, { body: data });
+            if (this.constructor._name === 'Rating'){
+              res = await api.post(this._url || this.constructor._url, { body: this.toJSON()});
+              return res.body;
+            } else {
+              res = await api.post(this._url || this.constructor._url, { body: data });
+              this.mapProps(res.body);
+              return this;
+            }
         }
-
-        this.mapProps(res.body);
-        return this;
-      } catch (e) {
-        throw (e);
-      }
-    }
-
-    async ratings() { //used exclusively for accessing rating NOT ELEGANT AT ALL
-      //CANT ACCESS CLASS VARIABLES? BC LINE 177 IS THE ONLY THING THAT CHANGES
-       try {
-        this.validateProperties();
-      } catch (e) {
-        return Promise.reject(e);
-      }
-
-      try {
-        let res;
-
-        res = await api.post(this._url || this.constructor._url, { body: JSON.stringify(this)});
-        // console.log(res.text);
-        // console.log(JSON.parse(res.text));
-        // console.log(res.body.ratings[0].rates);
-        // console.log(res.body.ratings.length);
-        //console.log(JSON.parse(res.text));
-        this.mapProps(res.body);
-        // var output = res.body;
-        // for (var x = 0; x < res.body.ratings.length ; x++){
-        //   output.ratings[x].rates = res.body.ratings[x].rates;
-        // }
-        // console.log(output);
-        return res.body;
       } catch (e) {
         throw (e);
       }

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -153,24 +153,20 @@ export default api => (
       } catch (e) {
         return Promise.reject(e);
       }
+
       try {
         const data = this.constructor.wrapJSON(this.toJSON());
-        let output;
+
         let res;
 
         if (this.id) {
           res = await api.put(`${this._url || this.constructor._url}/${this.id}`, { body: data });
-          output = this;
-        } else if (this.constructor._name === 'Rating') {
-          res = await api.post(this._url || this.constructor._url, { body: this.toJSON() });
-          output = res.body;
         } else {
           res = await api.post(this._url || this.constructor._url, { body: data });
-          output = this;
         }
 
         this.mapProps(res.body);
-        return output;
+        return this;
       } catch (e) {
         throw (e);
       }

--- a/src/resources/batch.js
+++ b/src/resources/batch.js
@@ -7,6 +7,7 @@ export default api => (
   class Batch extends base(api) {
     static _name = 'Batch';
     static _url = 'v2/batches';
+    static _collectionKey = 'batches';
     static key = 'batch';
 
     static propTypes = {

--- a/src/resources/batch.js
+++ b/src/resources/batch.js
@@ -6,7 +6,7 @@ export const DEFAULT_LABEL_FORMAT = 'pdf';
 export default api => (
   class Batch extends base(api) {
     static _name = 'Batch';
-    static _url = 'batches';
+    static _url = 'v2/batches';
     static key = 'batch';
 
     static propTypes = {

--- a/src/resources/carrierAccount.js
+++ b/src/resources/carrierAccount.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class CarrierAccount extends base(api) {
     static _name = 'CarrierAccount';
-    static _url = 'carrier_accounts';
+    static _url = 'v2/carrier_accounts';
     static key = 'carrier_account';
 
     static propTypes = {

--- a/src/resources/carrierAccount.js
+++ b/src/resources/carrierAccount.js
@@ -5,6 +5,7 @@ export default api => (
   class CarrierAccount extends base(api) {
     static _name = 'CarrierAccount';
     static _url = 'v2/carrier_accounts';
+    static _collectionKey = 'carrier_accounts';
     static key = 'carrier_account';
 
     static propTypes = {

--- a/src/resources/carrierType.js
+++ b/src/resources/carrierType.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class CarrierType extends base(api) {
     static _name = 'CarrierType';
-    static _url = 'carrier_types';
+    static _url = 'v2/carrier_types';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/carrierType.js
+++ b/src/resources/carrierType.js
@@ -5,6 +5,7 @@ export default api => (
   class CarrierType extends base(api) {
     static _name = 'CarrierType';
     static _url = 'v2/carrier_types';
+    static _collectionKey = 'carrier_types';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/customsInfo.js
+++ b/src/resources/customsInfo.js
@@ -7,7 +7,7 @@ export default (api) => {
 
   return class CustomsInfo extends base(api) {
     static _name = 'CustomsInfo';
-    static _url = 'customs_infos';
+    static _url = 'v2/customs_infos';
     static key = 'customs_info';
 
     static propTypes = {

--- a/src/resources/customsItem.js
+++ b/src/resources/customsItem.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class CustomsItem extends base(api) {
     static _name = 'CustomsItem';
-    static _url = 'customs_items';
+    static _url = 'v2/customs_items';
     static key = 'customs_item';
 
     static propTypes = {

--- a/src/resources/insurance.js
+++ b/src/resources/insurance.js
@@ -10,6 +10,7 @@ export default (api) => {
   return class Insurance extends base(api) {
     static _name = 'Insurance';
     static _url = 'v2/insurances';
+    static _collectionKey = 'insurances';
     static key = 'insurance';
 
     static propTypes = {

--- a/src/resources/insurance.js
+++ b/src/resources/insurance.js
@@ -9,7 +9,7 @@ export default (api) => {
 
   return class Insurance extends base(api) {
     static _name = 'Insurance';
-    static _url = 'insurances';
+    static _url = 'v2/insurances';
     static key = 'insurance';
 
     static propTypes = {

--- a/src/resources/order.js
+++ b/src/resources/order.js
@@ -11,6 +11,7 @@ export default (api) => {
   return class Order extends base(api) {
     static _name = 'Order';
     static _url = 'v2/orders';
+    static _collectionKey = 'orders';
     static key = 'order';
 
     static propTypes = {

--- a/src/resources/order.js
+++ b/src/resources/order.js
@@ -10,7 +10,7 @@ export default (api) => {
 
   return class Order extends base(api) {
     static _name = 'Order';
-    static _url = 'orders';
+    static _url = 'v2/orders';
     static key = 'order';
 
     static propTypes = {

--- a/src/resources/parcel.js
+++ b/src/resources/parcel.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class Parcel extends base(api) {
     static _name = 'Parcel';
-    static _url = 'parcels';
+    static _url = 'v2/parcels';
     static key ='parcel';
 
     static propTypes = {

--- a/src/resources/pickup.js
+++ b/src/resources/pickup.js
@@ -13,7 +13,7 @@ export default (api) => {
 
   return class Pickup extends base(api) {
     static _name = 'Pickup';
-    static _url = 'pickups';
+    static _url = 'v2/pickups';
     static key = 'pickup';
 
     static propTypes = {

--- a/src/resources/rating.js
+++ b/src/resources/rating.js
@@ -19,12 +19,30 @@ export default (api) => {
       carrier_accounts: T.array,
     }
 
+    async save() {
+      try {
+        this.validateProperties();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+      try {
+        const res = await api.post(this._url || this.constructor._url, { body: this.toJSON() });
+
+        this.mapProps(res.body);
+        return res.body;
+      } catch (e) {
+        throw (e);
+      }
+    }
+
     static all() {
       return this.notImplemented('all');
     }
+
     static delete() {
       return this.notImplemented('delete');
     }
+
     static retrieve() {
       return this.notImplemented('retrieve');
     }

--- a/src/resources/rating.js
+++ b/src/resources/rating.js
@@ -1,0 +1,34 @@
+import T from 'proptypes';
+import base from './base';
+import address from './address';
+import parcel from './parcel';
+import carrierAccount from './carrierAccount';
+
+export default (api) => {
+  const Address = address(api);
+  const Parcel = parcel(api);
+  const CarrierAccount = carrierAccount(api);
+
+  return class Rating extends base(api) {
+	static _name = 'Rating';
+	static _url = 'rating/v1/rates';
+	static key = 'rating';
+
+	static propTypes = {
+		to_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
+		from_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
+		parcels: T.arrayOf(T.oneOfType([T.string, T.shape(Parcel.propTypes)])),
+		carrier_accounts: T.array,
+		//ratings: T.arrayOf(T.arrayOf(T.object)),
+	  	//messages: T.array,
+	}
+
+	static all() {
+	  return this.notImplemented('all');
+	}
+
+	static delete() {
+	  return this.notImplemented('delete');
+	}
+  }
+}

--- a/src/resources/rating.js
+++ b/src/resources/rating.js
@@ -2,33 +2,31 @@ import T from 'proptypes';
 import base from './base';
 import address from './address';
 import parcel from './parcel';
-import carrierAccount from './carrierAccount';
 
 export default (api) => {
   const Address = address(api);
   const Parcel = parcel(api);
-  const CarrierAccount = carrierAccount(api);
 
   return class Rating extends base(api) {
-	static _name = 'Rating';
-	static _url = 'rating/v1/rates';
-	static key = 'rating';
+    static _name = 'Rating';
+    static _url = 'rating/v1/rates';
+    static key = 'rating';
 
-	static propTypes = {
-		to_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
-		from_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
-		parcels: T.arrayOf(T.oneOfType([T.string, T.shape(Parcel.propTypes)])),
-		carrier_accounts: T.array,
-	}
+    static propTypes = {
+      to_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
+      from_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
+      parcels: T.arrayOf(T.oneOfType([T.string, T.shape(Parcel.propTypes)])),
+      carrier_accounts: T.array,
+    }
 
-	static all() {
-	  return this.notImplemented('all');
-	}
-	static delete() {
-	  return this.notImplemented('delete');
-	}
-	static retrieve() {
-	  return this.notImplemented('retrieve');
-	}
-  }
-}
+    static all() {
+      return this.notImplemented('all');
+    }
+    static delete() {
+      return this.notImplemented('delete');
+    }
+    static retrieve() {
+      return this.notImplemented('retrieve');
+    }
+  };
+};

--- a/src/resources/rating.js
+++ b/src/resources/rating.js
@@ -19,16 +19,16 @@ export default (api) => {
 		from_address: T.oneOfType([T.string, T.shape(Address.propTypes)]),
 		parcels: T.arrayOf(T.oneOfType([T.string, T.shape(Parcel.propTypes)])),
 		carrier_accounts: T.array,
-		//ratings: T.arrayOf(T.arrayOf(T.object)),
-	  	//messages: T.array,
 	}
 
 	static all() {
 	  return this.notImplemented('all');
 	}
-
 	static delete() {
 	  return this.notImplemented('delete');
+	}
+	static retrieve() {
+	  return this.notImplemented('retrieve');
 	}
   }
 }

--- a/src/resources/report.js
+++ b/src/resources/report.js
@@ -3,7 +3,7 @@ import base from './base';
 
 export default api => (
   class Report extends base(api) {
-    static _url = 'reports';
+    static _url = 'v2/reports';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/report.js
+++ b/src/resources/report.js
@@ -4,6 +4,7 @@ import base from './base';
 export default api => (
   class Report extends base(api) {
     static _url = 'v2/reports';
+    static _collectionKey = 'reports';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/scan_form.js
+++ b/src/resources/scan_form.js
@@ -8,6 +8,7 @@ export default (api) => {
   return class ScanForm extends base(api) {
     static _name = 'ScanForm';
     static _url = 'v2/scan_forms';
+    static _collectionKey = 'scan_forms';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/scan_form.js
+++ b/src/resources/scan_form.js
@@ -7,7 +7,7 @@ export default (api) => {
 
   return class ScanForm extends base(api) {
     static _name = 'ScanForm';
-    static _url = 'scan_forms';
+    static _url = 'v2/scan_forms';
 
     static propTypes = {
       id: T.string,

--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -15,7 +15,7 @@ export default (api) => {
 
   return class Shipment extends base(api) {
     static _name = 'Shipment';
-    static _url = 'shipments';
+    static _url = 'v2/shipments';
     static key = 'shipment';
 
     static propTypes = {

--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -16,6 +16,7 @@ export default (api) => {
   return class Shipment extends base(api) {
     static _name = 'Shipment';
     static _url = 'v2/shipments';
+    static _collectionKey = 'shipments';
     static key = 'shipment';
 
     static propTypes = {

--- a/src/resources/tracker.js
+++ b/src/resources/tracker.js
@@ -5,6 +5,7 @@ export default api => (
   class Tracker extends base(api) {
     static _name = 'Tracker';
     static _url = 'v2/trackers';
+    static _collectionKey = 'trackers';
     static key = 'tracker';
 
     static propTypes = {

--- a/src/resources/tracker.js
+++ b/src/resources/tracker.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class Tracker extends base(api) {
     static _name = 'Tracker';
-    static _url = 'trackers';
+    static _url = 'v2/trackers';
     static key = 'tracker';
 
     static propTypes = {

--- a/src/resources/user.js
+++ b/src/resources/user.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class User extends base(api) {
     static _name = 'User';
-    static _url = 'users';
+    static _url = 'v2/users';
     static key = 'user';
 
     static propTypes = {

--- a/src/resources/webhook.js
+++ b/src/resources/webhook.js
@@ -4,7 +4,7 @@ import base from './base';
 export default api => (
   class Webhook extends base(api) {
     static _name = 'Webhook';
-    static _url = 'webhooks';
+    static _url = 'v2/webhooks';
     static key = 'webhook';
 
     static propTypes = {

--- a/src/resources/webhook.js
+++ b/src/resources/webhook.js
@@ -5,6 +5,7 @@ export default api => (
   class Webhook extends base(api) {
     static _name = 'Webhook';
     static _url = 'v2/webhooks';
+    static _collectionKey = 'webhooks';
     static key = 'webhook';
 
     static propTypes = {

--- a/test/easypost.js
+++ b/test/easypost.js
@@ -118,7 +118,7 @@ describe('Base API object', () => {
       });
     });
 
-    it('requets json', (done) => {
+    it('requests json', (done) => {
       api.request('').then(() => {
         expect(api.agent.getStub.accept).to.have.been.calledWith('json');
         done();

--- a/test/helpers/superagentStub.js
+++ b/test/helpers/superagentStub.js
@@ -17,7 +17,8 @@ export const requestStub = (fail, failRes) => {
   stub.auth = sinon.stub().returns(stub);
   stub.send = sinon.stub().returns(stub);
   stub.query = sinon.stub().returns(stub);
-
+  stub.type = sinon.stub().returns(stub);
+  
   return stub;
 };
 

--- a/test/resources/apiKey.js
+++ b/test/resources/apiKey.js
@@ -54,7 +54,7 @@ describe('ApiKey Resource', () => {
       it('calls api.post when disable is called and key has an id', () => {
         key.disable();
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('api_keys/1/disable');
+        expect(stub.post).to.have.been.calledWith('v2/api_keys/1/disable');
       });
     });
 
@@ -67,7 +67,7 @@ describe('ApiKey Resource', () => {
       it('calls api.post when enable is called and key has an id', () => {
         key.enable();
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('api_keys/1/enable');
+        expect(stub.post).to.have.been.calledWith('v2/api_keys/1/enable');
       });
     });
   });

--- a/test/resources/base.js
+++ b/test/resources/base.js
@@ -46,7 +46,7 @@ describe('Base Resource', () => {
       it('can call all from the API via url', () => {
         stub = apiStub(url, false, { base: [{ }] });
         Base = base(stub);
-        Base._url = url;
+        Base._url, Base._collectionKey = url;
 
         return Base.all().then((bs) => {
           expect(stub.get).to.have.been.calledOnce;

--- a/test/resources/batch.js
+++ b/test/resources/batch.js
@@ -41,7 +41,7 @@ describe('Batch Resource', () => {
       it('calls api.post when addShipment is called with a shipment id', () => {
         bi.addShipment(shipmentId);
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('batches/1/add_shipments', {
+        expect(stub.post).to.have.been.calledWith('v2/batches/1/add_shipments', {
           body: {
             shipments: [{ id: shipmentId }],
           },
@@ -60,7 +60,7 @@ describe('Batch Resource', () => {
       it('calls api.post when addShipments is called with shipment ids', () => {
         bi.addShipments(shipmentIds);
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('batches/1/add_shipments', {
+        expect(stub.post).to.have.been.calledWith('v2/batches/1/add_shipments', {
           body: {
             shipments: [{ id: shipmentIds[0] }, { id: shipmentIds[1] }],
           },
@@ -81,7 +81,7 @@ describe('Batch Resource', () => {
       it('calls api.post when removeShipment is called with a shipment id', () => {
         bi.removeShipment(shipmentId);
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('batches/1/remove_shipments', {
+        expect(stub.post).to.have.been.calledWith('v2/batches/1/remove_shipments', {
           body: {
             shipments: [{ id: shipmentId }],
           },
@@ -100,7 +100,7 @@ describe('Batch Resource', () => {
       it('calls api.post when removeShipments is called with shipment ids', () => {
         bi.removeShipments(shipmentIds);
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('batches/1/remove_shipments', {
+        expect(stub.post).to.have.been.calledWith('v2/batches/1/remove_shipments', {
           body: {
             shipments: [{ id: shipmentIds[0] }, { id: shipmentIds[1] }],
           },
@@ -128,7 +128,7 @@ describe('Batch Resource', () => {
     it('calls api.post when generateLabel is called, defaulting to pdf', () => {
       bi.generateLabel();
       expect(stub.post).to.have.been.called;
-      expect(stub.post).to.have.been.calledWith('batches/1/label', {
+      expect(stub.post).to.have.been.calledWith('v2/batches/1/label', {
         body: {
           file_format: DEFAULT_LABEL_FORMAT,
         },
@@ -140,7 +140,7 @@ describe('Batch Resource', () => {
 
       bi.generateLabel(format);
       expect(stub.post).to.have.been.called;
-      expect(stub.post).to.have.been.calledWith('batches/1/label', {
+      expect(stub.post).to.have.been.calledWith('v2/batches/1/label', {
         body: {
           file_format: format,
         },
@@ -167,7 +167,7 @@ describe('Batch Resource', () => {
     it('calls api.post when createScanForm is called', () => {
       bi.createScanForm();
       expect(stub.post).to.have.been.called;
-      expect(stub.post).to.have.been.calledWith('batches/1/scan_form');
+      expect(stub.post).to.have.been.calledWith('v2/batches/1/scan_form');
     });
   });
 
@@ -195,7 +195,7 @@ describe('Batch Resource', () => {
     it('calls api.post when buy is called', () => {
       bi.buy();
       expect(stub.post).to.have.been.called;
-      expect(stub.post).to.have.been.calledWith('batches/1/buy');
+      expect(stub.post).to.have.been.calledWith('v2/batches/1/buy');
     });
   });
 });

--- a/test/resources/order.js
+++ b/test/resources/order.js
@@ -23,7 +23,7 @@ describe('Order Resource', () => {
     const oi = new Order();
     return oi.getRates().then(() => {
       expect(stub.get).to.have.been.called;
-      expect(stub.get).to.have.been.calledWith(`orders/${oi.id}/rates`);
+      expect(stub.get).to.have.been.calledWith(`v2/orders/${oi.id}/rates`);
     });
   });
 
@@ -70,7 +70,7 @@ describe('Order Resource', () => {
 
       return oi.buy(carrier, service).then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`orders/${oi.id}/buy`, {
+        expect(stub.post).to.have.been.calledWith(`v2/orders/${oi.id}/buy`, {
           body: data,
         });
       });

--- a/test/resources/pickup.js
+++ b/test/resources/pickup.js
@@ -64,7 +64,7 @@ describe('Pickup Resource', () => {
 
       return pi.buy(carrier, service).then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`pickups/${pi.id}/buy`, {
+        expect(stub.post).to.have.been.calledWith(`v2/pickups/${pi.id}/buy`, {
           body: data,
         });
       });
@@ -107,7 +107,7 @@ describe('Pickup Resource', () => {
     it('calls api.post when cancel is called', () => {
       return pi.cancel().then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`pickups/${pi.id}/cancel`);
+        expect(stub.post).to.have.been.calledWith(`v2/pickups/${pi.id}/cancel`);
       });
     });
 

--- a/test/resources/rating.js
+++ b/test/resources/rating.js
@@ -1,0 +1,25 @@
+import rating from '../../src/resources/rating';
+import apiStub from '../helpers/apiStub';
+import RequestError from '../../src/errors/request';
+
+//THIS IS THE TEST PART OF IT
+describe('Rating Resource', () => {
+  it('exists', () => {
+    expect(rating).to.not.be.undefined;
+    expect(rating).to.be.a('function');
+  });
+
+  it('throws on all', () => {
+    const Rating = rating(apiStub());
+    return Rating.all().then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
+  it('throws on delete', () => {
+    const Rating = rating(apiStub());
+    return Rating.delete().then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+});

--- a/test/resources/rating.js
+++ b/test/resources/rating.js
@@ -1,4 +1,5 @@
 import rating from '../../src/resources/rating';
+import NotImplementedError from '../../src/errors/notImplemented';
 import apiStub from '../helpers/apiStub';
 import RequestError from '../../src/errors/request';
 

--- a/test/resources/rating.js
+++ b/test/resources/rating.js
@@ -22,4 +22,11 @@ describe('Rating Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on retrieve', () => {
+    const Rating = rating(apiStub());
+    return Rating.retrieve().then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/rating.js
+++ b/test/resources/rating.js
@@ -3,7 +3,6 @@ import NotImplementedError from '../../src/errors/notImplemented';
 import apiStub from '../helpers/apiStub';
 import RequestError from '../../src/errors/request';
 
-//THIS IS THE TEST PART OF IT
 describe('Rating Resource', () => {
   it('exists', () => {
     expect(rating).to.not.be.undefined;
@@ -29,5 +28,15 @@ describe('Rating Resource', () => {
     return Rating.retrieve().then(() => {}, (err) => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
+  });
+
+  it('calls api.post when save is called and with correct url', () => {
+      const stub = apiStub();
+      const Rating = rating(stub);
+      const rt = new Rating({});
+      rt.save();
+
+      expect(stub.post).to.have.been.called;
+      expect(stub.post).to.have.been.calledWith('rating/v1/rates');
   });
 });

--- a/test/resources/report.js
+++ b/test/resources/report.js
@@ -34,10 +34,9 @@ describe('Report Resource', () => {
   it('calls all using the type that is passed', () => {
     const stub = apiStub('', false, { reports: [] });
     const Report = report(stub);
-    console.log(Report);
     return Report.all('shipment').then(() => {
       expect(stub.get).to.have.been.calledOnce;
-      expect(stub.get).to.have.been.calledWith('v2/reports/shipment');
+      expect(stub.get).to.have.been.calledWith('reports/shipment');
     });
   });
 

--- a/test/resources/report.js
+++ b/test/resources/report.js
@@ -27,17 +27,17 @@ describe('Report Resource', () => {
 
     return Report.retrieve('id_123').then(() => {
       expect(stub.get).to.have.been.calledOnce;
-      expect(stub.get).to.have.been.calledWith('reports/id_123');
+      expect(stub.get).to.have.been.calledWith('v2/reports/id_123');
     });
   });
 
   it('calls all using the type that is passed', () => {
     const stub = apiStub('', false, { reports: [] });
     const Report = report(stub);
-
+    console.log(Report);
     return Report.all('shipment').then(() => {
       expect(stub.get).to.have.been.calledOnce;
-      expect(stub.get).to.have.been.calledWith('reports/shipment');
+      expect(stub.get).to.have.been.calledWith('v2/reports/shipment');
     });
   });
 

--- a/test/resources/shipment.js
+++ b/test/resources/shipment.js
@@ -58,7 +58,7 @@ describe('Shipment Resource', () => {
 
       return si.buy(rate, insuranceAmount).then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`shipments/${si.id}/buy`, {
+        expect(stub.post).to.have.been.calledWith(`v2/shipments/${si.id}/buy`, {
           body: data,
         });
       });
@@ -70,7 +70,7 @@ describe('Shipment Resource', () => {
 
       return si.buy(rate).then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`shipments/${si.id}/buy`, {
+        expect(stub.post).to.have.been.calledWith(`v2/shipments/${si.id}/buy`, {
           body: data,
         });
       });
@@ -124,7 +124,7 @@ describe('Shipment Resource', () => {
 
       return si.insure(amount).then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`shipments/${si.id}/insure`, {
+        expect(stub.post).to.have.been.calledWith(`v2/shipments/${si.id}/insure`, {
           body: data,
         });
       });
@@ -178,7 +178,7 @@ describe('Shipment Resource', () => {
 
       return si.convertLabelFormat(format).then(() => {
         expect(stub.get).to.have.been.called;
-        expect(stub.get).to.have.been.calledWith(`shipments/${si.id}/label`, { query: data });
+        expect(stub.get).to.have.been.calledWith(`v2/shipments/${si.id}/label`, { query: data });
       });
     });
 
@@ -218,7 +218,7 @@ describe('Shipment Resource', () => {
     it('calls api.post when regenerateRates is called', () => {
       return si.regenerateRates().then(() => {
         expect(stub.get).to.have.been.called;
-        expect(stub.get).to.have.been.calledWith(`shipments/${si.id}/rates`);
+        expect(stub.get).to.have.been.calledWith(`v2/shipments/${si.id}/rates`);
       });
     });
 
@@ -256,7 +256,7 @@ describe('Shipment Resource', () => {
     it('calls api.post when refund is called', () => {
       return si.refund().then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`shipments/${si.id}/refund`);
+        expect(stub.post).to.have.been.calledWith(`v2/shipments/${si.id}/refund`);
       });
     });
 
@@ -309,7 +309,7 @@ describe('Shipment Resource', () => {
 
       return si.return().then(() => {
         expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith(`shipments/${si.id}`);
+        expect(stub.post).to.have.been.calledWith(`v2/shipments/${si.id}`);
       });
     });
 


### PR DESCRIPTION
Can now call rating endpoint, example found below (important to call console.dir with depth of 4, as otherwise the rates just show up as [Array]), also not entirely sure why lines 48 and 49 were changed in package.json, as I didn't do that manually. 
```
const rt = new api.Rating({
  to_address: {
  name: 'Dr. Steve Brule',
    street1: '179 N Harbor Dr',
    city: 'Redondo Beach',
    state: 'CA',
    zip: '90277',
    country: 'US',
    phone: '4155559999',
    email: 'dr_steve_brule@gmail.com'
},
  from_address: {
  name: 'EasyPost',
  street1: '118 2nd Street',
  street2: '4th Floor',
  city: 'San Francisco',
  state: 'CA',
  zip: '94105',
  phone: '415-123-4567'
},
  parcels: [{
  length: 20.2,
  width: 10.9,
  height: 5,
  weight: 65.9
}],
  carrier_accounts:["ca_f5de031c879e4a4faebb7a7dcbf5dc7c", "ca_5496e6901d3240ffa2b1ba17674fb46f"]
});

rt.save().then((r) => {console.dir(r, {depth: 4})}).catch((error) => {console.log(error);});
```