### PR TITLE
Add nodent-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.23.0",
+    "nodent-runtime": "^3.0.4",
     "proptypes": "^1.1.0",
     "regenerator-runtime": "^0.11.0",
     "source-map-support": "^0.5.0",


### PR DESCRIPTION
New dep that isn't installed without dev-dependencies, for
async-to-generator transforms.

For #89 