### PR TITLE
instance.delete()

### DIFF
--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -185,6 +185,15 @@ export default api => (
       }
     }
 
+    async delete() {
+      if (this.id) {
+        await this.constructor.delete(this.id);
+        return this;
+      }
+
+      throw new Error('Cannot delete an object without an id.');
+    }
+
     toJSON() {
       const idKeys = this.constructor.jsonIdKeys;
 

--- a/test/resources/address.js
+++ b/test/resources/address.js
@@ -22,6 +22,15 @@ describe('Address Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const Address = address(apiStub());
+    const instance = new Address({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   it('wraps json in its name', () => {
     const Address = address(apiStub());
     const data = {

--- a/test/resources/apiKey.js
+++ b/test/resources/apiKey.js
@@ -30,6 +30,15 @@ describe('ApiKey Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const ApiKey = apiKey(apiStub());
+    const instance = new ApiKey({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   it('throws on all', () => {
     return ApiKey.all().then(() => {}, (err) => {
       expect(err).to.be.an.instanceOf(NotImplementedError);

--- a/test/resources/base.js
+++ b/test/resources/base.js
@@ -282,12 +282,48 @@ describe('Base Resource', () => {
       }, (err) => { throw new Error(err); });
     });
 
-    it('throws if there is no shipment id', () => {
+    it('throws if there is no instance id', () => {
       delete data.id;
 
       const bi = new Base(data);
 
       bi.retrieve().catch((e) => {
+        expect(e.message).to.match(/without an id/);
+      });
+    });
+  });
+
+  describe('delete()', () => {
+    let stub;
+    let Base;
+    const propTypes = { a: T.string, id: T.string };
+    const name = 'base';
+    const data = { a: 'a', id: 'id' };
+    const stubRes = { toJSON: () => ({ a: 'b', id: data.id }) };
+
+    beforeEach(() => {
+      stub = apiStub();
+      Base = base(stub);
+      Base.propTypes = propTypes;
+      Base._name = name;
+      Base._url = name;
+    });
+
+    it('calls delete with the instance id', () => {
+      const bi = new Base(data);
+      const deleteStub = sinon.stub(Base, 'delete').returns(stubRes);
+
+      return bi.delete().then(() => {
+        expect(deleteStub).to.have.been.calledWith(bi.id);
+      }, (err) => { throw new Error(err); });
+    });
+
+    it('throws if there is no instance id', () => {
+      delete data.id;
+
+      const bi = new Base(data);
+
+      bi.delete().catch((e) => {
         expect(e.message).to.match(/without an id/);
       });
     });

--- a/test/resources/batch.js
+++ b/test/resources/batch.js
@@ -15,6 +15,15 @@ describe('Batch Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const Batch = batch(apiStub());
+    const instance = new Batch({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   describe('managing shipments', () => {
     const shipmentId = '1';
     const shipmentIds = ['1', '2'];

--- a/test/resources/carrierAccount.js
+++ b/test/resources/carrierAccount.js
@@ -23,4 +23,16 @@ describe('CarrierAccount Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('deletes', () => {
+    const CarrierAccount = carrierAccount(apiStub());
+    const id = 1;
+    return CarrierAccount.delete(id);
+  });
+
+  it('deletes an instance', () => {
+    const CarrierAccount = carrierAccount(apiStub());
+    const instance = new CarrierAccount({ id: 1 });
+    return instance.delete();
+  });
 });

--- a/test/resources/carrierType.js
+++ b/test/resources/carrierType.js
@@ -22,6 +22,15 @@ describe('CarrierType Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const CarrierType = carrierType(apiStub());
+    const instance = new CarrierType({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   it('throws on save', () => {
     const CarrierType = carrierType(apiStub());
     const cti = new CarrierType();

--- a/test/resources/customsInfo.js
+++ b/test/resources/customsInfo.js
@@ -21,4 +21,13 @@ describe('Customs Info Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const CustomsInfo = customsInfo(apiStub());
+    const instance = new CustomsInfo({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/customsItem.js
+++ b/test/resources/customsItem.js
@@ -38,4 +38,13 @@ describe('Customs Item Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const CustomsItem = customsItem(apiStub());
+    const instance = new CustomsItem({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/insurance.js
+++ b/test/resources/insurance.js
@@ -14,4 +14,13 @@ describe('Insurance Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const Insurance = insurance(apiStub());
+    const instance = new Insurance({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/order.js
+++ b/test/resources/order.js
@@ -17,6 +17,15 @@ describe('Order Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const Order = order(apiStub());
+    const instance = new Order({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   it('regenerates rates', () => {
     const stub = apiStub();
     const Order = order(stub);

--- a/test/resources/parcel.js
+++ b/test/resources/parcel.js
@@ -37,4 +37,13 @@ describe('Parcel Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const Parcel = parcel(apiStub());
+    const instance = new Parcel({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/pickup.js
+++ b/test/resources/pickup.js
@@ -24,6 +24,15 @@ describe('Pickup Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const Pickup = pickup(apiStub());
+    const instance = new Pickup({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   describe('buying', () => {
     let Pickup;
     let pi;

--- a/test/resources/report.js
+++ b/test/resources/report.js
@@ -68,4 +68,13 @@ describe('Report Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const Report = report(apiStub());
+    const instance = new Report({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/scan_form.js
+++ b/test/resources/scan_form.js
@@ -22,6 +22,15 @@ describe('ScanForm Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const ScanForm = scanForm(apiStub());
+    const instance = new ScanForm({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   describe('toJSON', () => {
     let ScanForm;
     let stub;

--- a/test/resources/shipment.js
+++ b/test/resources/shipment.js
@@ -23,6 +23,15 @@ describe('Shipment Resource', () => {
     });
   });
 
+  it('throws on instance delete', () => {
+    const Shipment = shipment(apiStub());
+    const instance = new Shipment({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+
   describe('buying', () => {
     let Shipment;
     let si;

--- a/test/resources/tracker.js
+++ b/test/resources/tracker.js
@@ -21,4 +21,13 @@ describe('Tracker Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('throws on instance delete', () => {
+    const Tracker = tracker(apiStub());
+    const instance = new Tracker({ id: 1 });
+
+    return instance.delete('id').then(() => {}, (err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
 });

--- a/test/resources/user.js
+++ b/test/resources/user.js
@@ -14,4 +14,16 @@ describe('User Resource', () => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
     });
   });
+
+  it('deletes', () => {
+    const User = user(apiStub());
+    const id = 1;
+    return User.delete(id);
+  });
+
+  it('deletes an instance', () => {
+    const User = user(apiStub());
+    const instance = new User({ id: 1 });
+    return instance.delete();
+  });
 });

--- a/test/resources/webhook.js
+++ b/test/resources/webhook.js
@@ -13,4 +13,16 @@ describe('Webhook Resource', () => {
     const data = [new Webhook()];
     expect(Webhook.unwrapAll({ webhooks: data })).to.deep.equal(data);
   });
+
+  it('deletes', () => {
+    const Webhook = webhook(apiStub());
+    const id = 1;
+    return Webhook.delete(id);
+  });
+
+  it('deletes an instance', () => {
+    const Webhook = webhook(apiStub());
+    const instance = new Webhook({ id: 1 });
+    return instance.delete();
+  });
 });


### PR DESCRIPTION
Allow deleting a model instace that has an id as an alternative to ModelClass.delete(id).

Closes issue #90 