### PR TITLE
Allows all records for addresses

### DIFF
--- a/src/resources/address.js
+++ b/src/resources/address.js
@@ -32,10 +32,6 @@ export default api => (
     static key = 'address';
     static propTypes = propTypes;
 
-    static all() {
-      return this.notImplemented('all');
-    }
-
     static delete() {
       return this.notImplemented('delete');
     }

--- a/test/resources/address.js
+++ b/test/resources/address.js
@@ -9,13 +9,6 @@ describe('Address Resource', () => {
     expect(address).to.be.a('function');
   });
 
-  it('throws on all', () => {
-    const Address = address(apiStub());
-    return Address.all().then(() => {}, err => {
-      expect(err).to.be.an.instanceOf(NotImplementedError);
-    });
-  });
-
   it('throws on delete', () => {
     const Address = address(apiStub());
     return Address.delete('id').then(() => {}, err => {


### PR DESCRIPTION
The Node client library does not allow users to retrieve all `addresses` but the other CL's do. I've removed the `NotImplemented` code to allow users to retrieve all records as 1) the API supports this functionality and 2) the other CL's allow for these methods on these objects.