### PR TITLE
Allow API Key retrieval

### DIFF
--- a/src/resources/apiKey.js
+++ b/src/resources/apiKey.js
@@ -18,10 +18,6 @@ export default api => (
       return this.notImplemented('delete');
     }
 
-    static retrieve() {
-      return this.notImplemented('retrieve');
-    }
-
     async save() {
       return this.constructor.notImplemented('save');
     }

--- a/test/resources/apiKey.js
+++ b/test/resources/apiKey.js
@@ -19,10 +19,6 @@ describe('ApiKey Resource', () => {
     expect(apiKey).to.be.a('function');
   });
 
-  it('throws on retrieve', () => ApiKey.retrieve().then(() => {}, err => {
-    expect(err).to.be.an.instanceOf(NotImplementedError);
-  }));
-
   it('throws on delete', () => ApiKey.delete('id').then(() => {}, err => {
     expect(err).to.be.an.instanceOf(NotImplementedError);
   }));


### PR DESCRIPTION
Our other client libraries such as PHP, Python, and Ruby allow for individual user API key retrieval. Our docs say that you can retrieve them but only return `undefined` (separate issue opened to update docs):

**Bad Example:**
```node
const Easypost = require('@easypost/api');
const api = new Easypost('<YOUR_TEST/PRODUCTION_API_KEY>');

// Load child keys
api.User.retrieve('user_...')
  .then(child => console.log(child.api_keys));
```

Without the ability to just retrieve a single key (say a child key you don't have on file) to update something, you currently have to engineer some really weird workarounds like one we've used with a customer where they knew the name/id of the user but needed the individual key and couldn't get it unless they were all retrieved, matched, and filtered (don't mind the quick and dirty approach):

```node
const Easypost = require('@easypost/api');

const api = new Easypost(process.env.API_KEY);

// Retrieve all user's API keys, match them to names and only update those with the specified name
// This is done this way because the EasyPost Node CL does not allow you to retrieve the API keys of a single user
// USAGE: API_KEY=123... NAME='test test' node update-user-by-key-name-match.js

async function retrieveUsers() {
    keys = await api.ApiKey.all().catch(console.log)
    for (i = 0; i < keys.length; i++) {
        user = await api.User.retrieve(keys[i]['user_id']).catch(console.log)
        if (user['name'] == process.env.NAME) {
            console.log(user['name'] + ' | ' + user['id'] + ' | ' + keys[i]['key'])
        
            // Items to update
            user.recharge_threshold = '50.00'
            user.save().then(console.log).catch(console.log)
        }
    }
}

retrieveUsers()
```

Instead, we should be able to just pull the individual key from the the API as 1) it supports this 2) other CL's support this and 3) it's a simple removal of the `notImplemented` method. 

If this PR is merged, we'll need to compile the library and release a new version.