### PR TITLE
fix: changes usps_zone from string to integer

### DIFF
--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -35,7 +35,7 @@ export const propTypes = {
   tracking_code: T.string,
   service: T.string,
   services: T.arrayOf(T.string),
-  usps_zone: T.string,
+  usps_zone: T.integer,
   status: T.string,
   tracker: T.oneOfType([T.string, T.shape(trackerPropTypes)]),
   fees: T.array,


### PR DESCRIPTION
We've changed the `usps_zone` field on the API side from a `string` to an `integer` and need to update the `propType` here to match.

Closes #169 