### PR TITLE
fix: adds missing customs info fields

### DIFF
--- a/src/resources/customsInfo.js
+++ b/src/resources/customsInfo.js
@@ -18,6 +18,7 @@ export const propTypes = {
   non_delivery_option: T.string,
   customs_items: T.arrayOf(T.shape(ciPropTypes)),
   declaration: T.string,
+  restriction_comments: T.string,
 };
 
 export default api => (

--- a/src/resources/customsInfo.js
+++ b/src/resources/customsInfo.js
@@ -17,6 +17,7 @@ export const propTypes = {
   eel_pfc: T.string,
   non_delivery_option: T.string,
   customs_items: T.arrayOf(T.shape(ciPropTypes)),
+  declaration: T.string,
 };
 
 export default api => (


### PR DESCRIPTION
Adds missing `declaration` and `restriction_comments` fields to the propTypes of the `customsInfo` object.