### PR TITLE
Bump version to 3.11.1 so we can repackage and republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGELOG
 
+### 3.11.1 2021-06-11
+
+* Re-package to fix missing file
+* add "prepublishOnly" script and ignore all build assets (#177)
+* fix: switch "package" to "prepublishOnly"
+* docs: adds info about built docs to README
+
 ### 3.11.0 2021-06-10
 
 * Adds `SmartRate` functionality to the `Shipments` object (available by calling `getSmartrates()` on a shipment)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * Re-package to fix missing file
 * add "prepublishOnly" script and ignore all build assets (#177)
-* fix: switch "package" to "prepublishOnly"
 * docs: adds info about built docs to README
 
 ### 3.11.0 2021-06-10

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@easypost/api",
   "description": "EasyPost Node Client Library",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "author": "Easypost Engineering <support@easypost.com>",
   "homepage": "https://easypost.com",
   "bin": {


### PR DESCRIPTION
Version bump so we can rebuild the assets that weren't published in v3.11.0

Closes #175 