### PR TITLE
pin to @easypost/build == 2.6.4 to fix a regression introduced by bumping mini-css-extract-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/plugin-transform-react-inline-elements": "^7.7.4",
     "@babel/preset-env": "^7.7.6",
     "@babel/register": "^7.7.4",
-    "@easypost/build": "^2.4.3",
+    "@easypost/build": "2.6.4",
     "@easypost/eslint-config-easypost-base": "~1.0.3",
     "babel-eslint": "^10.0.1",
     "babel-loader": "~8.0.6",


### PR DESCRIPTION
Pins `@easypost/build` to 2.6.4 to fix a regression introduced by bumping `mini-css-extract-plugin` in 2.6.6