### PR TITLE
fix: changes usps_zone from integer to number type

### DIFF
--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -35,7 +35,7 @@ export const propTypes = {
   tracking_code: T.string,
   service: T.string,
   services: T.arrayOf(T.string),
-  usps_zone: T.integer,
+  usps_zone: T.number,
   status: T.string,
   tracker: T.oneOfType([T.string, T.shape(trackerPropTypes)]),
   fees: T.array,


### PR DESCRIPTION
Apparently the `propType` of an `integer` is supposed to be a `number` here: https://www.npmjs.com/package/prop-types

Fixes the `usps_zone` field type.