### PR TITLE
chore: version bump to 3.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+## 3.11.2 2021-06-12
+
+* Corrects the `usps_zone` propType from integer to number
+
 ### 3.11.1 2021-06-11
 
 * Re-package to fix missing file

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@easypost/api",
   "description": "EasyPost Node Client Library",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "author": "Easypost Engineering <support@easypost.com>",
   "homepage": "https://easypost.com",
   "bin": {


### PR DESCRIPTION
Version bump:

* Corrects the `usps_zone` propType from integer to number