### PR TITLE
docs: update README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,40 +39,62 @@ of node, you can use:
 ## Example
 
 ```javascript
-const apiKey = 'cueqNZUb3ldeWTNX7MU3Mel8UXtaAMUi';
 const EasyPost = require('@easypost/api');
 
-const api = new EasyPost(apiKey);
+const api = new EasyPost('API_KEY');
 
-// set addresses
-const toAddress = new api.Address({
-  name: 'Dr. Steve Brule',
-  street1: '179 N Harbor Dr',
-  city: 'Redondo Beach',
-  state: 'CA',
-  zip: '90277',
-  country: 'US',
-  phone: '310-808-5243'
+const shipment = new api.Shipment({
+  to_address: {
+    name: 'Dr. Steve Brule',
+    street1: '179 N Harbor Dr',
+    city: 'Redondo Beach',
+    state: 'CA',
+    zip: '90277',
+    country: 'US',
+    phone: '4155559999',
+  },
+  from_address: {
+    street1: '417 MONTGOMERY ST',
+    street2: 'FLOOR 5',
+    city: 'SAN FRANCISCO',
+    state: 'CA',
+    zip: '94104',
+    country: 'US',
+    company: 'EasyPost',
+    phone: '415-123-4567',
+  },
+  parcel: {
+    length: 8,
+    width: 5,
+    height: 5,
+    weight: 5
+  },
+  customs_info: {
+    eel_pfc: 'NOEEI 30.37(a)',
+    customs_certify: true,
+    customs_signer: 'Steve Brule',
+    contents_type: 'merchandise',
+    contents_explanation: '',
+    restriction_type: 'none',
+    restriction_comments: '',
+    non_delivery_option: 'abandon',
+    declaration: 'Here is a bunch of information...',
+
+    customs_items: [
+      new api.CustomsItem({
+        'description': 'Sweet shirts 1',
+        'quantity': 2,
+        'weight': 11,
+        'value': 23,
+        'hs_tariff_number': '654321',
+        'origin_country': 'US',
+        'code': '123'
+      }),
+    ]
+  }
 });
 
-const fromAddress = new api.Address({
-  name: 'EasyPost',
-  street1: '118 2nd Street',
-  street2: '4th Floor',
-  city: 'San Francisco',
-  state: 'CA',
-  zip: '94105',
-  phone: '415-123-4567'
-});
-
-/* es5 with promises: */
-fromAddress.save().then(addr => {
-  console.log(addr.id);
-});
-
-/* es2017 with async/await: */
-await fromAddress.save();
-console.log(fromAddress.id);
+shipment.save().then(s => s.buy(shipment.lowestRate()).then(console.log).catch(console.log))
 ```
 
 ### Options


### PR DESCRIPTION
We can improve our "Getting Started" example in the README by replacing the create-address example with a create-shipment and buy example (which includes addresses). This will now match all other client libraries and be a better representation of how to get started with the API.

* Replaces the address example with a shipment example
* Removes API Key from README