### PR TITLE
feat: adds support for tax_identifiers

### DIFF
--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -43,6 +43,7 @@ export const propTypes = {
   batch_id: T.string,
   batch_status: T.string,
   batch_message: T.string,
+  tax_identifiers: T.arrayOf(T.object),
 };
 
 export default api => (


### PR DESCRIPTION
This PR adds support for the new `tax_identifiers` object.

End-to-end tested this (requires https://github.com/EasyPost/easypost-node/pull/186), and got it working: 

```javascript
  tax_identifiers: [
    {
      entity: 'SENDER',
      tax_id: '12345',
      tax_id_type: 'EORI',
      issuing_country: 'GB'
    }
  ],
```