### PR TITLE
chore: lowered the default timeout of requests from 120 seconds to 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+## NEXT RELEASE
+
+* Lowered the default timeout of requests from 120 seconds to 30 seconds
+
 ## 4.0.0 2021-10-06
 
 * JSON encodes POST bodies instead of form encoding them by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT RELEASE
 
-* Lowered the default timeout of requests from 120 seconds to 30 seconds
+* Lowered the default timeout of requests from 120 seconds to 60 seconds
 
 ## 4.0.0 2021-10-06
 

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -27,7 +27,7 @@ import RequestError from './errors/request';
 
 
 export const MS_SECOND = 1000;
-export const DEFAULT_TIMEOUT = 30 * MS_SECOND;
+export const DEFAULT_TIMEOUT = 60 * MS_SECOND;
 export const DEFAULT_BASE_URL = 'https://api.easypost.com/v2/';
 
 export const UA_INFO = {

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -27,7 +27,7 @@ import RequestError from './errors/request';
 
 
 export const MS_SECOND = 1000;
-export const DEFAULT_TIMEOUT = 120 * MS_SECOND;
+export const DEFAULT_TIMEOUT = 30 * MS_SECOND;
 export const DEFAULT_BASE_URL = 'https://api.easypost.com/v2/';
 
 export const UA_INFO = {


### PR DESCRIPTION
Currently, connections would stay open for up to 120 seconds which is far too long for an API context.

60 seconds was chosen as it's long enough not to be hostile but short enough to not leave connections open for vast amounts of time. We are standardizing timeouts across all the libraries.