### PR TITLE
chore: run linting on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm test
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src test",
     "watch": "ep-node-build --watch",
     "repl": "./repl.js --local easypost.js",
-    "prepublishOnly": "npm run build && npm run test"
+    "prepublishOnly": "npm run build && npm run test && npm run lint"
   },
   "dependencies": {
     "core-js": "3.1.3",


### PR DESCRIPTION
We have a `lint` npm target but don't use it on CI. Let's do so to enforce our style on PRs.