### PR TITLE
fix: do not unwrap "all" endpoint responses

### DIFF
--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -23,7 +23,12 @@ export default (api) =>
       try {
         url = url || this._url;
         const res = await api.get(url, { query });
-        return res.body;
+        const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
+        const result = {
+          [url]: objectList,
+          has_more: res.body.has_more,
+        };
+        return result;
       } catch (e) {
         return Promise.reject(e);
       }

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -23,8 +23,7 @@ export default (api) =>
       try {
         url = url || this._url;
         const res = await api.get(url, { query });
-        const result = res.body;
-        return result;
+        return res.body;
       } catch (e) {
         return Promise.reject(e);
       }

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -23,8 +23,7 @@ export default (api) =>
       try {
         url = url || this._url;
         const res = await api.get(url, { query });
-        const result = this.unwrapAll(res.body).map(this.create.bind(this));
-        result.has_more = res.body.has_more;
+        const result = res.body;
         return result;
       } catch (e) {
         return Promise.reject(e);

--- a/test/cassettes/Address-Resource_3542783961/retrieves-all-addresses_2336737309/recording.har
+++ b/test/cassettes/Address-Resource_3542783961/retrieves-all-addresses_2336737309/recording.har
@@ -1,0 +1,175 @@
+{
+  "log": {
+    "_recordingName": "Address Resource/retrieves all addresses",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.4"
+    },
+    "entries": [
+      {
+        "_id": "04d0b86ce15553cac6edb3b62e6f1c37",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 492,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "page_size",
+              "value": "5"
+            }
+          ],
+          "url": "https://api.easypost.com/v2/addresses?page_size=5"
+        },
+        "response": {
+          "bodySize": 620,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 620,
+            "text": "[\"H4sIAAAAAAAAA+yVQW/bIBTHv0rk6zIJY3AMt2rqDjtNSnaaJusBzyprgi1M1nVRvvsezpq11aQmyzUWB/PnB++Jn2TvCnAu4jjiWOivu8K7QlMU2841suPSKCNcWaI1RgDYsquNXfCSi2Je9OY72kT8zeEIimxESOhayDFnnL9nFY0Vr7RUWrB3jGnGCNwO7jQwwAYJ+QT2frYcIMb+IdfpNwOER1q4hfHxcz8mCscUEVNJYdU0s1X/EEYMbrb8u8Zzs0Oa8Xyy9SkfsIQw+xghWD/afiKpMco/3NDklx/oVYmSLaaq25Bi3vRlSdPhrg+ZlMeHQtyAXxc6bNfrebHpXQYSTv1Z6t4jXS1Yv56KHyi6O+8wJA/HjR06jLBuE/xss5JDOrX2KvuB0XfeQvJ9IIW7/X7+zCLwqik7JcgiZIugOH+yaKqan22xkrpSp1h8CV4tXmLROFTSdk6BxGxRgVFHi87W51jkq1JpvtBMvGHxH+DV4iUWeWWMlGzxZNE0Xfe/X9SDHK6FPMniC/Bq8RKLNRc1w7pRINSf/6K6wGKtpdBl+bbF1+DV4rkWv82LOxjbTR+pdopb3P8GAAD//wMA5W1zDP0IAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "5ec9893d6222bfe5e79969c1008aa179"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"f74577fbcb92c1cc3bca0432f8676b1d\""
+            },
+            {
+              "name": "x-request-id",
+              "value": "222d06b4-5393-455d-8a21-dd3644e7f08e"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.049718"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb5nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202203042109-ebc16e3e74-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 88c34981dc, extlb1nuq 88c34981dc"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 796,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-03-05T01:41:57.073Z",
+        "time": 309,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 309
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/resources/address.js
+++ b/test/resources/address.js
@@ -37,7 +37,6 @@ describe('Address Resource', () => {
 
     expect(addressesArray.length).to.be.lessThanOrEqual(5);
     expect(addresses.has_more).to.not.be.null;
-    // TODO: Fix the instanceOf assertion
     addressesArray.forEach((address) => {
       expect(address).to.be.an.instanceOf(easypost.Address);
     });

--- a/test/resources/address.js
+++ b/test/resources/address.js
@@ -35,13 +35,11 @@ describe('Address Resource', () => {
 
     const addressesArray = addresses.addresses;
 
-    // expect(addressesArray).to.be.lessThanOrEqual(5);
+    expect(addressesArray.length).to.be.lessThanOrEqual(5);
     expect(addresses.has_more).to.not.be.null;
-    // TODO: This is broken, cannot iterate like this in Mocha test
+    // TODO: Fix the instanceOf assertion
     addressesArray.forEach((address) => {
-      it('should be an instance of object', funtion () {
-        expect(address).to.be.an.instanceOf(String);
-      });
+      expect(address).to.be.an.instanceOf(easypost.Address);
     });
   });
 });

--- a/test/resources/address.js
+++ b/test/resources/address.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import EasyPost from '../../src/easypost';
 import * as setupPolly from '../setup_polly';
 
@@ -8,9 +9,9 @@ describe('Address Resource', () => {
     const { server } = this.polly;
     setupPolly.stripCreds(server);
 
-    const api = new EasyPost(process.env.EASYPOST_TEST_API_KEY);
+    const easypost = new EasyPost(process.env.EASYPOST_TEST_API_KEY);
 
-    const address = await new api.Address({
+    const address = await new easypost.Address({
       name: 'Jack Sparrow',
       company: 'EasyPost',
       street1: '388 Townsend St',
@@ -22,5 +23,25 @@ describe('Address Resource', () => {
     }).save();
 
     expect(address.street1).to.equal('388 Townsend St');
+  });
+
+  it('retrieves all addresses', async function createAddress() {
+    const { server } = this.polly;
+    setupPolly.stripCreds(server);
+
+    const easypost = new EasyPost(process.env.EASYPOST_TEST_API_KEY);
+
+    const addresses = await easypost.Address.all({ page_size: 5 });
+
+    const addressesArray = addresses.addresses;
+
+    // expect(addressesArray).to.be.lessThanOrEqual(5);
+    expect(addresses.has_more).to.not.be.null;
+    // TODO: This is broken, cannot iterate like this in Mocha test
+    addressesArray.forEach((address) => {
+      it('should be an instance of object', funtion () {
+        expect(address).to.be.an.instanceOf(String);
+      });
+    });
   });
 });

--- a/test/resources/base.js
+++ b/test/resources/base.js
@@ -54,11 +54,11 @@ describe('Base Resource', () => {
         Base._url = url;
 
         return Base.all().then(
-          (bs) => {
+          (b) => {
             expect(stub.get).to.have.been.calledOnce;
             expect(stub.get).to.have.been.calledWith(Base._url, { query: {} });
-            expect(bs.has_more).to.equal(true);
-            bs.map((b) => expect(b).to.be.an.instanceOf(Base));
+            expect(b.base).to.be.an('array');
+            expect(b.has_more).to.equal(true);
           },
           (err) => {
             throw new Error(err);


### PR DESCRIPTION
# Summary

It appears the Node library is unwrapping the responses from the `all` methods to create something like the following:

```
{
  [
    Shipment {
      _validationErrors: null,
      created_at: '2021-12-08T15:53:32Z',
      is_return: false,
      ...
    },
    has_more: true
  ]
}
```

When all our other client libraries and documentation do not unwrap the responses:

```
{
  "shipments": [
    {
      "batch_id": null,
      "batch_message": null,
      "batch_status": null,
      ...
    }
  ],
  has_more: true
}
```

This PR stops unwrapping responses from the `all` endpoint so the key of the objects in question will exist (matching our docs and other client libraries) and the `has_more` key will be populated properly where it's supposed to be.

**This is a breaking change and will require a major version bump.**

There are probably better ways to correct this issue, but based on the way this library is setup, I chose this approach as it required the least amount of refactoring.

## Testing

I've end-to-end tested this with the shipments and addresses endpoint and it's now working correctly.

Closes #195 