### PR TITLE
feat: adds the Node version to the user-agent header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Lowered the default timeout of requests from 120 seconds to 60 seconds
+* Added the Nodejs version in use to the User-Agent header on requests
 
 ## 4.0.0 2021-10-06
 

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -44,7 +44,7 @@ export const DEFAULT_HEADERS = {
   Accept: 'application/json',
   'Accept-Encoding': 'gzip,deflate,sdch,br',
   'Content-Type': 'application/json',
-  'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version}`,
+  'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version} Nodejs/${process.versions.node}`,
   [EASYPOST_UA_HEADER]: JSON.stringify(UA_INFO),
 };
 


### PR DESCRIPTION
Adds the Node version to the user-agent header.

Tested via the repl:
```bash
jhammond@easypost-node $ node
Welcome to Node.js v14.18.2.
Type ".help" for more information.
> process.versions.node
'14.18.2'
```