### PR TITLE
feat: add support to one-call buy an order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 
+* Adds support to one-call buy an order
 * Lowered the default timeout of requests from 120 seconds to 60 seconds
 * Added the Nodejs version in use to the User-Agent header on requests
 

--- a/src/resources/order.js
+++ b/src/resources/order.js
@@ -21,6 +21,7 @@ export const propTypes = {
   messages: T.arrayOf(T.object),
   is_return: T.bool,
   carrier_accounts: T.arrayOf(T.oneOfType([T.string, T.object])),
+  service: T.string,
 };
 
 export default api => (


### PR DESCRIPTION
Adds support to one-call buy an order by adding the missing `service` field to the order object. You one-call buy an order just as you would a shipment, by passing the `service` you want to purchase and the `carrier_account` ID of the carrier it belongs to.

This was end-to-end tested to ensure it works properly.