### PR TITLE
remove retrieveRate() method and its unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@
 * Added the Nodejs version in use to the User-Agent header on requests
 * Added support for create list of trackers
 * Added support for update brand for user
-* Removed `RetrieveRate()` method because the shipment object already
-* has rates. If you need to get new rates for a shipment, please use
-* regenerateRates() method instead
+* Removed `retrieveRates()` method because the shipment object already has rates. If you need to get new rates for a shipment, please use regenerateRates() method instead
 
 ## 4.0.0 2021-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Added the Nodejs version in use to the User-Agent header on requests
 * Added support for create list of trackers
 * Added support for update brand for user
+* Removed `RetrieveRate()` method because the shipment object already
+* has rates. If you need to get new rates for a shipment, please use
+* regenerateRates() method instead
 
 ## 4.0.0 2021-10-06
 

--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -103,14 +103,6 @@ export default api => (
       return this.rpc('label', { file_format: format }, undefined, 'get');
     }
 
-    async retrieveRates() {
-      this.verifyParameters({
-        this: ['id'],
-      });
-
-      return this.rpc('rates', undefined, undefined, 'get');
-    }
-
     async regenerateRates() {
       this.verifyParameters({
         this: ['id'],

--- a/test/resources/shipment.js
+++ b/test/resources/shipment.js
@@ -205,42 +205,6 @@ describe('Shipment Resource', () => {
     });
   });
 
-  describe('retrieving rates', () => {
-    let Shipment;
-    let si;
-    let stub;
-
-    beforeEach(() => {
-      stub = apiStub();
-      Shipment = shipment(stub);
-      si = new Shipment({ id: '1' });
-    });
-
-    it('throws if retrieveRates is called and shipment does not have an id', done => {
-      si = new Shipment();
-      si.retrieveRates().catch(e => {
-        expect(e).to.be.an.instanceof(Error);
-        expect(e.message).to.match(/id/);
-        done();
-      });
-    });
-
-    it('calls api.get when retrieveRates is called', () => si.retrieveRates().then(() => {
-      expect(stub.get).to.have.been.called;
-      expect(stub.get).to.have.been.calledWith(`shipments/${si.id}/rates`);
-    }));
-
-    it('rejects on api failures', done => {
-      Shipment = shipment(apiStub('shipment', true));
-      si = new Shipment({ id: '1' });
-
-      si.retrieveRates().catch(e => {
-        expect(e).to.be.an.instanceof(RequestError);
-        done();
-      });
-    });
-  });
-
   describe('regenerating rates', () => {
     let Shipment;
     let si;


### PR DESCRIPTION
This PR removes **retrieveRate()** in the shipment class and its belonging unit tests because the shipment object already has rates, which makes this method unnecessary. If you need to get new rates for a shipment, please use **regenerateRate()** method.