### PR TITLE
remove enable/disable apikey functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added support for update brand for user
 * Removed `retrieveRates()` method because the shipment object already has rates. If you need to get new rates for a shipment, please use regenerateRates() method instead
 * Add `retrieveMe()` Convenience Function that allow users to retrieve without specifying an ID.
+* Removed `enable()` and `disable()` methods in the apiKey class. Please use this functionality through  EasyPost website 
 
 ## 4.0.0 2021-10-06
 

--- a/src/resources/apiKey.js
+++ b/src/resources/apiKey.js
@@ -37,21 +37,5 @@ export default api => (
     static unwrapAll(data) {
       return this.convertKeyMap(data);
     }
-
-    enable() {
-      this.verifyParameters({
-        this: ['id'],
-      });
-
-      return this.rpc('enable', undefined, this.constructor._url);
-    }
-
-    disable() {
-      this.verifyParameters({
-        this: ['id'],
-      });
-
-      return this.rpc('disable', undefined, this.constructor._url);
-    }
   }
 );

--- a/test/resources/apiKey.js
+++ b/test/resources/apiKey.js
@@ -5,13 +5,11 @@ import apiKey from '../../src/resources/apiKey';
 
 describe('ApiKey Resource', () => {
   let ApiKey;
-  let key;
   let stub;
 
   beforeEach(() => {
     stub = apiStub();
     ApiKey = apiKey(stub);
-    key = new ApiKey({ id: '1' });
   });
 
   it('exists', () => {
@@ -40,34 +38,6 @@ describe('ApiKey Resource', () => {
 
     return cti.save().then(() => {}, err => {
       expect(err).to.be.an.instanceOf(NotImplementedError);
-    });
-  });
-
-  describe('managing shipments', () => {
-    describe('disabling a key', () => {
-      it('throws if disable is called and key does not have an id', () => {
-        key = new ApiKey();
-        expect(() => key.disable()).to.throw(/requires id/);
-      });
-
-      it('calls api.post when disable is called and key has an id', () => {
-        key.disable();
-        expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('api_keys/1/disable');
-      });
-    });
-
-    describe('enabling a key', () => {
-      it('throws if enable is called and key does not have an id', () => {
-        key = new ApiKey();
-        expect(() => key.enable()).to.throw(/requires id/);
-      });
-
-      it('calls api.post when enable is called and key has an id', () => {
-        key.enable();
-        expect(stub.post).to.have.been.called;
-        expect(stub.post).to.have.been.calledWith('api_keys/1/enable');
-      });
     });
   });
 


### PR DESCRIPTION
This PR removes enable() and disable() API Key functionality and unit tests as well. Users should not have the ability to enable/disable via API call, they should use this feature through the EasyPost website.