### PR TITLE
Retrieve me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added support for create list of trackers
 * Added support for update brand for user
 * Removed `retrieveRates()` method because the shipment object already has rates. If you need to get new rates for a shipment, please use regenerateRates() method instead
+* Add `RetrieveMe()` Convenience Function that allow users to retrieve without specifying an ID.
 
 ## 4.0.0 2021-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Added support for create list of trackers
 * Added support for update brand for user
 * Removed `retrieveRates()` method because the shipment object already has rates. If you need to get new rates for a shipment, please use regenerateRates() method instead
-* Add `RetrieveMe()` Convenience Function that allow users to retrieve without specifying an ID.
+* Add `retrieveMe()` Convenience Function that allow users to retrieve without specifying an ID.
 
 ## 4.0.0 2021-10-06
 

--- a/src/resources/user.js
+++ b/src/resources/user.js
@@ -39,6 +39,11 @@ export default api => (
       }
     }
 
+    static async retrieveMe() {
+      const response = await api.get(this._url);
+      return this.create(response.body);
+    }
+
     static all() {
       return this.notImplemented('all');
     }

--- a/test/resources/user.js
+++ b/test/resources/user.js
@@ -33,6 +33,15 @@ describe('User Resource', () => {
     });
   });
 
+  describe('retrieve me', () => {
+    it('retrieve current user', () => {
+      const stub = apiStub();
+      const User = user(stub);
+      User.retrieveMe();
+      expect(stub.get).to.have.been.calledWith('users');
+    });
+  });
+
   it('deletes', () => {
     const User = user(apiStub());
     const id = 1;


### PR DESCRIPTION
Node library is currently missing the **`retrieve_me`** function. This is the same as retrieving a user without specifying an ID, but some libs have a specific function for this. Unifying this to make our libraries more consistent.