### PR TITLE
chore: drops support for Node < 10

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,48 +1,58 @@
 {
-  "presets": [[
-    "@babel/env", {
-      targets: { node: "current" }
-    }
-  ]],
-  "plugins": [
-    "@babel/plugin-syntax-export-extensions",
-    [
-      "@babel/plugin-proposal-class-properties",
-      {
-        "loose": false
-      }
+    "presets": [
+        [
+            "@babel/env",
+            {
+                "targets": {
+                    "node": "current"
+                }
+            }
+        ]
     ],
-    "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-proposal-export-namespace-from",
-    "babel-plugin-transform-export-extensions"
-  ],
-
-  "env": {
-    "test": {
-      "presets": [[
-        "@babel/env", {
-          targets: { node: "8.11" }
-        }
-      ]],
-      "plugins": [
+    "plugins": [
         "@babel/plugin-syntax-export-extensions",
         [
-          "@babel/plugin-proposal-class-properties",
-          {
-            "loose": false
-          }
+            "@babel/plugin-proposal-class-properties",
+            {
+                "loose": false
+            }
         ],
         "@babel/plugin-proposal-export-default-from",
         "@babel/plugin-proposal-export-namespace-from",
-        "babel-plugin-transform-export-extensions",
-        ["istanbul", {
-          "exclude": [
-            "test/**/*"
-          ]
-        }]
-      ],
+        "babel-plugin-transform-export-extensions"
+    ],
+    "env": {
+        "test": {
+            "presets": [
+                [
+                    "@babel/env",
+                    {
+                        "targets": {
+                            "node": "10.0"
+                        }
+                    }
+                ]
+            ],
+            "plugins": [
+                "@babel/plugin-syntax-export-extensions",
+                [
+                    "@babel/plugin-proposal-class-properties",
+                    {
+                        "loose": false
+                    }
+                ],
+                "@babel/plugin-proposal-export-default-from",
+                "@babel/plugin-proposal-export-namespace-from",
+                "babel-plugin-transform-export-extensions",
+                [
+                    "istanbul",
+                    {
+                        "exclude": [
+                            "test/**/*"
+                        ]
+                    }
+                ]
+            ]
+        }
     }
-  }
 }
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,6 @@ node_modules
 npm-debug.log
 /easypost.js
 /easypost.js.map
-/easypost.6-lts.js
-/easypost.6-lts.js.map
-/easypost.8-lts.js
-/easypost.8-lts.js.map
-/easypost.legacy.js
-/easypost.legacy.js.map
 .nyc_output
 coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+* Bumps the minimum version of Node to `v10`
+* Removes build targets of `0.10`, `6`, and `8`, the library is now only published under a single bundled package `easypost`
 * Adds support to one-call buy an order
 * Lowered the default timeout of requests from 120 seconds to 60 seconds
 * Added the Nodejs version in use to the User-Agent header on requests

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ EasyPost is a simple shipping API. You can sign up for an account at https://eas
 npm install --save @easypost/api
 ```
 
-**Note:** if you are using a version of Node less than 6.9, you will need to install and
-include a polyfill, such as `babel-polyfill`, and include it in your project:
+**Note:** If you are using @easypost/api prior to v5 and a version of Node less than 6.9, you will need to install and include a polyfill, such as `babel-polyfill`, and include it in your project:
 
 ```bash
 npm install --save babel-polyfill
@@ -29,8 +28,7 @@ You can alternatively download the various built assets from this project's [rel
 
 ## Compatability
 
-By default, @easypost/api works with Node v6 LTS. To include for other versions
-of node, you can use:
+By default, @easypost/api (prior to v5) works with Node v6 LTS. To include for other versions of node, you can use:
 
 * `require('@easypost/api/easypost.8-lts.js')` (Node 8.9+)
 * `require('@easypost/api/easypost.6-lts.js')` (Node 6.9+)
@@ -213,8 +211,7 @@ API_KEY=yourkey ./repl.js --local easypost.js
 
 ## Note on ES6 Usage
 
-You can import specific versions of the compiled code if you're using later
-versions of Node. 
+You can import specific versions of the compiled code if you're using later versions of Node and using @easypost/api prior to v5.
 
 ```javascript
 // Imports the un-transformed es6

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": ">= v0.10.0"
+    "node": ">= 10.0"
   },
   "scripts": {
     "audit": "ep-node-build audit",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -23,8 +23,5 @@ function config(output, nodestr) {
 }
 
 module.exports = [
-  config('easypost.js', '6.9'),
-  config('easypost.6-lts.js', '6.9'),
-  config('easypost.8-lts.js', '8.9'),
-  config('easypost.legacy.js', '0.10'),
+  config('easypost.js', '10'),
 ];


### PR DESCRIPTION
Drops support for Node < 10 and removes the build matrix for those versions.