### PR TITLE
fix: customs_item.value propType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add `retrieveMe()` Convenience Function that allow users to retrieve without specifying an ID.
 - Removed `enable()` and `disable()` methods in the apiKey class. Please use this functionality through EasyPost website
 - Removed `options.useCookie` from the parameter since it's deprecated in v4.0. Please use `options.useProxy` instead.
+- Fixes `customs_item.value` to ve a `number` instead of a `string`
 
 ## 4.0.0 2021-10-06
 

--- a/src/resources/customs_item.js
+++ b/src/resources/customs_item.js
@@ -9,7 +9,7 @@ export const propTypes = {
   updated_at: T.oneOfType([T.object, T.string]),
   description: T.string,
   quantity: T.number,
-  value: T.string, // decimal, so use as a string instead of a number
+  value: T.number,
   weight: T.number,
   hs_tariff_number: T.string,
   code: T.string,


### PR DESCRIPTION
Corrects the `customs_item.value` propType from string to number. This should have always been number, because the Javascript spec defines a number as a whole number or a decimal. Our docs have this field as a float so this now more clearly defines what is acceptable in this field:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number