### PR TITLE
chore: adds jsdoc style blocks to each function

### DIFF
--- a/src/easypost.js
+++ b/src/easypost.js
@@ -101,23 +101,6 @@ export const PROP_TYPES = {
 };
 
 export default class API {
-  // Build request headers to be sent by default with each request, combined
-  // (or overridden) by any additional headers
-  static buildHeaders(additionalHeaders = {}) {
-    const headers = {
-      ...DEFAULT_HEADERS,
-      ...additionalHeaders,
-    };
-
-    if (typeof window === 'undefined') {
-      return headers;
-    }
-
-    delete headers['User-Agent'];
-    delete headers['Accept-Encoding'];
-    return headers;
-  }
-
   constructor(key, options = {}) {
     const { useProxy, timeout, baseUrl, superagentMiddleware, requestMiddleware } = options;
 
@@ -138,14 +121,41 @@ export default class API {
     this.use(RESOURCES);
   }
 
+  /**
+   * Build request headers to be sent by default with each request, combined (or overridden) by any additional headers
+   * @param {object} additionalHeaders
+   * @returns {object}
+   */
+  static buildHeaders(additionalHeaders = {}) {
+    const headers = {
+      ...DEFAULT_HEADERS,
+      ...additionalHeaders,
+    };
+
+    if (typeof window === 'undefined') {
+      return headers;
+    }
+
+    delete headers['User-Agent'];
+    delete headers['Accept-Encoding'];
+    return headers;
+  }
+
+  /**
+   * Convert to an EasyPost resource.
+   * @param {*} resources
+   */
   use(resources) {
     Object.keys(resources).forEach((c) => {
       this[c] = resources[c](this);
     });
   }
 
-  // If the path passed in is a full URI, use it; otherwise, prepend the base
-  // url from the api.
+  /**
+   * If the path passed in is a full URI, use it; otherwise, prepend the base url from the api.
+   * @param {string} path
+   * @returns {string}
+   */
   buildPath(path = '') {
     if (path.indexOf('http') === 0) {
       return path;
@@ -154,6 +164,14 @@ export default class API {
     return this.baseUrl + path;
   }
 
+  /**
+   * Make an HTTP request.
+   * @param {string} path
+   * @param {string} method
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
     const { query, body } = params;
 
@@ -187,22 +205,57 @@ export default class API {
     }
   }
 
+  /**
+   * Make a GET HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   get(path, params, headers) {
     return this.request(path, METHODS.GET, params, headers);
   }
 
+  /**
+   * Make a POST HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   post(path, params, headers) {
     return this.request(path, METHODS.POST, params, headers);
   }
 
+  /**
+   * Make a PUT HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   put(path, params, headers) {
     return this.request(path, METHODS.PUT, params, headers);
   }
 
+  /**
+   * Make a PATCH HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   patch(path, params, headers) {
     return this.request(path, METHODS.PATCH, params, headers);
   }
 
+  /**
+   * Make a DELETE HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
   del(path, params, headers) {
     return this.request(path, METHODS.DELETE, params, headers);
   }

--- a/src/errors/error.js
+++ b/src/errors/error.js
@@ -1,6 +1,5 @@
 export default class ErrorClass {
   constructor(message) {
-    /* eslint no-prototype-builtins: 0 */
     Error.captureStackTrace(this, this.constructor);
 
     Object.defineProperty(this, 'message', {

--- a/src/resources/address.js
+++ b/src/resources/address.js
@@ -34,12 +34,20 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * delete not implemented.
+     * @returns {this}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
-    // Object format is { address: { ... }, verify: [ ] }, so we need to pull
-    // the verify properties to the top level when wrapping.
+    /**
+     * Object format is { address: { ... }, verify: [ ] }, so we need to pull
+     * the verify properties to the top level when wrapping.
+     * @param {object} json
+     * @returns {string}
+     */
     static wrapJSON(json) {
       const topLevelKeys = ['verify', 'verify_strict'];
 

--- a/src/resources/api_key.js
+++ b/src/resources/api_key.js
@@ -15,14 +15,27 @@ export default (api) =>
 
     static _url = 'api_keys';
 
+    /**
+     * delete not implemented.
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * save not implemented.
+     * @returns {Promise<never>}
+     */
     async save() {
       return this.constructor.notImplemented('save');
     }
 
+    /**
+     * Converts the key map of API keys.
+     * @param {*} data
+     * @returns {*}
+     */
     static convertKeyMap(data) {
       if (!data.keys) {
         return [];
@@ -37,6 +50,11 @@ export default (api) =>
       return res;
     }
 
+    /**
+     * Unwraps the response of the `/all` request
+     * @param {*} data
+     * @returns {this}
+     */
     static unwrapAll(data) {
       return this.convertKeyMap(data);
     }

--- a/src/resources/batch.js
+++ b/src/resources/batch.js
@@ -29,10 +29,19 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * delete not implemented.
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * Add a shipment to a batch.
+     * @param {string} shipmentId
+     * @returns {this}
+     */
     addShipment(shipmentId) {
       this.verifyParameters(
         {
@@ -45,6 +54,11 @@ export default (api) =>
       return this.rpc('add_shipments', { shipments: [{ id: shipmentId }] });
     }
 
+    /**
+     * Add shipments to a batch.
+     * @param {Array} shipmentIds
+     * @returns {this}
+     */
     addShipments(shipmentIds) {
       this.verifyParameters(
         {
@@ -59,6 +73,11 @@ export default (api) =>
       });
     }
 
+    /**
+     * Remove a shipment from a batch.
+     * @param {string} shipmentId
+     * @returns {this}
+     */
     removeShipment(shipmentId) {
       this.verifyParameters(
         {
@@ -71,6 +90,11 @@ export default (api) =>
       return this.rpc('remove_shipments', { shipments: [{ id: shipmentId }] });
     }
 
+    /**
+     * Removes shipments from a batch.
+     * @param {Array} shipmentIds
+     * @returns
+     */
     removeShipments(shipmentIds) {
       this.verifyParameters(
         {
@@ -85,6 +109,11 @@ export default (api) =>
       });
     }
 
+    /**
+     * Convert the label of a batch.
+     * @param {string} fileFormat
+     * @returns {this}
+     */
     generateLabel(fileFormat = DEFAULT_LABEL_FORMAT) {
       this.verifyParameters(
         {
@@ -97,6 +126,10 @@ export default (api) =>
       return this.rpc('label', { file_format: fileFormat });
     }
 
+    /**
+     * Create a scanform for a batch.
+     * @returns {this}
+     */
     createScanForm() {
       this.verifyParameters({
         this: ['id'],
@@ -105,6 +138,10 @@ export default (api) =>
       return this.rpc('scan_form');
     }
 
+    /**
+     * Buy a batch.
+     * @returns {this}
+     */
     buy() {
       this.verifyParameters({
         this: ['id', 'shipments'],

--- a/src/resources/brand.js
+++ b/src/resources/brand.js
@@ -2,6 +2,7 @@ import T from 'proptypes';
 import base from './base';
 
 export const propTypes = {
+  id: T.string,
   background_color: T.string,
   color: T.string,
   logo: T.string,

--- a/src/resources/carrier_type.js
+++ b/src/resources/carrier_type.js
@@ -18,14 +18,26 @@ export default (api) =>
 
     static _url = 'carrier_types';
 
+    /**
+     * retrieve not implemented.
+     * @returns {Promise<never>}
+     */
     static retrieve() {
       return super.notImplemented('retrieve');
     }
 
+    /**
+     * delete not implemented.
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * save not implemented.
+     * @returns {Promise<never>}
+     */
     async save() {
       return this.constructor.notImplemented('save');
     }

--- a/src/resources/customs_info.js
+++ b/src/resources/customs_info.js
@@ -30,10 +30,18 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * all not implemented.
+     * @returns {Promise<never>}
+     */
     static all() {
       return super.notImplemented('all');
     }
 
+    /**
+     * delete not implemented.
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }

--- a/src/resources/customs_item.js
+++ b/src/resources/customs_item.js
@@ -27,14 +27,6 @@ export default (api) =>
 
     static key = 'customs_item';
 
-    static all() {
-      return this.notImplemented('all');
-    }
-
-    static delete() {
-      return this.notImplemented('delete');
-    }
-
     constructor(data) {
       let { value } = data;
 
@@ -45,11 +37,19 @@ export default (api) =>
       super({ ...data, value });
     }
 
-    async save() {
-      if (this.value && typeof this.value !== 'string') {
-        this.value = this.value.toString();
-      }
+    /**
+     * all not implemented.
+     * @returns {Promise<never>}
+     */
+    static all() {
+      return this.notImplemented('all');
+    }
 
-      return super.save();
+    /**
+     * delete not implemented.
+     * @returns {Promise<never>}
+     */
+    static delete() {
+      return this.notImplemented('delete');
     }
   };

--- a/src/resources/event.js
+++ b/src/resources/event.js
@@ -26,10 +26,18 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * save not implemented
+     * @returns {Promise<never>}
+     */
     static save() {
       return this.notImplemented('save');
     }

--- a/src/resources/insurance.js
+++ b/src/resources/insurance.js
@@ -34,6 +34,10 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }

--- a/src/resources/order.js
+++ b/src/resources/order.js
@@ -35,14 +35,28 @@ export default (api) =>
 
     static jsonIdKeys = ['to_address', 'from_address', 'return_address', 'buyer_address'];
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static all() {
       return this.notImplemented('all');
     }
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * Buy an order.
+     * @param {string} carrier
+     * @param {string} service
+     * @returns {this}
+     */
     async buy(carrier, service) {
       this.verifyParameters(
         {
@@ -56,6 +70,10 @@ export default (api) =>
       return this.rpc('buy', { carrier, service });
     }
 
+    /**
+     * Get the rates of an order.
+     * @returns {this}
+     */
     async getRates() {
       return this.rpc('rates', undefined, undefined, 'get');
     }

--- a/src/resources/parcel.js
+++ b/src/resources/parcel.js
@@ -24,10 +24,18 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static all() {
       return this.notImplemented('all');
     }
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }

--- a/src/resources/pickup.js
+++ b/src/resources/pickup.js
@@ -38,14 +38,28 @@ export default (api) =>
 
     static jsonIdKeys = ['address', 'shipment', 'batch'];
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static all() {
       return this.notImplemented('all');
     }
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * Buy a pickup.
+     * @param {strin} carrier
+     * @param {string} service
+     * @returns {this}
+     */
     async buy(carrier, service) {
       this.verifyParameters(
         {
@@ -59,6 +73,10 @@ export default (api) =>
       return this.rpc('buy', { carrier, service });
     }
 
+    /**
+     * Cancel a pickup.
+     * @returns {this}
+     */
     async cancel() {
       this.verifyParameters({
         this: ['id'],

--- a/src/resources/rate.js
+++ b/src/resources/rate.js
@@ -33,14 +33,26 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static all() {
       return this.notImplemented('all');
     }
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * save not implemented
+     * @returns {Promise<never>}
+     */
     static save() {
       return this.notImplemented('save');
     }

--- a/src/resources/report.js
+++ b/src/resources/report.js
@@ -30,18 +30,38 @@ export default (api) =>
       }
     }
 
+    /**
+     * Construct the URL for the reports endpoint.
+     * @param {string} type
+     * @returns
+     */
     static constructUrl(type) {
       return `reports/${type}`;
     }
 
+    /**
+     * Retrieve a list of reports.
+     * @param {string} type
+     * @param {object} query
+     * @returns {this}
+     */
     static async all(type, query = {}) {
       return super.all(query, this.constructUrl(type));
     }
 
+    /**
+     * Override the wrapJSON function for this object.
+     * @param {object} json
+     * @returns {object}
+     */
     static wrapJSON(json) {
       return json;
     }
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }

--- a/src/resources/scan_form.js
+++ b/src/resources/scan_form.js
@@ -28,10 +28,19 @@ export default (api) =>
       return this.notImplemented('delete');
     }
 
+    /**
+     * Override the wrapJSON function for this object.
+     * @param {object} json
+     * @returns
+     */
     static wrapJSON(json) {
       return json;
     }
 
+    /**
+     * Converts an object to JSON.
+     * @returns {object}
+     */
     toJSON() {
       if (this.shipments) {
         return {

--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -67,10 +67,20 @@ export default (api) =>
       'tracker',
     ];
 
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
     static delete() {
       return this.notImplemented('delete');
     }
 
+    /**
+     * Buy a shipment.
+     * @param {object} rate
+     * @param {number} insuranceAmount
+     * @returns {this}
+     */
     async buy(rate, insuranceAmount) {
       this.verifyParameters(
         {
@@ -99,6 +109,11 @@ export default (api) =>
       return this.rpc('buy', data);
     }
 
+    /**
+     * Convert the label format of a shipment.
+     * @param {string} format
+     * @returns {this}
+     */
     async convertLabelFormat(format) {
       this.verifyParameters(
         {
@@ -111,6 +126,10 @@ export default (api) =>
       return this.rpc('label', { file_format: format }, undefined, 'get');
     }
 
+    /**
+     * Regenerate rates of a shipment.
+     * @returns {this}
+     */
     async regenerateRates() {
       this.verifyParameters({
         this: ['id'],
@@ -119,6 +138,10 @@ export default (api) =>
       return this.rpc('rerate', undefined, undefined, 'post');
     }
 
+    /**
+     * Get the smartrates of a shipment.
+     * @returns {this}
+     */
     async getSmartrates() {
       this.verifyParameters({
         this: ['id'],
@@ -127,6 +150,11 @@ export default (api) =>
       return this.rpc('smartrate', undefined, undefined, 'get');
     }
 
+    /**
+     * Insure a shipment.
+     * @param {number} amount
+     * @returns {this}
+     */
     async insure(amount) {
       this.verifyParameters(
         {
@@ -139,6 +167,10 @@ export default (api) =>
       return this.rpc('insure', { amount });
     }
 
+    /**
+     * Refund a shipment.
+     * @returns {this}
+     */
     async refund() {
       this.verifyParameters({
         this: ['id'],
@@ -147,6 +179,12 @@ export default (api) =>
       return this.rpc('refund');
     }
 
+    /**
+     * Get the lowest rate of a shipment.
+     * @param {string} carriers
+     * @param {string} services
+     * @returns {object}
+     */
     lowestRate(carriers, services) {
       let rates = this.rates || [];
 

--- a/src/resources/tracker.js
+++ b/src/resources/tracker.js
@@ -35,6 +35,11 @@ export default (api) =>
       return this.notImplemented('delete');
     }
 
+    /**
+     * Create trackers in bulk.
+     * @param {object} params
+     * @returns {bool|Promise<never>}
+     */
     static async createList(params = {}) {
       const newParams = { trackers: params };
       try {

--- a/src/resources/user.js
+++ b/src/resources/user.js
@@ -28,6 +28,12 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * Retrieve a child user.
+     * @param {string} id
+     * @param {string} urlPrefix
+     * @returns {this}
+     */
     static async retrieve(id, urlPrefix) {
       try {
         let url = urlPrefix || this._url; // retrieve self
@@ -42,15 +48,28 @@ export default (api) =>
       }
     }
 
+    /**
+     * Retrieve the authenticated user.
+     * @returns {this}
+     */
     static async retrieveMe() {
       const response = await api.get(this._url);
       return this.create(response.body);
     }
 
+    /**
+     * all not implemented
+     * @returns {Promise<never>}
+     */
     static all() {
       return this.notImplemented('all');
     }
 
+    /**
+     * Update the brand of a user.
+     * @param {object} params
+     * @returns {object}
+     */
     async updateBrand(params) {
       try {
         const newParams = { brand: params };

--- a/test/resources/customs_item.js
+++ b/test/resources/customs_item.js
@@ -8,23 +8,6 @@ describe('Customs Item Resource', () => {
     expect(customsItem).to.be.a('function');
   });
 
-  it('converts number `value`s to strings', () => {
-    const CustomsItem = customsItem(apiStub());
-    const ci = new CustomsItem({ value: 20.7 });
-
-    expect(ci.value).to.equal('20.7');
-  });
-
-  it('converts number `value`s to strings on save', () => {
-    const CustomsItem = customsItem(apiStub());
-    const ci = new CustomsItem({});
-    ci.value = 20.7;
-
-    ci.save();
-
-    expect(ci.value).to.equal('20.7');
-  });
-
   it('throws on all', () => {
     const CustomsItem = customsItem(apiStub());
     return CustomsItem.all().then(


### PR DESCRIPTION
- Adds `jsdoc` style blocks to each function (I tried keeping things generic for now, we can tighten these down as time goes on)
- Moves `constructors` to be the first thing in their respective classes
- Adds `brand` ID which was previously missing to ensure proper documentation
- Removes custom `save` function from customs_item class that was missed in the previous PR