### PR TITLE
move columns and additional_columns from url query to request body.

### DIFF
--- a/src/resources/report.js
+++ b/src/resources/report.js
@@ -33,50 +33,6 @@ export default (api) =>
     }
 
     /**
-     * Save (create or update) a report.
-     * This function is overridden from the parent class with default save behavior.
-     * @returns {this|Promise<never>}
-     */
-    async save() {
-      try {
-        this.validateProperties();
-      } catch (e) {
-        return Promise.reject(e);
-      }
-
-      try {
-        const data = this.constructor.wrapJSON(this.toJSON());
-
-        let url = `${this._url || this.constructor._url}?`;
-
-        if (data.columns != null) {
-          Object.values(data.columns).forEach((column) => {
-            url += `columns[]=${column}&`;
-          });
-          // Delete the columns from the data since it's added in the url query.
-          delete data.columns;
-        }
-
-        if (data.additional_columns != null) {
-          Object.values(data.additional_columns).forEach((column) => {
-            url += `additional_columns[]=${column}&`;
-          });
-          // Delete the additional_columns from the data since it's added in the url query.
-          delete data.additional_columns;
-        }
-
-        const res = await api.post(url, {
-          body: data,
-        });
-
-        this.mapProps(res.body);
-        return this;
-      } catch (e) {
-        throw e;
-      }
-    }
-
-    /**
      * Construct the URL for the reports endpoint.
      * @param {string} type
      * @returns

--- a/test/cassettes/Report-Resource_72515537/creates-a-report-by-specifying-columns_1660528128/recording.har
+++ b/test/cassettes/Report-Resource_72515537/creates-a-report-by-specifying-columns_1660528128/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "1d78c9703e8a7bac271baee8c4abfc53",
+        "_id": "97a1084362998119d960a6d35fb7b8f3",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 69,
+          "bodySize": 93,
           "cookies": [],
           "headers": [
             {
@@ -37,29 +37,23 @@
             },
             {
               "name": "content-length",
-              "value": 69
+              "value": 93
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 532,
+          "headersSize": 508,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"type\":\"shipment\",\"start_date\":\"2022-03-07\",\"end_date\":\"2022-03-09\"}"
+            "text": "{\"type\":\"shipment\",\"start_date\":\"2022-03-07\",\"end_date\":\"2022-03-09\",\"columns\":[\"usps_zone\"]}"
           },
-          "queryString": [
-            {
-              "_fromType": "array",
-              "name": "columns",
-              "value": "usps_zone"
-            }
-          ],
-          "url": "https://api.easypost.com/v2/reports/shipment?columns%5B%5D=usps_zone"
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
           "bodySize": 272,
@@ -67,7 +61,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 272,
-            "text": "[\"H4sIAAAAAAAAA4SOQQ7CIBBF78LaJog0LRxDXbkhLTOkGEoJTKOJ8e5S3Zi4cDfz/vuZeTAPTLMypYzJKO5AolKKj0520qmDbeUeOoVt3/ejYzu2jFe0VCunyacZIx0xLZlqYjMOhGCGLRVciIYfGiHOQmjZa95eqrMm+OsUGjKZzftyeFcTjPDDVeXzAhsjLPTp01rqHvG2ncyB6biG8B4N3pPPWN4ffKiPNqyAxk4+QMbItBtCwecLAAD//wMAOt/JSxsBAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SOQQ7CIBBF78JaE8RWKcdQV25IC58Ug5TANJoY7y7VjYkLdzPvv5+ZB/OWKVbGlJG0c651QjRDZ9AAUnYbLs2wk5uGW9kObMWm4QJDtXIcfboi0gFpylQTk9ETrO6XVHAh1ny7FtuTEIpLxZtzdeZk/zqF+kx68b4cvq8Jov3hXeXXyS6MUOjTp7nUPeK2nMyBqTiH8B417slnlPcHH+qjCbOFNqMPNiMy5fpQ8HwBAAD//wMA4Pk7BxsBAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -97,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "79b8c6fc623a5225ff246b6100123926"
+              "value": "4aee9dd6623b9a43ff10b6830010f134"
             },
             {
               "name": "cache-control",
@@ -117,11 +111,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"2f170d1ce8e41ac42a44439112ef17c8\""
+              "value": "W/\"8a4494f4314dec7ee42bea3d47c07bae\""
             },
             {
               "name": "x-runtime",
-              "value": "0.043047"
+              "value": "0.038352"
             },
             {
               "name": "content-encoding",
@@ -133,11 +127,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203222149-4f3b000452-master"
+              "value": "easypost-202203231943-61a988cd70-master"
             },
             {
               "name": "x-backend",
@@ -145,7 +139,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, intlb1wdc 3e97db20d4, extlb1wdc 3e97db20d4"
+              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
             },
             {
               "name": "strict-transport-security",
@@ -156,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-03-22T22:48:05.396Z",
-        "time": 243,
+        "startedDateTime": "2022-03-23T22:08:03.688Z",
+        "time": 290,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -171,7 +165,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 243
+          "wait": 290
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/creates-a-report-with-additional-columns_3168456315/recording.har
+++ b/test/cassettes/Report-Resource_72515537/creates-a-report-with-additional-columns_3168456315/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "2ce285e6eb6c189f1f063fdaf28ab8af",
+        "_id": "87b34e79f810b701641931f390d4bbb6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 69,
+          "bodySize": 119,
           "cookies": [],
           "headers": [
             {
@@ -37,42 +37,31 @@
             },
             {
               "name": "content-length",
-              "value": 69
+              "value": 119
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 581,
+          "headersSize": 509,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"type\":\"shipment\",\"start_date\":\"2022-03-07\",\"end_date\":\"2022-03-09\"}"
+            "text": "{\"type\":\"shipment\",\"start_date\":\"2022-03-07\",\"end_date\":\"2022-03-09\",\"additional_columns\":[\"from_name\",\"from_company\"]}"
           },
-          "queryString": [
-            {
-              "_fromType": "array",
-              "name": "additional_columns",
-              "value": "from_name"
-            },
-            {
-              "_fromType": "array",
-              "name": "additional_columns",
-              "value": "from_company"
-            }
-          ],
-          "url": "https://api.easypost.com/v2/reports/shipment?additional_columns%5B%5D=from_name&additional_columns%5B%5D=from_company"
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
-          "bodySize": 276,
+          "bodySize": 272,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 276,
-            "text": "[\"H4sIAAAAAAAAA4SOQW7DIBBF78K6kSh2gsMxmqy6QZj5lqkIRjBWI0W5e3CyqdRFdjPvv6+ZmwgkjKhzLsiWDnLfddAHLadeD27oPWGUk8ZI/adz4kMs4w88t8ppDvmCxF/IS+GW+ALHIOu2VEmldrLbKXVWyvSDkfvv5qyZ3jqVXWG7eX8cqVuCRP/4sfHLQhtjVH71ea1tT/jdTpYoTFpjfI4W1xwK6vODFw3Jx5Vg/RwiFSRhJhcr7g8AAAD//wMAvR9OrhsBAAA=\"]"
+            "size": 272,
+            "text": "[\"H4sIAAAAAAAAA4SOQQ7CIBBF78LaJgQJRY6hrtwQykxTDKUEptHEeHepbkxcuJt5//3MPFgAZlidcsFsHUfp5agEjFJqhYP2qh+565XTBw2a7dgyXNFTq5ymkGdMdMS8FGqJL+gIwbotFVyIju87sT8LYbg2XF6as2b461RyhezmfTm8bwkm+OGHxucFNkZY6dOntbY94W07WSIzaY3xPVq851Cwvj/40JB8XAGtn0KEgomZ0cWKzxcAAAD//wMAkzX79BsBAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -102,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "79b8c6fc623a5225ff246b6200123934"
+              "value": "4aee9dd0623b9a44ff10b6840010f156"
             },
             {
               "name": "cache-control",
@@ -122,11 +111,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"747ff7bb3279570f68c4d1dae6ab90b8\""
+              "value": "W/\"06e9108b45ceea467edefbd07ef57e47\""
             },
             {
               "name": "x-runtime",
-              "value": "0.040861"
+              "value": "0.034012"
             },
             {
               "name": "content-encoding",
@@ -142,7 +131,7 @@
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203222149-4f3b000452-master"
+              "value": "easypost-202203231943-61a988cd70-master"
             },
             {
               "name": "x-backend",
@@ -150,7 +139,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, intlb1wdc 3e97db20d4, extlb1wdc 3e97db20d4"
+              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
             },
             {
               "name": "strict-transport-security",
@@ -161,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-03-22T22:48:05.648Z",
-        "time": 210,
+        "startedDateTime": "2022-03-23T22:08:03.987Z",
+        "time": 259,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -176,7 +165,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 210
+          "wait": 259
         }
       }
     ],


### PR DESCRIPTION
This PR moves the columns and additional_columns from URL query to request body because a long query URL can be rejected or silently truncated. Basically, the overridden `save()` is removed and then re-record cassettes.

E2E test:
<img width="129" alt="Screen Shot 2022-03-23 at 6 04 53 PM" src="https://user-images.githubusercontent.com/22759143/159804404-1d89711a-95db-472d-a29f-87bc1d5f7b9f.png">
