### PR TITLE
add refund class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Add support for `columns` and `additional_columns` on Report creation
 - Adds `address.verifyAddress()` and `Address.createAndVerify()` functions
 - Adds `Batch.createAndBuy()` function
+- Adds `Refund` class which has `Refund.save()`, `Refund.all()`, and `Refund.retrieve()`
 
 ## 4.0.0 2021-10-06
 

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -17,6 +17,7 @@ import Order, { propTypes as orderPropTypes } from './resources/order';
 import Parcel, { propTypes as parcelPropTypes } from './resources/parcel';
 import Pickup, { propTypes as pickupPropTypes } from './resources/pickup';
 import Rate, { propTypes as ratePropTypes } from './resources/rate';
+import Refund, { propTypes as refundPropTypes } from './resources/refund';
 import Report, { propTypes as reportPropTypes } from './resources/report';
 import ScanForm, { propTypes as scanFormPropTypes } from './resources/scan_form';
 import Shipment, { propTypes as shipmentPropTypes } from './resources/shipment';
@@ -72,6 +73,7 @@ export const RESOURCES = {
   Parcel,
   Pickup,
   Rate,
+  Refund,
   Report,
   ScanForm,
   Shipment,
@@ -95,6 +97,7 @@ export const PROP_TYPES = {
   parcelPropTypes,
   pickupPropTypes,
   ratePropTypes,
+  refundPropTypes,
   reportPropTypes,
   scanFormPropTypes,
   shipmentPropTypes,

--- a/src/resources/refund.js
+++ b/src/resources/refund.js
@@ -1,0 +1,44 @@
+import T from 'proptypes';
+import base from './base';
+
+export const propTypes = {
+  id: T.string,
+  tracking_code: T.string,
+  confirmation_number: T.string,
+  status: T.string,
+  carrier: T.string,
+  shipment_id: T.string,
+};
+
+export default (api) =>
+  class Refund extends base(api) {
+    static _name = 'Refund';
+
+    static _url = 'refunds';
+
+    static key = 'refund';
+
+    static propTypes = propTypes;
+
+    /**
+     * create a refund
+     * @returns {Promise<never>}
+     */
+    static async save(params = {}) {
+      const newParams = { refund: params };
+      try {
+        const response = await api.post(this._url, { body: newParams });
+        return response.body;
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+
+    /**
+     * delete not implemented
+     * @returns {Promise<never>}
+     */
+    static delete() {
+      return this.notImplemented('delete');
+    }
+  };

--- a/test/cassettes/Refund-Resource_710135213/creates-a-refund_2084766157/recording.har
+++ b/test/cassettes/Refund-Resource_710135213/creates-a-refund_2084766157/recording.har
@@ -1,0 +1,492 @@
+{
+  "log": {
+    "_recordingName": "Refund Resource/creates a refund",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.4"
+    },
+    "entries": [
+      {
+        "_id": "a494ab03e37523b38629c5cba9c60037",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 503,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 503
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 502,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"service\":\"First\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 2208,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2208,
+            "text": "[\"H4sIAAAAAAAAA+xY227bOBD9FUOvm9ikbhT9ZuSy227rBLG73WZRCBRJ2UxkSaCkpk6Rf9+hLo4vTWMgQbPYJgiQcDgcDeccDjnzzeJaslKKkJXW0LKRbR8i9xCRKSZDzxt6waV1YKki1LKsdGoNY5YU8sBayKJgM1lYw38+wygTElaXsihBO8tLlaUw9c3ildYy5UuY/DA5hrmcLRcyLc1cuczNosnJ+Pjkwro7sAT4ETLxhaUcJhBItIylWQ/DtEqSA6soWVmBZatKr9PsJgWLpWb8WqWzkDdOUBchbH6p42OMXeQTTD1QrHLxo41Ss9GIlXweKtF9rxl3X12XtQHohLwqymxRhCqNs04W62wB+xEaVM2GjVmLCR3GLBZSEhb5NMJYcuoxj3Ec+xFiSGBpYhhdSW4cHbXrDx4F6jeEhgg9vtF7xZQtTMTeQgB7k5xpnd2Y72SLnKUGshNWLM+zGtOi1FKWGIROEPSmEPpCpqI3uZ+zjbN52bONZa5KY2DC0t6pBjxVwTOrgc988WgEg1uV13BhROqvVmmpG6IYnsyz1Gh6qx8QygVTSRfdTc5x8F5JE1qukvrjjRbETgkgnGKrhbEUUrMkLNnXNaRr17ZkX6RWseKso/MdUFKlRaUbhloe6tdxzDRYXFsHoeQyWUGea56E2Ils5tg+E8hxfUFZJGLqI+IJCKhnB+uYnzfrH4f8cg+0jU4i01k5t4YYHD6wbpQwg8D8P5dqNoeVrhnkGkITqxSs5cCJNXrftGrY67uboYeQ5EAR0A0TFjW7vt9IM/Ounjhoo5GEnu0EGEnBqZAukza1KZVwBhzi28gl9PGd0z12Xuts5RSDXylnul4XZ3oBK1PDNIiRcTIUDUEfsNboAKeypDKksIYOQp24ULdmqfvVX2m2KQ6CyqqkXIljlchuTi0gQIM8na1mKw1BtOZlmRfDwUDCGTQBPjSLin7h9Kvi8AYif2j32YLdZim7KfpwZge1wmADjIHZB3IRGRAqUexTRGlMXDdyA1cKjwRxFAUc+Zz11z3IRdx40YDfCG/zZFco88TelRpPGonJ4RBRc020h8EMwzjAGDkBjWmMXRn7gc2FcGM7RthxPMnXD8OFQeT5CLGZNgqpv6j6LJ8qvZ5I6jx0bjKRbhgBxK95uX2hwb0ISSnc1GqFO8qJKsot1Vq0oyhkoiD7LIGPSwievSEpV8dyQxjOKgaZqZRSrK5p2GW4a6uYq9zcwnXKglEeAil8SYUfEbgxuR1EHKDxKaMRwzbm0VqGZbxO1c1azkIvYoQzx3ds7rlMyAgTJtyIw4Xm8IAiyBDr0MPFx3we2IQH0pURoZgSR0S2oD5jNvFeAPqTr3l3xT4Avu30a88eQd8mfRftCX9nci/8v4P2UyjQ3ngvyALqQJ53AXMe+C7hHjOfxrEMqB9TV/gvwILm0p3IxHz1YSqQvm0/zoRWax8itKq/Wh4AkAXzkSCB5C6nDpMB40RCWiAgZuwlGKBVps3b8UfoO+Rx9IM+2TcNtAb3Qh8/I/r4p6P/uS7nqlRslVMFZ2n7FGsF9REEDJsQvb4bftl3Q1Pbm6C2JCj1dcgjIT2BhScldWNEI6iffAy1lSOhgt4spKbt+m349u4ZfKff0IggOmVdjK7NPBfVCjUzJVi03K6+mtEWNveoPgWee96uYtPssO3wxLLr9XR4dgFoS94qShTfql1qU/2ugqmLFHF14os/3uq/7bG6/P0Dvjw+vR5//Cs5m14s3h8n6v3tzB1fnSw/Td/fXk5PF+OrN27NhOyhTkoED4Zg1UkBBjWdFE4iwTfeEc/fSaE7nZTR0Z+9yfno4uLs42YnZTT5dH42me52Us4+jk0HrDeZ9kbn06Z7smqotL2ltpkyGvdOL0bjozeTo7MfNFMOsV9fPz+jo1LqSj6lo2L8ds3fouK8BrexKLXOdEu4FQ/bgrLj/r7LvkFVWqqyMptzSJ8Qz4PbL8nSWSs8xLbdd6hPCfBMLWR420RqtABvORu8y4pwlM7gWiqsuzvTBKqKvGi1cJ21K52+dvr+Z52+qFqaa+s167xmnf9G1jGP5M3reK3VeipNMmmbinXDtZGwhQEEZKZXjWra8DnTM/PYa9xvXuWrx58p075vte3mbtk179Gn2X3TtdR3PLa9vSx/blvLez55Vl5M2geTdfcvAAAA//8DAMGi2QcHGwAA\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d884a624f25aeff12c9fe001ad32c"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_f746e9d6b7114c28bcf9f69a9ba121cb"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"1b065d60213ba15f1c1153696d705a6f\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "1.024026"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb6nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 832,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_f746e9d6b7114c28bcf9f69a9ba121cb",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-04-07T17:55:58.603Z",
+        "time": 1224,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1224
+        }
+      },
+      {
+        "_id": "9282d204d5838a5f5df982ababf1247f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 517,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments/shp_f746e9d6b7114c28bcf9f69a9ba121cb"
+        },
+        "response": {
+          "bodySize": 2600,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2600,
+            "text": "[\"H4sIAAAAAAAAA+xZbW/bOBL+K4K+nu3oXaK/GU5y7V6bBLF77eZQCBRJOWxlSaCopk7R/75DUlL80jRetNsubhsESDgcksNnHg45o082EQxLRlMs7antOZ43doKxEy/deBqG0zC5sUc2b1LBZCtKe5rjomEje82aBq9YY0//9xZaFWUwWrJGgnZVS16V0PXJJq0QrCQb6Hy1OIW+Gm/WrJSqT25qNWhxdnF6dm1/HtkU7Egx/YBLAh0OSATLmRoPzbItipHdSCxbmNluy/dldVfCjFJg8p6Xq5QYI1DgOK76RX7kum7gRLGLQlBsa/q1jSK10QxLcpty2q9n2v2q27IOgF5I2kZW6yblZV71slxUa9gPFaCqNqymtTEVaY5zyliMswhlrssICnGIiZtHmYMd6jKFYfaOEWXorBs/etJR/3KcqeM8vdEHxRKvFWK/AYDWosZCVHdqnWpd41K57Aw3m6tK+7SRgjHpgtBPEmsJ0DespNbioc9TxtbS8tTMhEs1wQKX1rkAf/KGVLZxn1pxPoPGPa+1u1wn1qu2pRSGKIont1WpNMPhB4RsjXnRo7vLOQLWc6agJbzQixstwI5TIBzHw8CcUSZwkUr8ccvT2rQ92QcmeM4J7un8GSjJy6YVhqF26Ew0jpWAGbfGAZSEFYPLa0GK1PUzD/tehKnjBxFFOKM5ipw4pABo6CXbPr8y4592+c0R3lY6BStX8taeumDwyL7jVDUS9f8t46tbGBmoRi0AmpyXMFsNnNii912n5oaTYBd6gKQGioBuWuDM7PphI6bnhe4YdWgUaej5ieswShBlAWYe8hBicAb8OPKcIEZP7xwdsXOtsxdTlP8kWwk9Lq/EGkaWimmAkTIypYagj8xmdIBTVdEqUthT33F6ccPv1dDgYzRodiEOQMVtIQdxzgvW9/E1AHRSl6uhtxUAon0rZd1MT04YnEEF8FgNaiaNP2mb8R0gP/YmeI3vqxLfNRM4syda4WTHGSdqH07gxCcxYk4eIQehPA6CLEgCRsM4ybMsIU5E8GTbgprmxgrjfCO8r4tDIasL71CqLDESFcMBUXVNdIdBNdM8cV3HT1COcjdgeZR4hNIg93LH9f2Qke3DcK088v0IsRs2GiY+cH2Wz7nYDiQ6Dl2pSCQMI4D4mpf7FxrcixCU0l2tTnigXPBG7qlq0YEiZQWH6LMBPm4APG9HIodjuSNMVy2GyCQZo8M1DbtMD+dqbnmtbmEdsqBVp0CKiCEaZTHcmMRLMgKuiRBGGXY9l2RbERYTHarNWILTMMMxwX7keyQMMGWZG2MaZAQuNJ8kyIEIse16uPhwRBIvJgkLWBYjF8U+zTyKIoy9OPwJrj/7WPdX7CPO9/yJtuwJ73vxJHCOdH8/5VH+/4K3v4UC3Y33E1mAfIjzAficJFEQkxCrpd2cJSjKUUCjn8ACc+kuWKFWfZwK8cTznmZCp3UMETrVf1ocACdTHDk0ThgJCPIxSzCJGYSFGMQY/wwGCF4J9Xb8mvf9+GnvJ5P42DDQTXiU993v6H33h3v/rU7n2pLupVMNwWX3FOsE+giCDw1Ev94N/9h3g8ntFagdCaR4n5KMspC6NGQMBbmDMsifIhdyK59BBr2bSC278fvuO7pmMNQb4IWQwqiy4XIQA0JSJ6R92/DoO5Ku4SuVjGWb/TzMtPa89LXM5Vtc98DpATezc/Os30Ubek8NLEORSIdWNl50JljPy7yyFuo/WVndzJQ1RPDaJFV7tZ4/h736I/n6AQv/AIuqFfrsdmv3DDVkMIsPOy0qk//v5LX9Tl/0nX3FY6uWMFSG+sKGaeqqh06N1H14DHYKtxq6LJ1GW3PDrb8cs2TpRFPf++sxs59dvlosLy+26kPLN/aXgbPj2Il8+7O6TXLWlx97Y/r9ba06N10DrHuBezwvcNNYV6baAaQ0vWrxEkaUMKnJ0x85cHqrxRe7FZ673fC4WPFyC51+59byzciCnTmuPWj9QDA1kyQv9Uzb5s2fza5fnGkLF/OR5UGYdO1d7S+YaVZ4uFT2Q5Tpx4VkolQQmvpcrgON6eMlVwW7h4FYSrau5VBTqNus4GSvUqJNmfT1El0Soe/OIvrsN/HGu+A3/37l3pyev794/d/icnm9fnla8Jf3q+Di3dnm9+XL+5vl+fri3fNA3zvVY3XbDNKTZKjbwn1l6rYkzijZyVq+f90WHdRtZ/P/WIur2fX15Wt7p247W/x+dblY2gd128vXF6rebi2W1uxqaWq1Q/m2i1dd6XZ2YZ1fzy7mzxfzS/vx0u3YjfRj90fUb6Vo2bfUb5XdgfrbtIRo55oZmRCV6GLJcLN1VOs5eOywT3YB68lWbc6PJ3EchvDWLqpy1QnHrudNfBShGHimYsS9QWq2BmsJPnlRNemsXMEjuIE4p0rObVM3nZar34itKH99V/g/+66QtRv1SP4VdX5Fnb9H1FEpebdM99Laen+cMxVMuk8Y+l1qJHitHAIy9WXM0bQht1isVGppzDc1gCHV3HkE78zafTvam1dlv9827/P+A96BxV541Mxvuw9ZRyZRgxV9/mN//gMAAP//AwBiyZyKdR8AAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d8845624f25afff12c9ff001ad389"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"b7a43655a1cea5b66549fa22f28d4940\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.114789"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb3nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-04-07T17:55:59.832Z",
+        "time": 343,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 343
+        }
+      },
+      {
+        "_id": "baf412b722ea6f71299391d2ad57202b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 71,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 71
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 499,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"refund\":{\"carrier\":\"USPS\",\"tracking_codes\":\"9400100109361114067195\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/refunds"
+        },
+        "response": {
+          "bodySize": 316,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 316,
+            "text": "[\"H4sIAAAAAAAAA4SPS07EMBBE7+L1jNTteOw4p0AMbEDIav8YDxMn8meFuDsOF0DqTZVe6anfv1nybGElZm8sSpjIA07BCic5oaZ5lvNIBChmdmKbvQfXxuA5xJ79aFwJ1II3dLQcOD+DOIN6QbVc5ALwNpi++3+ZVsh9pfxp3ObDwLQAwOP0JBFRgFSoL4dwyzGVlVrassl9taGwJffH48Rqo9brGNdu19SG8uCplHQw7PX6dB1FvaV9DbmZv8/rbTdRCRm0l1YNkeOzdVFHqUlbQo7Osp+PXwAAAP//AwBvgt6uKQEAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d8844624f25b0ff12ca00001ad39b"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"5068814ea74e191400b7c2bb1efdca53\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.096561"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb6nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-04-07T17:56:00.179Z",
+        "time": 302,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 302
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Refund-Resource_710135213/retrieves-a-refund_348903105/recording.har
+++ b/test/cassettes/Refund-Resource_710135213/retrieves-a-refund_348903105/recording.har
@@ -1,0 +1,323 @@
+{
+  "log": {
+    "_recordingName": "Refund Resource/retrieves a refund",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.4"
+    },
+    "entries": [
+      {
+        "_id": "2dc2fc13f51a5aa0d353b9bc5cc137d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 490,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "page_size",
+              "value": "5"
+            }
+          ],
+          "url": "https://api.easypost.com/v2/refunds?page_size=5"
+        },
+        "response": {
+          "bodySize": 664,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 664,
+            "text": "[\"H4sIAAAAAAAAA7TUzW7bMAwH8HfROQVIiaJEP8WwbpcNgyHqY/XWOIFjn4q++5QCHboeluYQwBcJf4niD5KfzFLbNpeTGb4/mamYwSxtLqMig0sF0FWlzDahpBg59lECpGh25qC/al77gs8vO/SZvNS01jKm86wFa++A7iB8wTB4HgC+9cx2LBcz65Ly72n+OeZDqT0mBIDnTxwjIgEHFH8ueJjbtOzTOh3mcd72WhczzNvj486c1rRuvStz2nQ/rb3kOZ+WZTpnzNf7T/d94vQwHfd1XseXzk8Px7EF4iqFNfRC2UbNTRpLEk1oMat53r11ckK5ADnHJZKGpBVahtIQ0FOI4WonP5C75PSa+YhTwNs4kY/QColD3ygJSydoVYgUUKxN75wQilC/QtiIyTUbQ0x9aRLnS9/FXufEA+EA9r9ObzIXnXxg4ts4FWclRwvO50w2l+htptpYs6+e+3H+dZImGWOghMURORVPlh0m70LlWvBaJycDxAtOfzMfcCJ/o3eHJRQlbUq9+6Igwpic5lAoJW/tOydl1Q6IIv3Klf5M2UNl8bZBDfBS9DqnOBBdcnrNfMTJ0o3+T5pVRcVZYFIbpXJK0eWWNbQa0Tz/2JmHdBr3h6WfbV22+vwHAAD//wMAhNBiOOUFAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d8845624f25b0ff12ca02001ad3bb"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"d3329e47494ff55bf79959936ab13e34\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.041822"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb4nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-04-07T17:56:00.718Z",
+        "time": 223,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 223
+        }
+      },
+      {
+        "_id": "069e2dbb1955fc78b79cb7c5bdcd46d1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 516,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/refunds/rfnd_b1603ad013eb4c62a19a8868eb4a0148"
+        },
+        "response": {
+          "bodySize": 312,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 312,
+            "text": "[\"H4sIAAAAAAAAA4SPS27DMAxE76J1ApCyIls+RdE0m2wE6teoiWVDn1XRu1fqBQpwM4M3eOA3i46tLIfktEEJEznAyRthJSdUtCxy6YkAxcJObDdf3tY+ePehJdcbmz1V7zSNlgPnZxBnmD9wXi9yBbh3ph3uX6Zmss+YPrXdne+YEgA4Tk0SEQXIGdVlCPcUYt6oxj3p1DbjM1tTe71OrFSqrfRxaWaLtSsHTznHwbDb9e3ai/KIx+ZT1X+fl8ehwyykV06auYssX4wNKkhFyhBytIb9/AIAAP//AwCyGUM9JwEAAA==\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d8844624f25b1ff12ca1a001ad3cc"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"c0ac7ea4aea15edca3021431c0100e1f\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.030626"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb8nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-04-07T17:56:00.947Z",
+        "time": 208,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 208
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Refund-Resource_710135213/retrieves-all-refunds_2266923862/recording.har
+++ b/test/cassettes/Refund-Resource_710135213/retrieves-all-refunds_2266923862/recording.har
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "_recordingName": "Refund Resource/retrieves all refunds",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.4"
+    },
+    "entries": [
+      {
+        "_id": "2dc2fc13f51a5aa0d353b9bc5cc137d3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip,deflate,sdch,br"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "user-agent",
+              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.13.1"
+            },
+            {
+              "name": "x-easypost-client-user-agent",
+              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.13.1\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 490,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "page_size",
+              "value": "5"
+            }
+          ],
+          "url": "https://api.easypost.com/v2/refunds?page_size=5"
+        },
+        "response": {
+          "bodySize": 664,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 664,
+            "text": "[\"H4sIAAAAAAAAA7TUzW7bMAwH8HfROQVIiaJEP8WwbpcNgyHqY/XWOIFjn4q++5QCHboeluYQwBcJf4niD5KfzFLbNpeTGb4/mamYwSxtLqMig0sF0FWlzDahpBg59lECpGh25qC/al77gs8vO/SZvNS01jKm86wFa++A7iB8wTB4HgC+9cx2LBcz65Ly72n+OeZDqT0mBIDnTxwjIgEHFH8ueJjbtOzTOh3mcd72WhczzNvj486c1rRuvStz2nQ/rb3kOZ+WZTpnzNf7T/d94vQwHfd1XseXzk8Px7EF4iqFNfRC2UbNTRpLEk1oMat53r11ckK5ADnHJZKGpBVahtIQ0FOI4WonP5C75PSa+YhTwNs4kY/QColD3ygJSydoVYgUUKxN75wQilC/QtiIyTUbQ0x9aRLnS9/FXufEA+EA9r9ObzIXnXxg4ts4FWclRwvO50w2l+htptpYs6+e+3H+dZImGWOghMURORVPlh0m70LlWvBaJycDxAtOfzMfcCJ/o3eHJRQlbUq9+6Igwpic5lAoJW/tOydl1Q6IIv3Klf5M2UNl8bZBDfBS9DqnOBBdcnrNfMTJ0o3+T5pVRcVZYFIbpXJK0eWWNbQa0Tz/2JmHdBr3h6WfbV22+vwHAAD//wMAhNBiOOUFAAA=\"]"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "949d8848624f25b0ff12ca01001ad3b0"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"d3329e47494ff55bf79959936ab13e34\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.047027"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb5nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202204071625-f7b25baf21-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-04-07T17:56:00.492Z",
+        "time": 219,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 219
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/resources/refund.test.js
+++ b/test/resources/refund.test.js
@@ -1,0 +1,65 @@
+/* eslint-disable func-names */
+import { expect } from 'chai';
+import * as setupPolly from '../setup_polly';
+import EasyPost from '../../src/easypost';
+import Fixture from '../helpers/fixture';
+import NotImplementedError from '../../src/errors/not_implemented';
+
+describe('Refund Resource', function () {
+  setupPolly.startPolly();
+
+  before(function () {
+    this.easypost = new EasyPost(process.env.EASYPOST_TEST_API_KEY);
+  });
+
+  beforeEach(function () {
+    const { server } = this.polly;
+    setupPolly.stripCreds(server);
+  });
+
+  it('creates a refund', async function () {
+    const shipment = await new this.easypost.Shipment(Fixture.oneCallBuyShipment()).save();
+
+    // We need to retrieve the shipment so that the tracking_code has time to populate
+    const retrievedShipment = await this.easypost.Shipment.retrieve(shipment.id);
+
+    const refundData = {
+      carrier: Fixture.usps(),
+      tracking_codes: retrievedShipment.tracking_code,
+    };
+
+    const refunds = await this.easypost.Refund.save(refundData);
+
+    expect(refunds[0].id).to.match(/^rfnd_/);
+    expect(refunds[0].status).to.equal('submitted');
+  });
+
+  it('retrieves all refunds', async function () {
+    const refunds = await this.easypost.Refund.all({ page_size: Fixture.pageSize() });
+
+    const refundsArray = refunds.refunds;
+
+    expect(refundsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
+    expect(refunds.has_more).to.not.be.null;
+    refundsArray.forEach((address) => {
+      expect(address).to.be.an.instanceOf(this.easypost.Refund);
+    });
+  });
+
+  it('retrieves a refund', async function () {
+    const refunds = await this.easypost.Refund.all({ page_size: Fixture.pageSize() });
+
+    const retrieveRefund = await this.easypost.Refund.retrieve(refunds.refunds[0].id);
+
+    expect(retrieveRefund).to.be.an.instanceOf(this.easypost.Refund);
+    expect(retrieveRefund).to.deep.include(refunds.refunds[0]);
+  });
+
+  it('throws on delete', function () {
+    const refund = new this.easypost.Refund({ id: 1 });
+
+    return refund.delete().catch((err) => {
+      expect(err).to.be.an.instanceOf(NotImplementedError);
+    });
+  });
+});


### PR DESCRIPTION
Our API allows you to either refund a shipment from the `shipment` object or from the `Refund` class; however, the `refund` class is currently missing from the Node library.

This PR adds the missing `Refund` class and unit tests to make sure they are working as expected.