### PR TITLE
Handle parameter placement internally

### DIFF
--- a/src/easypost.js
+++ b/src/easypost.js
@@ -3,27 +3,27 @@ import superagent from 'superagent';
 
 import pkg from '../package.json';
 
-import Address, { propTypes as addressPropTypes } from './resources/address';
-import ApiKey, { propTypes as apiKeyPropTypes } from './resources/api_key';
-import Batch, { propTypes as batchPropTypes } from './resources/batch';
-import Brand, { propTypes as brandPropTypes } from './resources/brand';
-import CarrierAccount, { propTypes as carrierAccountPropTypes } from './resources/carrier_account';
-import CarrierType, { propTypes as carrierTypePropTypes } from './resources/carrier_type';
-import CustomsInfo, { propTypes as customsInfoPropTypes } from './resources/customs_info';
-import CustomsItem, { propTypes as customsItemPropTypes } from './resources/customs_item';
-import Event, { propTypes as eventPropTypes } from './resources/event';
-import Insurance, { propTypes as insurancePropTypes } from './resources/insurance';
-import Order, { propTypes as orderPropTypes } from './resources/order';
-import Parcel, { propTypes as parcelPropTypes } from './resources/parcel';
-import Pickup, { propTypes as pickupPropTypes } from './resources/pickup';
-import Rate, { propTypes as ratePropTypes } from './resources/rate';
-import Refund, { propTypes as refundPropTypes } from './resources/refund';
-import Report, { propTypes as reportPropTypes } from './resources/report';
-import ScanForm, { propTypes as scanFormPropTypes } from './resources/scan_form';
-import Shipment, { propTypes as shipmentPropTypes } from './resources/shipment';
-import Tracker, { propTypes as trackerPropTypes } from './resources/tracker';
-import User, { propTypes as userPropTypes } from './resources/user';
-import Webhook, { propTypes as webhookPropTypes } from './resources/webhook';
+import Address, {propTypes as addressPropTypes} from './resources/address';
+import ApiKey, {propTypes as apiKeyPropTypes} from './resources/api_key';
+import Batch, {propTypes as batchPropTypes} from './resources/batch';
+import Brand, {propTypes as brandPropTypes} from './resources/brand';
+import CarrierAccount, {propTypes as carrierAccountPropTypes} from './resources/carrier_account';
+import CarrierType, {propTypes as carrierTypePropTypes} from './resources/carrier_type';
+import CustomsInfo, {propTypes as customsInfoPropTypes} from './resources/customs_info';
+import CustomsItem, {propTypes as customsItemPropTypes} from './resources/customs_item';
+import Event, {propTypes as eventPropTypes} from './resources/event';
+import Insurance, {propTypes as insurancePropTypes} from './resources/insurance';
+import Order, {propTypes as orderPropTypes} from './resources/order';
+import Parcel, {propTypes as parcelPropTypes} from './resources/parcel';
+import Pickup, {propTypes as pickupPropTypes} from './resources/pickup';
+import Rate, {propTypes as ratePropTypes} from './resources/rate';
+import Refund, {propTypes as refundPropTypes} from './resources/refund';
+import Report, {propTypes as reportPropTypes} from './resources/report';
+import ScanForm, {propTypes as scanFormPropTypes} from './resources/scan_form';
+import Shipment, {propTypes as shipmentPropTypes} from './resources/shipment';
+import Tracker, {propTypes as trackerPropTypes} from './resources/tracker';
+import User, {propTypes as userPropTypes} from './resources/user';
+import Webhook, {propTypes as webhookPropTypes} from './resources/webhook';
 
 import RequestError from './errors/request';
 
@@ -32,221 +32,223 @@ export const DEFAULT_TIMEOUT = 60 * MS_SECOND;
 export const DEFAULT_BASE_URL = 'https://api.easypost.com/v2/';
 
 export const UA_INFO = {
-  client_version: pkg.version,
-  lang: 'nodejs',
-  lang_version: process.version,
-  publisher: 'easypost',
-  platform: os.platform(),
+    client_version: pkg.version,
+    lang: 'nodejs',
+    lang_version: process.version,
+    publisher: 'easypost',
+    platform: os.platform(),
 };
 
 export const EASYPOST_UA_HEADER = 'X-EasyPost-Client-User-Agent';
 
 export const DEFAULT_HEADERS = {
-  Accept: 'application/json',
-  'Accept-Encoding': 'gzip,deflate,sdch,br',
-  'Content-Type': 'application/json',
-  'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version} Nodejs/${process.versions.node}`,
-  [EASYPOST_UA_HEADER]: JSON.stringify(UA_INFO),
+    Accept: 'application/json',
+    'Accept-Encoding': 'gzip,deflate,sdch,br',
+    'Content-Type': 'application/json',
+    'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version} Nodejs/${process.versions.node}`,
+    [EASYPOST_UA_HEADER]: JSON.stringify(UA_INFO),
 };
 
 // Map HTTP methods to superagent methods.
 export const METHODS = {
-  GET: 'get',
-  POST: 'post',
-  PUT: 'put',
-  DELETE: 'del',
+    GET: 'get',
+    POST: 'post',
+    PUT: 'put',
+    DELETE: 'del',
 };
 
 export const RESOURCES = {
-  Address,
-  ApiKey,
-  Batch,
-  Brand,
-  CarrierAccount,
-  CarrierType,
-  CustomsInfo,
-  CustomsItem,
-  Event,
-  Insurance,
-  Order,
-  Parcel,
-  Pickup,
-  Rate,
-  Refund,
-  Report,
-  ScanForm,
-  Shipment,
-  Tracker,
-  User,
-  Webhook,
+    Address,
+    ApiKey,
+    Batch,
+    Brand,
+    CarrierAccount,
+    CarrierType,
+    CustomsInfo,
+    CustomsItem,
+    Event,
+    Insurance,
+    Order,
+    Parcel,
+    Pickup,
+    Rate,
+    Refund,
+    Report,
+    ScanForm,
+    Shipment,
+    Tracker,
+    User,
+    Webhook,
 };
 
 export const PROP_TYPES = {
-  addressPropTypes,
-  apiKeyPropTypes,
-  batchPropTypes,
-  brandPropTypes,
-  carrierAccountPropTypes,
-  carrierTypePropTypes,
-  customsInfoPropTypes,
-  customsItemPropTypes,
-  eventPropTypes,
-  insurancePropTypes,
-  orderPropTypes,
-  parcelPropTypes,
-  pickupPropTypes,
-  ratePropTypes,
-  refundPropTypes,
-  reportPropTypes,
-  scanFormPropTypes,
-  shipmentPropTypes,
-  trackerPropTypes,
-  userPropTypes,
-  webhookPropTypes,
+    addressPropTypes,
+    apiKeyPropTypes,
+    batchPropTypes,
+    brandPropTypes,
+    carrierAccountPropTypes,
+    carrierTypePropTypes,
+    customsInfoPropTypes,
+    customsItemPropTypes,
+    eventPropTypes,
+    insurancePropTypes,
+    orderPropTypes,
+    parcelPropTypes,
+    pickupPropTypes,
+    ratePropTypes,
+    refundPropTypes,
+    reportPropTypes,
+    scanFormPropTypes,
+    shipmentPropTypes,
+    trackerPropTypes,
+    userPropTypes,
+    webhookPropTypes,
 };
 
 export default class API {
-  constructor(key, options = {}) {
-    const { useProxy, timeout, baseUrl, superagentMiddleware, requestMiddleware } = options;
+    constructor(key, options = {}) {
+        const {useProxy, timeout, baseUrl, superagentMiddleware, requestMiddleware} = options;
 
-    if (!key && !useProxy) {
-      throw new Error('No API key supplied. Pass in an API key as the first argument.');
+        if (!key && !useProxy) {
+            throw new Error('No API key supplied. Pass in an API key as the first argument.');
+        }
+
+        this.key = key;
+        this.timeout = timeout || DEFAULT_TIMEOUT;
+        this.baseUrl = baseUrl || DEFAULT_BASE_URL;
+        this.agent = superagent;
+        this.requestMiddleware = requestMiddleware;
+
+        if (superagentMiddleware) {
+            this.agent = superagentMiddleware(this.agent);
+        }
+
+        this.use(RESOURCES);
     }
 
-    this.key = key;
-    this.timeout = timeout || DEFAULT_TIMEOUT;
-    this.baseUrl = baseUrl || DEFAULT_BASE_URL;
-    this.agent = superagent;
-    this.requestMiddleware = requestMiddleware;
+    /**
+     * Build request headers to be sent by default with each request, combined (or overridden) by any additional headers
+     * @param {object} additionalHeaders
+     * @returns {object}
+     */
+    static buildHeaders(additionalHeaders = {}) {
+        const headers = {
+            ...DEFAULT_HEADERS,
+            ...additionalHeaders,
+        };
 
-    if (superagentMiddleware) {
-      this.agent = superagentMiddleware(this.agent);
+        if (typeof window === 'undefined') {
+            return headers;
+        }
+
+        delete headers['User-Agent'];
+        delete headers['Accept-Encoding'];
+        return headers;
     }
 
-    this.use(RESOURCES);
-  }
-
-  /**
-   * Build request headers to be sent by default with each request, combined (or overridden) by any additional headers
-   * @param {object} additionalHeaders
-   * @returns {object}
-   */
-  static buildHeaders(additionalHeaders = {}) {
-    const headers = {
-      ...DEFAULT_HEADERS,
-      ...additionalHeaders,
-    };
-
-    if (typeof window === 'undefined') {
-      return headers;
+    /**
+     * Convert to an EasyPost resource.
+     * @param {*} resources
+     */
+    use(resources) {
+        Object.keys(resources).forEach((c) => {
+            this[c] = resources[c](this);
+        });
     }
 
-    delete headers['User-Agent'];
-    delete headers['Accept-Encoding'];
-    return headers;
-  }
+    /**
+     * If the path passed in is a full URI, use it; otherwise, prepend the base url from the api.
+     * @param {string} path
+     * @returns {string}
+     */
+    buildPath(path = '') {
+        if (path.indexOf('http') === 0) {
+            return path;
+        }
 
-  /**
-   * Convert to an EasyPost resource.
-   * @param {*} resources
-   */
-  use(resources) {
-    Object.keys(resources).forEach((c) => {
-      this[c] = resources[c](this);
-    });
-  }
-
-  /**
-   * If the path passed in is a full URI, use it; otherwise, prepend the base url from the api.
-   * @param {string} path
-   * @returns {string}
-   */
-  buildPath(path = '') {
-    if (path.indexOf('http') === 0) {
-      return path;
+        return this.baseUrl + path;
     }
 
-    return this.baseUrl + path;
-  }
+    /**
+     * Make an HTTP request.
+     * @param {string} path
+     * @param {string} method
+     * @param {object} params
+     * @param {object} headers
+     * @returns {*}
+     */
+    async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
+        let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
 
-  /**
-   * Make an HTTP request.
-   * @param {string} path
-   * @param {string} method
-   * @param {object} params
-   * @param {object} headers
-   * @returns {*}
-   */
-  async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
-    let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
+        if (this.requestMiddleware) {
+            req = this.requestMiddleware(req);
+        }
 
-    if (this.requestMiddleware) {
-      req = this.requestMiddleware(req);
+        if (this.key) {
+            req.auth(this.key);
+        }
+
+        if (params !== {} && params !== undefined) {
+            if (method === METHODS.GET || method === METHODS.DELETE) {
+                req.query(params);
+            } else {
+                req.send(params);
+            }
+        }
+
+        try {
+            const res = await req;
+            return res;
+        } catch (e) {
+            if (e.response && e.response.body) {
+                throw new RequestError(e.response.body, path);
+            }
+
+            throw e;
+        }
     }
 
-    if (this.key) {
-      req.auth(this.key);
+    /**
+     * Make a GET HTTP request.
+     * @param {string} path
+     * @param {object} params
+     * @param {object} headers
+     * @returns {*}
+     */
+    get(path, params = {}, headers = {}) {
+        return this.request(path, METHODS.GET, params, headers);
     }
 
-    if (method === METHODS.GET || method === METHODS.DELETE) {
-      req.query(params);
-    } else {
-      req.send(params);
+    /**
+     * Make a POST HTTP request.
+     * @param {string} path
+     * @param {object} params
+     * @param {object} headers
+     * @returns {*}
+     */
+    post(path, params = {}, headers = {}) {
+        return this.request(path, METHODS.POST, params, headers);
     }
 
-    try {
-      const res = await req;
-      return res;
-    } catch (e) {
-      if (e.response && e.response.body) {
-        throw new RequestError(e.response.body, path);
-      }
-
-      throw e;
+    /**
+     * Make a PUT HTTP request.
+     * @param {string} path
+     * @param {object} params
+     * @param {object} headers
+     * @returns {*}
+     */
+    put(path, params = {}, headers = {}) {
+        return this.request(path, METHODS.PUT, params, headers);
     }
-  }
 
-  /**
-   * Make a GET HTTP request.
-   * @param {string} path
-   * @param {object} params
-   * @param {object} headers
-   * @returns {*}
-   */
-  get(path, params = {}, headers = {}) {
-    return this.request(path, METHODS.GET, params, headers);
-  }
-
-  /**
-   * Make a POST HTTP request.
-   * @param {string} path
-   * @param {object} params
-   * @param {object} headers
-   * @returns {*}
-   */
-  post(path, params = {}, headers = {}) {
-    return this.request(path, METHODS.POST, params, headers);
-  }
-
-  /**
-   * Make a PUT HTTP request.
-   * @param {string} path
-   * @param {object} params
-   * @param {object} headers
-   * @returns {*}
-   */
-  put(path, params = {}, headers = {}) {
-    return this.request(path, METHODS.PUT, params, headers);
-  }
-
-  /**
-   * Make a DELETE HTTP request.
-   * @param {string} path
-   * @param {object} params
-   * @param {object} headers
-   * @returns {*}
-   */
-  del(path, params = {}, headers = {}) {
-    return this.request(path, METHODS.DELETE, params, headers);
-  }
+    /**
+     * Make a DELETE HTTP request.
+     * @param {string} path
+     * @param {object} params
+     * @param {object} headers
+     * @returns {*}
+     */
+    del(path, params = {}, headers = {}) {
+        return this.request(path, METHODS.DELETE, params, headers);
+    }
 }

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -178,8 +178,6 @@ export default class API {
    * @returns {*}
    */
   async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
-    const { query, body } = params;
-
     let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
 
     if (this.requestMiddleware) {
@@ -190,12 +188,10 @@ export default class API {
       req.auth(this.key);
     }
 
-    if (body) {
-      req.send(body);
-    }
-
-    if (query) {
-      req.query(query);
+    if (method === METHODS.GET || method === METHODS.DELETE) {
+      req.query(params);
+    } else {
+      req.send(params);
     }
 
     try {
@@ -217,7 +213,7 @@ export default class API {
    * @param {object} headers
    * @returns {*}
    */
-  get(path, params, headers) {
+  get(path, params = {}, headers = {}) {
     return this.request(path, METHODS.GET, params, headers);
   }
 
@@ -228,7 +224,7 @@ export default class API {
    * @param {object} headers
    * @returns {*}
    */
-  post(path, params, headers) {
+  post(path, params = {}, headers = {}) {
     return this.request(path, METHODS.POST, params, headers);
   }
 
@@ -239,7 +235,7 @@ export default class API {
    * @param {object} headers
    * @returns {*}
    */
-  put(path, params, headers) {
+  put(path, params = {}, headers = {}) {
     return this.request(path, METHODS.PUT, params, headers);
   }
 
@@ -250,7 +246,7 @@ export default class API {
    * @param {object} headers
    * @returns {*}
    */
-  del(path, params, headers) {
+  del(path, params = {}, headers = {}) {
     return this.request(path, METHODS.DELETE, params, headers);
   }
 }

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -3,27 +3,27 @@ import superagent from 'superagent';
 
 import pkg from '../package.json';
 
-import Address, {propTypes as addressPropTypes} from './resources/address';
-import ApiKey, {propTypes as apiKeyPropTypes} from './resources/api_key';
-import Batch, {propTypes as batchPropTypes} from './resources/batch';
-import Brand, {propTypes as brandPropTypes} from './resources/brand';
-import CarrierAccount, {propTypes as carrierAccountPropTypes} from './resources/carrier_account';
-import CarrierType, {propTypes as carrierTypePropTypes} from './resources/carrier_type';
-import CustomsInfo, {propTypes as customsInfoPropTypes} from './resources/customs_info';
-import CustomsItem, {propTypes as customsItemPropTypes} from './resources/customs_item';
-import Event, {propTypes as eventPropTypes} from './resources/event';
-import Insurance, {propTypes as insurancePropTypes} from './resources/insurance';
-import Order, {propTypes as orderPropTypes} from './resources/order';
-import Parcel, {propTypes as parcelPropTypes} from './resources/parcel';
-import Pickup, {propTypes as pickupPropTypes} from './resources/pickup';
-import Rate, {propTypes as ratePropTypes} from './resources/rate';
-import Refund, {propTypes as refundPropTypes} from './resources/refund';
-import Report, {propTypes as reportPropTypes} from './resources/report';
-import ScanForm, {propTypes as scanFormPropTypes} from './resources/scan_form';
-import Shipment, {propTypes as shipmentPropTypes} from './resources/shipment';
-import Tracker, {propTypes as trackerPropTypes} from './resources/tracker';
-import User, {propTypes as userPropTypes} from './resources/user';
-import Webhook, {propTypes as webhookPropTypes} from './resources/webhook';
+import Address, { propTypes as addressPropTypes } from './resources/address';
+import ApiKey, { propTypes as apiKeyPropTypes } from './resources/api_key';
+import Batch, { propTypes as batchPropTypes } from './resources/batch';
+import Brand, { propTypes as brandPropTypes } from './resources/brand';
+import CarrierAccount, { propTypes as carrierAccountPropTypes } from './resources/carrier_account';
+import CarrierType, { propTypes as carrierTypePropTypes } from './resources/carrier_type';
+import CustomsInfo, { propTypes as customsInfoPropTypes } from './resources/customs_info';
+import CustomsItem, { propTypes as customsItemPropTypes } from './resources/customs_item';
+import Event, { propTypes as eventPropTypes } from './resources/event';
+import Insurance, { propTypes as insurancePropTypes } from './resources/insurance';
+import Order, { propTypes as orderPropTypes } from './resources/order';
+import Parcel, { propTypes as parcelPropTypes } from './resources/parcel';
+import Pickup, { propTypes as pickupPropTypes } from './resources/pickup';
+import Rate, { propTypes as ratePropTypes } from './resources/rate';
+import Refund, { propTypes as refundPropTypes } from './resources/refund';
+import Report, { propTypes as reportPropTypes } from './resources/report';
+import ScanForm, { propTypes as scanFormPropTypes } from './resources/scan_form';
+import Shipment, { propTypes as shipmentPropTypes } from './resources/shipment';
+import Tracker, { propTypes as trackerPropTypes } from './resources/tracker';
+import User, { propTypes as userPropTypes } from './resources/user';
+import Webhook, { propTypes as webhookPropTypes } from './resources/webhook';
 
 import RequestError from './errors/request';
 
@@ -32,223 +32,223 @@ export const DEFAULT_TIMEOUT = 60 * MS_SECOND;
 export const DEFAULT_BASE_URL = 'https://api.easypost.com/v2/';
 
 export const UA_INFO = {
-    client_version: pkg.version,
-    lang: 'nodejs',
-    lang_version: process.version,
-    publisher: 'easypost',
-    platform: os.platform(),
+  client_version: pkg.version,
+  lang: 'nodejs',
+  lang_version: process.version,
+  publisher: 'easypost',
+  platform: os.platform(),
 };
 
 export const EASYPOST_UA_HEADER = 'X-EasyPost-Client-User-Agent';
 
 export const DEFAULT_HEADERS = {
-    Accept: 'application/json',
-    'Accept-Encoding': 'gzip,deflate,sdch,br',
-    'Content-Type': 'application/json',
-    'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version} Nodejs/${process.versions.node}`,
-    [EASYPOST_UA_HEADER]: JSON.stringify(UA_INFO),
+  Accept: 'application/json',
+  'Accept-Encoding': 'gzip,deflate,sdch,br',
+  'Content-Type': 'application/json',
+  'User-Agent': `EasyPost/v2 NodejsClient/${pkg.version} Nodejs/${process.versions.node}`,
+  [EASYPOST_UA_HEADER]: JSON.stringify(UA_INFO),
 };
 
 // Map HTTP methods to superagent methods.
 export const METHODS = {
-    GET: 'get',
-    POST: 'post',
-    PUT: 'put',
-    DELETE: 'del',
+  GET: 'get',
+  POST: 'post',
+  PUT: 'put',
+  DELETE: 'del',
 };
 
 export const RESOURCES = {
-    Address,
-    ApiKey,
-    Batch,
-    Brand,
-    CarrierAccount,
-    CarrierType,
-    CustomsInfo,
-    CustomsItem,
-    Event,
-    Insurance,
-    Order,
-    Parcel,
-    Pickup,
-    Rate,
-    Refund,
-    Report,
-    ScanForm,
-    Shipment,
-    Tracker,
-    User,
-    Webhook,
+  Address,
+  ApiKey,
+  Batch,
+  Brand,
+  CarrierAccount,
+  CarrierType,
+  CustomsInfo,
+  CustomsItem,
+  Event,
+  Insurance,
+  Order,
+  Parcel,
+  Pickup,
+  Rate,
+  Refund,
+  Report,
+  ScanForm,
+  Shipment,
+  Tracker,
+  User,
+  Webhook,
 };
 
 export const PROP_TYPES = {
-    addressPropTypes,
-    apiKeyPropTypes,
-    batchPropTypes,
-    brandPropTypes,
-    carrierAccountPropTypes,
-    carrierTypePropTypes,
-    customsInfoPropTypes,
-    customsItemPropTypes,
-    eventPropTypes,
-    insurancePropTypes,
-    orderPropTypes,
-    parcelPropTypes,
-    pickupPropTypes,
-    ratePropTypes,
-    refundPropTypes,
-    reportPropTypes,
-    scanFormPropTypes,
-    shipmentPropTypes,
-    trackerPropTypes,
-    userPropTypes,
-    webhookPropTypes,
+  addressPropTypes,
+  apiKeyPropTypes,
+  batchPropTypes,
+  brandPropTypes,
+  carrierAccountPropTypes,
+  carrierTypePropTypes,
+  customsInfoPropTypes,
+  customsItemPropTypes,
+  eventPropTypes,
+  insurancePropTypes,
+  orderPropTypes,
+  parcelPropTypes,
+  pickupPropTypes,
+  ratePropTypes,
+  refundPropTypes,
+  reportPropTypes,
+  scanFormPropTypes,
+  shipmentPropTypes,
+  trackerPropTypes,
+  userPropTypes,
+  webhookPropTypes,
 };
 
 export default class API {
-    constructor(key, options = {}) {
-        const {useProxy, timeout, baseUrl, superagentMiddleware, requestMiddleware} = options;
+  constructor(key, options = {}) {
+    const { useProxy, timeout, baseUrl, superagentMiddleware, requestMiddleware } = options;
 
-        if (!key && !useProxy) {
-            throw new Error('No API key supplied. Pass in an API key as the first argument.');
-        }
-
-        this.key = key;
-        this.timeout = timeout || DEFAULT_TIMEOUT;
-        this.baseUrl = baseUrl || DEFAULT_BASE_URL;
-        this.agent = superagent;
-        this.requestMiddleware = requestMiddleware;
-
-        if (superagentMiddleware) {
-            this.agent = superagentMiddleware(this.agent);
-        }
-
-        this.use(RESOURCES);
+    if (!key && !useProxy) {
+      throw new Error('No API key supplied. Pass in an API key as the first argument.');
     }
 
-    /**
-     * Build request headers to be sent by default with each request, combined (or overridden) by any additional headers
-     * @param {object} additionalHeaders
-     * @returns {object}
-     */
-    static buildHeaders(additionalHeaders = {}) {
-        const headers = {
-            ...DEFAULT_HEADERS,
-            ...additionalHeaders,
-        };
+    this.key = key;
+    this.timeout = timeout || DEFAULT_TIMEOUT;
+    this.baseUrl = baseUrl || DEFAULT_BASE_URL;
+    this.agent = superagent;
+    this.requestMiddleware = requestMiddleware;
 
-        if (typeof window === 'undefined') {
-            return headers;
-        }
-
-        delete headers['User-Agent'];
-        delete headers['Accept-Encoding'];
-        return headers;
+    if (superagentMiddleware) {
+      this.agent = superagentMiddleware(this.agent);
     }
 
-    /**
-     * Convert to an EasyPost resource.
-     * @param {*} resources
-     */
-    use(resources) {
-        Object.keys(resources).forEach((c) => {
-            this[c] = resources[c](this);
-        });
+    this.use(RESOURCES);
+  }
+
+  /**
+   * Build request headers to be sent by default with each request, combined (or overridden) by any additional headers
+   * @param {object} additionalHeaders
+   * @returns {object}
+   */
+  static buildHeaders(additionalHeaders = {}) {
+    const headers = {
+      ...DEFAULT_HEADERS,
+      ...additionalHeaders,
+    };
+
+    if (typeof window === 'undefined') {
+      return headers;
     }
 
-    /**
-     * If the path passed in is a full URI, use it; otherwise, prepend the base url from the api.
-     * @param {string} path
-     * @returns {string}
-     */
-    buildPath(path = '') {
-        if (path.indexOf('http') === 0) {
-            return path;
-        }
+    delete headers['User-Agent'];
+    delete headers['Accept-Encoding'];
+    return headers;
+  }
 
-        return this.baseUrl + path;
+  /**
+   * Convert to an EasyPost resource.
+   * @param {*} resources
+   */
+  use(resources) {
+    Object.keys(resources).forEach((c) => {
+      this[c] = resources[c](this);
+    });
+  }
+
+  /**
+   * If the path passed in is a full URI, use it; otherwise, prepend the base url from the api.
+   * @param {string} path
+   * @returns {string}
+   */
+  buildPath(path = '') {
+    if (path.indexOf('http') === 0) {
+      return path;
     }
 
-    /**
-     * Make an HTTP request.
-     * @param {string} path
-     * @param {string} method
-     * @param {object} params
-     * @param {object} headers
-     * @returns {*}
-     */
-    async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
-        let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
+    return this.baseUrl + path;
+  }
 
-        if (this.requestMiddleware) {
-            req = this.requestMiddleware(req);
-        }
+  /**
+   * Make an HTTP request.
+   * @param {string} path
+   * @param {string} method
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
+  async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
+    let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
 
-        if (this.key) {
-            req.auth(this.key);
-        }
-
-        if (params !== {} && params !== undefined) {
-            if (method === METHODS.GET || method === METHODS.DELETE) {
-                req.query(params);
-            } else {
-                req.send(params);
-            }
-        }
-
-        try {
-            const res = await req;
-            return res;
-        } catch (e) {
-            if (e.response && e.response.body) {
-                throw new RequestError(e.response.body, path);
-            }
-
-            throw e;
-        }
+    if (this.requestMiddleware) {
+      req = this.requestMiddleware(req);
     }
 
-    /**
-     * Make a GET HTTP request.
-     * @param {string} path
-     * @param {object} params
-     * @param {object} headers
-     * @returns {*}
-     */
-    get(path, params = {}, headers = {}) {
-        return this.request(path, METHODS.GET, params, headers);
+    if (this.key) {
+      req.auth(this.key);
     }
 
-    /**
-     * Make a POST HTTP request.
-     * @param {string} path
-     * @param {object} params
-     * @param {object} headers
-     * @returns {*}
-     */
-    post(path, params = {}, headers = {}) {
-        return this.request(path, METHODS.POST, params, headers);
+    if (params !== {} && params !== undefined) {
+      if (method === METHODS.GET || method === METHODS.DELETE) {
+        req.query(params);
+      } else {
+        req.send(params);
+      }
     }
 
-    /**
-     * Make a PUT HTTP request.
-     * @param {string} path
-     * @param {object} params
-     * @param {object} headers
-     * @returns {*}
-     */
-    put(path, params = {}, headers = {}) {
-        return this.request(path, METHODS.PUT, params, headers);
-    }
+    try {
+      const res = await req;
+      return res;
+    } catch (e) {
+      if (e.response && e.response.body) {
+        throw new RequestError(e.response.body, path);
+      }
 
-    /**
-     * Make a DELETE HTTP request.
-     * @param {string} path
-     * @param {object} params
-     * @param {object} headers
-     * @returns {*}
-     */
-    del(path, params = {}, headers = {}) {
-        return this.request(path, METHODS.DELETE, params, headers);
+      throw e;
     }
+  }
+
+  /**
+   * Make a GET HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
+  get(path, params = {}, headers = {}) {
+    return this.request(path, METHODS.GET, params, headers);
+  }
+
+  /**
+   * Make a POST HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
+  post(path, params = {}, headers = {}) {
+    return this.request(path, METHODS.POST, params, headers);
+  }
+
+  /**
+   * Make a PUT HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
+  put(path, params = {}, headers = {}) {
+    return this.request(path, METHODS.PUT, params, headers);
+  }
+
+  /**
+   * Make a DELETE HTTP request.
+   * @param {string} path
+   * @param {object} params
+   * @param {object} headers
+   * @returns {*}
+   */
+  del(path, params = {}, headers = {}) {
+    return this.request(path, METHODS.DELETE, params, headers);
+  }
 }

--- a/src/resources/address.js
+++ b/src/resources/address.js
@@ -51,7 +51,7 @@ export default (api) =>
 
       try {
         const url = `${this._url}/create_and_verify`;
-        const response = await api.post(url, { body: newParams });
+        const response = await api.post(url, newParams);
 
         return this.create(response.body.address);
       } catch (e) {

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -118,7 +118,7 @@ export default (api) =>
     static async all(query = {}, url) {
       try {
         url = url || this._url;
-        const res = await api.get(url, { query });
+        const res = await api.get(url, query);
         const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
 
         // Override the key used for reports to be the generic `reports` instead
@@ -192,7 +192,7 @@ export default (api) =>
     }
 
     /**
-     * RPC - builds the details needed to make an HTTP request.
+     * RPC (Remote Procedure Call) - builds the details needed to make an HTTP request.
      * @param {string} path
      * @param {object|Array} body
      * @param {string} pathPrefix
@@ -208,9 +208,9 @@ export default (api) =>
         let res;
 
         if (method === 'get') {
-          res = await api[method](url, { query: body });
+          res = await api[method](url, body);
         } else if (body) {
-          res = await api[method](url, { body });
+          res = await api[method](url, body);
         } else {
           res = await api[method](url);
         }
@@ -244,11 +244,9 @@ export default (api) =>
         let res;
 
         if (this.id) {
-          res = await api.put(`${this._url || this.constructor._url}/${this.id}`, { body: data });
+          res = await api.put(`${this._url || this.constructor._url}/${this.id}`, data);
         } else {
-          res = await api.post(this._url || this.constructor._url, {
-            body: data,
-          });
+          res = await api.post(this._url || this.constructor._url, data);
         }
 
         this.mapProps(res.body);

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -2,320 +2,312 @@ import ValidationError from '../errors/validation';
 import NotImplementedError from '../errors/not_implemented';
 
 export default (api) =>
-  class Base {
-    static _url = null;
+    class Base {
+        static _url = null;
 
-    static _name = null;
+        static _name = null;
 
-    static key = null;
+        static key = null;
 
-    static propTypes = {};
+        static propTypes = {};
 
-    static jsonIdKeys = [];
+        static jsonIdKeys = [];
 
-    _validationErrors = null;
+        _validationErrors = null;
 
-    constructor(data = {}) {
-      this.mapProps(data);
-    }
-
-    /**
-     *
-     * @param {bool} throwOnFailure
-     * @returns {object}
-     */
-    validateProperties(throwOnFailure = true) {
-      this._validationErrors = null;
-      const props = this.toJSON();
-
-      // Loop through proptypes and match them against props; this will catch
-      // issues such as isRequired or type mismatches.
-      const errors = Object.keys(this.constructor.propTypes).reduce((errorHash, key) => {
-        const err = this.constructor.propTypes[key](
-          props,
-          key,
-          `${this.constructor._name}`,
-          'prop',
-          key,
-        );
-
-        if (err) {
-          /* eslint no-param-reassign: 0 */
-          errorHash = errorHash || {};
-          errorHash[key] = err.toString();
-          return errorHash;
+        constructor(data = {}) {
+            this.mapProps(data);
         }
 
-        return errorHash;
-      }, false);
+        /**
+         *
+         * @param {bool} throwOnFailure
+         * @returns {object}
+         */
+        validateProperties(throwOnFailure = true) {
+            this._validationErrors = null;
+            const props = this.toJSON();
 
-      this._validationErrors = errors || null;
+            // Loop through proptypes and match them against props; this will catch
+            // issues such as isRequired or type mismatches.
+            const errors = Object.keys(this.constructor.propTypes).reduce((errorHash, key) => {
+                const err = this.constructor.propTypes[key](
+                    props,
+                    key,
+                    `${this.constructor._name}`,
+                    'prop',
+                    key,
+                );
 
-      if (errors && throwOnFailure) {
-        throw new ValidationError(errors, this.constructor._name);
-      }
+                if (err) {
+                    /* eslint no-param-reassign: 0 */
+                    errorHash = errorHash || {};
+                    errorHash[key] = err.toString();
+                    return errorHash;
+                }
 
-      return errors;
-    }
+                return errorHash;
+            }, false);
 
-    /**
-     * Map data props to `this`, so that it can be used easily. Someday, we'll
-     * have cross browser proxy support and do neat getter/setter things. For
-     * now, just map it on the instance.
-     * @param {*} data
-     */
-    mapProps(data) {
-      Object.keys(data).forEach((key) => {
-        this[key] = data[key];
-      });
-    }
+            this._validationErrors = errors || null;
 
-    /**
-     * Verifies that parameters are set when required.
-     * @param {*} parameters
-     * @param  {...any} args
-     */
-    verifyParameters(parameters = {}, ...args) {
-      if (parameters.this) {
-        parameters.this.forEach((p) => {
-          if (!this[p]) {
-            throw new Error(`Object requires ${p} to be set.`);
-          }
-        });
-      }
+            if (errors && throwOnFailure) {
+                throw new ValidationError(errors, this.constructor._name);
+            }
 
-      if (parameters.args) {
-        parameters.args.forEach((p, i) => {
-          if (!args[i]) {
-            throw new Error(`Missing parameter: ${p}`);
-          }
-        });
-      }
-    }
-
-    /**
-     * Retrieve a record from the API.
-     * @param {string} id
-     * @param {string} urlPrefix
-     * @returns {Base|Promise<never>}
-     */
-    static async retrieve(id, urlPrefix) {
-      try {
-        const url = urlPrefix ? `${urlPrefix}/${id}` : `${this._url}/${id}`;
-        const res = await api.get(url);
-        return this.create(res.body);
-      } catch (e) {
-        return Promise.reject(e);
-      }
-    }
-
-    /**
-     * Retrieve a list of records from the API.
-     * @param {object} query
-     * @param {string} url
-     * @returns {object|Promise<never>}
-     */
-    static async all(query = {}, url) {
-      try {
-        url = url || this._url;
-        const res = await api.get(url, query);
-        const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
-
-        // Override the key used for reports to be the generic `reports` instead
-        // of including the report type in the object key below (eg: reports/shipment).
-        if (url.includes('reports')) {
-          url = 'reports';
+            return errors;
         }
 
-        const result = {
-          [url]: objectList,
-          has_more: res.body.has_more,
-        };
-        return result;
-      } catch (e) {
-        return Promise.reject(e);
-      }
-    }
-
-    /**
-     * Deletes an object from the API.
-     * @param {string} id
-     * @returns {Promise|Promise<never>}
-     */
-    static async delete(id) {
-      if (!id) {
-        throw new Error(`No id was passed into ${this._name} delete()`);
-      }
-
-      try {
-        return await api.del(`${this._url}/${id}`);
-      } catch (e) {
-        return Promise.reject(e);
-      }
-    }
-
-    /**
-     * Creates a new NotImplementedError.
-     * @param {string} fnName
-     * @returns {Promise<never>}
-     */
-    static notImplemented(fnName) {
-      return Promise.reject(new NotImplementedError(fnName, this._url));
-    }
-
-    /**
-     * Wraps JSON in a nested object.
-     * @param {object} json
-     * @returns {object}
-     */
-    static wrapJSON(json) {
-      return { [this.key]: json };
-    }
-
-    /**
-     * Creates a new object from the API.
-     * @param {*} data
-     * @returns {Base}
-     */
-    static create(data) {
-      return new this(data);
-    }
-
-    /**
-     * Unwraps the response from an `/all` call.
-     * @param {*} data
-     * @returns {Array|Base}
-     */
-    static unwrapAll(data) {
-      if (Array.isArray(data)) return data;
-      return data[this._url];
-    }
-
-    /**
-     * RPC (Remote Procedure Call) - builds the details needed to make an HTTP request.
-     * @param {string} path
-     * @param {object|Array} body
-     * @param {string} pathPrefix
-     * @param {string} method
-     * @returns {*}
-     */
-    async rpc(path, body, pathPrefix, method = 'post') {
-      const slashPath = path ? `/${path}` : '';
-      const prefix = pathPrefix || this.constructor._url;
-      const url = `${prefix}/${this.id}${slashPath}`;
-
-      try {
-        let res;
-
-        if (method === 'get') {
-          res = await api[method](url, body);
-        } else if (body) {
-          res = await api[method](url, body);
-        } else {
-          res = await api[method](url);
+        /**
+         * Map data props to `this`, so that it can be used easily. Someday, we'll
+         * have cross browser proxy support and do neat getter/setter things. For
+         * now, just map it on the instance.
+         * @param {*} data
+         */
+        mapProps(data) {
+            Object.keys(data).forEach((key) => {
+                this[key] = data[key];
+            });
         }
 
-        // When hitting the `/smartrate` endpoint, return the results directly
-        if (path === 'smartrate') {
-          return res.body.result || [];
+        /**
+         * Verifies that parameters are set when required.
+         * @param {*} parameters
+         * @param  {...any} args
+         */
+        verifyParameters(parameters = {}, ...args) {
+            if (parameters.this) {
+                parameters.this.forEach((p) => {
+                    if (!this[p]) {
+                        throw new Error(`Object requires ${p} to be set.`);
+                    }
+                });
+            }
+
+            if (parameters.args) {
+                parameters.args.forEach((p, i) => {
+                    if (!args[i]) {
+                        throw new Error(`Missing parameter: ${p}`);
+                    }
+                });
+            }
         }
 
-        this.mapProps(res.body);
-        return this;
-      } catch (e) {
-        throw e;
-      }
-    }
-
-    /**
-     * Save (create or update) a record.
-     * @returns {this|Promise<never>}
-     */
-    async save() {
-      try {
-        this.validateProperties();
-      } catch (e) {
-        return Promise.reject(e);
-      }
-
-      try {
-        const data = this.constructor.wrapJSON(this.toJSON());
-
-        let res;
-
-        if (this.id) {
-          res = await api.put(`${this._url || this.constructor._url}/${this.id}`, data);
-        } else {
-          res = await api.post(this._url || this.constructor._url, data);
+        /**
+         * Retrieve a record from the API.
+         * @param {string} id
+         * @param {string} urlPrefix
+         * @returns {Base|Promise<never>}
+         */
+        static async retrieve(id, urlPrefix) {
+            try {
+                const url = urlPrefix ? `${urlPrefix}/${id}` : `${this._url}/${id}`;
+                const res = await api.get(url);
+                return this.create(res.body);
+            } catch (e) {
+                return Promise.reject(e);
+            }
         }
 
-        this.mapProps(res.body);
-        return this;
-      } catch (e) {
-        throw e;
-      }
-    }
+        /**
+         * Retrieve a list of records from the API.
+         * @param {object} query
+         * @param {string} url
+         * @returns {object|Promise<never>}
+         */
+        static async all(query = {}, url) {
+            try {
+                url = url || this._url;
+                const res = await api.get(url, query);
+                const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
 
-    /**
-     * Retrieve a record from the API.
-     */
-    async retrieve() {
-      if (this.id) {
-        const res = await this.constructor.retrieve(this.id);
-        const props = res.toJSON();
+                // Override the key used for reports to be the generic `reports` instead
+                // of including the report type in the object key below (eg: reports/shipment).
+                if (url.includes('reports')) {
+                    url = 'reports';
+                }
 
-        Object.keys(props).forEach((k) => {
-          this[k] = props[k];
-        });
-      } else {
-        throw new Error('Cannot retrieve an object without an id.');
-      }
-    }
-
-    /**
-     * Delete a record from the API.
-     * @returns {this}
-     */
-    async delete() {
-      if (this.id) {
-        await this.constructor.delete(this.id);
-        return this;
-      }
-
-      throw new Error('Cannot delete an object without an id.');
-    }
-
-    /**
-     * Converts an object to JSON.
-     * @returns {object}
-     */
-    toJSON() {
-      const idKeys = this.constructor.jsonIdKeys;
-
-      return Object.keys(this.constructor.propTypes).reduce((json, key) => {
-        if (this[key]) {
-          // If providing an object as a parameter to another object, only pass along
-          // the ID so the API will use the object reference correctly.
-          if (idKeys.includes(key) && typeof this[key] !== 'object') {
-            json[key] = { id: this[key] };
-            return json;
-          }
-          if (idKeys.includes(key) && this[key].id) {
-            json[key] = { id: this[key].id };
-            return json;
-          }
-
-          // unwrap the json if it's an object instance
-          if (this[key].toJSON) {
-            json[key] = this[key].toJSON();
-            return json;
-          }
-
-          json[key] = this[key];
-          return json;
+                const result = {
+                    [url]: objectList,
+                    has_more: res.body.has_more,
+                };
+                return result;
+            } catch (e) {
+                return Promise.reject(e);
+            }
         }
 
-        return json;
-      }, {});
-    }
-  };
+        /**
+         * Deletes an object from the API.
+         * @param {string} id
+         * @returns {Promise|Promise<never>}
+         */
+        static async delete(id) {
+            if (!id) {
+                throw new Error(`No id was passed into ${this._name} delete()`);
+            }
+
+            try {
+                return await api.del(`${this._url}/${id}`);
+            } catch (e) {
+                return Promise.reject(e);
+            }
+        }
+
+        /**
+         * Creates a new NotImplementedError.
+         * @param {string} fnName
+         * @returns {Promise<never>}
+         */
+        static notImplemented(fnName) {
+            return Promise.reject(new NotImplementedError(fnName, this._url));
+        }
+
+        /**
+         * Wraps JSON in a nested object.
+         * @param {object} json
+         * @returns {object}
+         */
+        static wrapJSON(json) {
+            return {[this.key]: json};
+        }
+
+        /**
+         * Creates a new object from the API.
+         * @param {*} data
+         * @returns {Base}
+         */
+        static create(data) {
+            return new this(data);
+        }
+
+        /**
+         * Unwraps the response from an `/all` call.
+         * @param {*} data
+         * @returns {Array|Base}
+         */
+        static unwrapAll(data) {
+            if (Array.isArray(data)) return data;
+            return data[this._url];
+        }
+
+        /**
+         * RPC (Remote Procedure Call) - builds the details needed to make an HTTP request.
+         * @param {string} path
+         * @param {object|Array} body
+         * @param {string} pathPrefix
+         * @param {string} method
+         * @returns {*}
+         */
+        async rpc(path, body = undefined, pathPrefix = undefined, method = 'post') {
+            const slashPath = path ? `/${path}` : '';
+            const prefix = pathPrefix || this.constructor._url;
+            const url = `${prefix}/${this.id}${slashPath}`;
+
+            try {
+                let res = await api[method](url, body);
+
+                // When hitting the `/smartrate` endpoint, return the results directly
+                if (path === 'smartrate') {
+                    return res.body.result || [];
+                }
+
+                this.mapProps(res.body);
+                return this;
+            } catch (e) {
+                throw e;
+            }
+        }
+
+        /**
+         * Save (create or update) a record.
+         * @returns {this|Promise<never>}
+         */
+        async save() {
+            try {
+                this.validateProperties();
+            } catch (e) {
+                return Promise.reject(e);
+            }
+
+            try {
+                const data = this.constructor.wrapJSON(this.toJSON());
+
+                let res;
+
+                if (this.id) {
+                    res = await api.put(`${this._url || this.constructor._url}/${this.id}`, data);
+                } else {
+                    res = await api.post(this._url || this.constructor._url, data);
+                }
+
+                this.mapProps(res.body);
+                return this;
+            } catch (e) {
+                throw e;
+            }
+        }
+
+        /**
+         * Retrieve a record from the API.
+         */
+        async retrieve() {
+            if (this.id) {
+                const res = await this.constructor.retrieve(this.id);
+                const props = res.toJSON();
+
+                Object.keys(props).forEach((k) => {
+                    this[k] = props[k];
+                });
+            } else {
+                throw new Error('Cannot retrieve an object without an id.');
+            }
+        }
+
+        /**
+         * Delete a record from the API.
+         * @returns {this}
+         */
+        async delete() {
+            if (this.id) {
+                await this.constructor.delete(this.id);
+                return this;
+            }
+
+            throw new Error('Cannot delete an object without an id.');
+        }
+
+        /**
+         * Converts an object to JSON.
+         * @returns {object}
+         */
+        toJSON() {
+            const idKeys = this.constructor.jsonIdKeys;
+
+            return Object.keys(this.constructor.propTypes).reduce((json, key) => {
+                if (this[key]) {
+                    // If providing an object as a parameter to another object, only pass along
+                    // the ID so the API will use the object reference correctly.
+                    if (idKeys.includes(key) && typeof this[key] !== 'object') {
+                        json[key] = {id: this[key]};
+                        return json;
+                    }
+                    if (idKeys.includes(key) && this[key].id) {
+                        json[key] = {id: this[key].id};
+                        return json;
+                    }
+
+                    // unwrap the json if it's an object instance
+                    if (this[key].toJSON) {
+                        json[key] = this[key].toJSON();
+                        return json;
+                    }
+
+                    json[key] = this[key];
+                    return json;
+                }
+
+                return json;
+            }, {});
+        }
+    };

--- a/src/resources/base.js
+++ b/src/resources/base.js
@@ -2,312 +2,312 @@ import ValidationError from '../errors/validation';
 import NotImplementedError from '../errors/not_implemented';
 
 export default (api) =>
-    class Base {
-        static _url = null;
+  class Base {
+    static _url = null;
 
-        static _name = null;
+    static _name = null;
 
-        static key = null;
+    static key = null;
 
-        static propTypes = {};
+    static propTypes = {};
 
-        static jsonIdKeys = [];
+    static jsonIdKeys = [];
 
-        _validationErrors = null;
+    _validationErrors = null;
 
-        constructor(data = {}) {
-            this.mapProps(data);
+    constructor(data = {}) {
+      this.mapProps(data);
+    }
+
+    /**
+     *
+     * @param {bool} throwOnFailure
+     * @returns {object}
+     */
+    validateProperties(throwOnFailure = true) {
+      this._validationErrors = null;
+      const props = this.toJSON();
+
+      // Loop through proptypes and match them against props; this will catch
+      // issues such as isRequired or type mismatches.
+      const errors = Object.keys(this.constructor.propTypes).reduce((errorHash, key) => {
+        const err = this.constructor.propTypes[key](
+          props,
+          key,
+          `${this.constructor._name}`,
+          'prop',
+          key,
+        );
+
+        if (err) {
+          /* eslint no-param-reassign: 0 */
+          errorHash = errorHash || {};
+          errorHash[key] = err.toString();
+          return errorHash;
         }
 
-        /**
-         *
-         * @param {bool} throwOnFailure
-         * @returns {object}
-         */
-        validateProperties(throwOnFailure = true) {
-            this._validationErrors = null;
-            const props = this.toJSON();
+        return errorHash;
+      }, false);
 
-            // Loop through proptypes and match them against props; this will catch
-            // issues such as isRequired or type mismatches.
-            const errors = Object.keys(this.constructor.propTypes).reduce((errorHash, key) => {
-                const err = this.constructor.propTypes[key](
-                    props,
-                    key,
-                    `${this.constructor._name}`,
-                    'prop',
-                    key,
-                );
+      this._validationErrors = errors || null;
 
-                if (err) {
-                    /* eslint no-param-reassign: 0 */
-                    errorHash = errorHash || {};
-                    errorHash[key] = err.toString();
-                    return errorHash;
-                }
+      if (errors && throwOnFailure) {
+        throw new ValidationError(errors, this.constructor._name);
+      }
 
-                return errorHash;
-            }, false);
+      return errors;
+    }
 
-            this._validationErrors = errors || null;
+    /**
+     * Map data props to `this`, so that it can be used easily. Someday, we'll
+     * have cross browser proxy support and do neat getter/setter things. For
+     * now, just map it on the instance.
+     * @param {*} data
+     */
+    mapProps(data) {
+      Object.keys(data).forEach((key) => {
+        this[key] = data[key];
+      });
+    }
 
-            if (errors && throwOnFailure) {
-                throw new ValidationError(errors, this.constructor._name);
-            }
+    /**
+     * Verifies that parameters are set when required.
+     * @param {*} parameters
+     * @param  {...any} args
+     */
+    verifyParameters(parameters = {}, ...args) {
+      if (parameters.this) {
+        parameters.this.forEach((p) => {
+          if (!this[p]) {
+            throw new Error(`Object requires ${p} to be set.`);
+          }
+        });
+      }
 
-            return errors;
+      if (parameters.args) {
+        parameters.args.forEach((p, i) => {
+          if (!args[i]) {
+            throw new Error(`Missing parameter: ${p}`);
+          }
+        });
+      }
+    }
+
+    /**
+     * Retrieve a record from the API.
+     * @param {string} id
+     * @param {string} urlPrefix
+     * @returns {Base|Promise<never>}
+     */
+    static async retrieve(id, urlPrefix) {
+      try {
+        const url = urlPrefix ? `${urlPrefix}/${id}` : `${this._url}/${id}`;
+        const res = await api.get(url);
+        return this.create(res.body);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+
+    /**
+     * Retrieve a list of records from the API.
+     * @param {object} query
+     * @param {string} url
+     * @returns {object|Promise<never>}
+     */
+    static async all(query = {}, url) {
+      try {
+        url = url || this._url;
+        const res = await api.get(url, query);
+        const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
+
+        // Override the key used for reports to be the generic `reports` instead
+        // of including the report type in the object key below (eg: reports/shipment).
+        if (url.includes('reports')) {
+          url = 'reports';
         }
 
-        /**
-         * Map data props to `this`, so that it can be used easily. Someday, we'll
-         * have cross browser proxy support and do neat getter/setter things. For
-         * now, just map it on the instance.
-         * @param {*} data
-         */
-        mapProps(data) {
-            Object.keys(data).forEach((key) => {
-                this[key] = data[key];
-            });
+        const result = {
+          [url]: objectList,
+          has_more: res.body.has_more,
+        };
+        return result;
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+
+    /**
+     * Deletes an object from the API.
+     * @param {string} id
+     * @returns {Promise|Promise<never>}
+     */
+    static async delete(id) {
+      if (!id) {
+        throw new Error(`No id was passed into ${this._name} delete()`);
+      }
+
+      try {
+        return await api.del(`${this._url}/${id}`);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+
+    /**
+     * Creates a new NotImplementedError.
+     * @param {string} fnName
+     * @returns {Promise<never>}
+     */
+    static notImplemented(fnName) {
+      return Promise.reject(new NotImplementedError(fnName, this._url));
+    }
+
+    /**
+     * Wraps JSON in a nested object.
+     * @param {object} json
+     * @returns {object}
+     */
+    static wrapJSON(json) {
+      return { [this.key]: json };
+    }
+
+    /**
+     * Creates a new object from the API.
+     * @param {*} data
+     * @returns {Base}
+     */
+    static create(data) {
+      return new this(data);
+    }
+
+    /**
+     * Unwraps the response from an `/all` call.
+     * @param {*} data
+     * @returns {Array|Base}
+     */
+    static unwrapAll(data) {
+      if (Array.isArray(data)) return data;
+      return data[this._url];
+    }
+
+    /**
+     * RPC (Remote Procedure Call) - builds the details needed to make an HTTP request.
+     * @param {string} path
+     * @param {object|Array} body
+     * @param {string} pathPrefix
+     * @param {string} method
+     * @returns {*}
+     */
+    async rpc(path, body = undefined, pathPrefix = undefined, method = 'post') {
+      const slashPath = path ? `/${path}` : '';
+      const prefix = pathPrefix || this.constructor._url;
+      const url = `${prefix}/${this.id}${slashPath}`;
+
+      try {
+        const res = await api[method](url, body);
+
+        // When hitting the `/smartrate` endpoint, return the results directly
+        if (path === 'smartrate') {
+          return res.body.result || [];
         }
 
-        /**
-         * Verifies that parameters are set when required.
-         * @param {*} parameters
-         * @param  {...any} args
-         */
-        verifyParameters(parameters = {}, ...args) {
-            if (parameters.this) {
-                parameters.this.forEach((p) => {
-                    if (!this[p]) {
-                        throw new Error(`Object requires ${p} to be set.`);
-                    }
-                });
-            }
+        this.mapProps(res.body);
+        return this;
+      } catch (e) {
+        throw e;
+      }
+    }
 
-            if (parameters.args) {
-                parameters.args.forEach((p, i) => {
-                    if (!args[i]) {
-                        throw new Error(`Missing parameter: ${p}`);
-                    }
-                });
-            }
+    /**
+     * Save (create or update) a record.
+     * @returns {this|Promise<never>}
+     */
+    async save() {
+      try {
+        this.validateProperties();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+
+      try {
+        const data = this.constructor.wrapJSON(this.toJSON());
+
+        let res;
+
+        if (this.id) {
+          res = await api.put(`${this._url || this.constructor._url}/${this.id}`, data);
+        } else {
+          res = await api.post(this._url || this.constructor._url, data);
         }
 
-        /**
-         * Retrieve a record from the API.
-         * @param {string} id
-         * @param {string} urlPrefix
-         * @returns {Base|Promise<never>}
-         */
-        static async retrieve(id, urlPrefix) {
-            try {
-                const url = urlPrefix ? `${urlPrefix}/${id}` : `${this._url}/${id}`;
-                const res = await api.get(url);
-                return this.create(res.body);
-            } catch (e) {
-                return Promise.reject(e);
-            }
+        this.mapProps(res.body);
+        return this;
+      } catch (e) {
+        throw e;
+      }
+    }
+
+    /**
+     * Retrieve a record from the API.
+     */
+    async retrieve() {
+      if (this.id) {
+        const res = await this.constructor.retrieve(this.id);
+        const props = res.toJSON();
+
+        Object.keys(props).forEach((k) => {
+          this[k] = props[k];
+        });
+      } else {
+        throw new Error('Cannot retrieve an object without an id.');
+      }
+    }
+
+    /**
+     * Delete a record from the API.
+     * @returns {this}
+     */
+    async delete() {
+      if (this.id) {
+        await this.constructor.delete(this.id);
+        return this;
+      }
+
+      throw new Error('Cannot delete an object without an id.');
+    }
+
+    /**
+     * Converts an object to JSON.
+     * @returns {object}
+     */
+    toJSON() {
+      const idKeys = this.constructor.jsonIdKeys;
+
+      return Object.keys(this.constructor.propTypes).reduce((json, key) => {
+        if (this[key]) {
+          // If providing an object as a parameter to another object, only pass along
+          // the ID so the API will use the object reference correctly.
+          if (idKeys.includes(key) && typeof this[key] !== 'object') {
+            json[key] = { id: this[key] };
+            return json;
+          }
+          if (idKeys.includes(key) && this[key].id) {
+            json[key] = { id: this[key].id };
+            return json;
+          }
+
+          // unwrap the json if it's an object instance
+          if (this[key].toJSON) {
+            json[key] = this[key].toJSON();
+            return json;
+          }
+
+          json[key] = this[key];
+          return json;
         }
 
-        /**
-         * Retrieve a list of records from the API.
-         * @param {object} query
-         * @param {string} url
-         * @returns {object|Promise<never>}
-         */
-        static async all(query = {}, url) {
-            try {
-                url = url || this._url;
-                const res = await api.get(url, query);
-                const objectList = this.unwrapAll(res.body).map(this.create.bind(this));
-
-                // Override the key used for reports to be the generic `reports` instead
-                // of including the report type in the object key below (eg: reports/shipment).
-                if (url.includes('reports')) {
-                    url = 'reports';
-                }
-
-                const result = {
-                    [url]: objectList,
-                    has_more: res.body.has_more,
-                };
-                return result;
-            } catch (e) {
-                return Promise.reject(e);
-            }
-        }
-
-        /**
-         * Deletes an object from the API.
-         * @param {string} id
-         * @returns {Promise|Promise<never>}
-         */
-        static async delete(id) {
-            if (!id) {
-                throw new Error(`No id was passed into ${this._name} delete()`);
-            }
-
-            try {
-                return await api.del(`${this._url}/${id}`);
-            } catch (e) {
-                return Promise.reject(e);
-            }
-        }
-
-        /**
-         * Creates a new NotImplementedError.
-         * @param {string} fnName
-         * @returns {Promise<never>}
-         */
-        static notImplemented(fnName) {
-            return Promise.reject(new NotImplementedError(fnName, this._url));
-        }
-
-        /**
-         * Wraps JSON in a nested object.
-         * @param {object} json
-         * @returns {object}
-         */
-        static wrapJSON(json) {
-            return {[this.key]: json};
-        }
-
-        /**
-         * Creates a new object from the API.
-         * @param {*} data
-         * @returns {Base}
-         */
-        static create(data) {
-            return new this(data);
-        }
-
-        /**
-         * Unwraps the response from an `/all` call.
-         * @param {*} data
-         * @returns {Array|Base}
-         */
-        static unwrapAll(data) {
-            if (Array.isArray(data)) return data;
-            return data[this._url];
-        }
-
-        /**
-         * RPC (Remote Procedure Call) - builds the details needed to make an HTTP request.
-         * @param {string} path
-         * @param {object|Array} body
-         * @param {string} pathPrefix
-         * @param {string} method
-         * @returns {*}
-         */
-        async rpc(path, body = undefined, pathPrefix = undefined, method = 'post') {
-            const slashPath = path ? `/${path}` : '';
-            const prefix = pathPrefix || this.constructor._url;
-            const url = `${prefix}/${this.id}${slashPath}`;
-
-            try {
-                let res = await api[method](url, body);
-
-                // When hitting the `/smartrate` endpoint, return the results directly
-                if (path === 'smartrate') {
-                    return res.body.result || [];
-                }
-
-                this.mapProps(res.body);
-                return this;
-            } catch (e) {
-                throw e;
-            }
-        }
-
-        /**
-         * Save (create or update) a record.
-         * @returns {this|Promise<never>}
-         */
-        async save() {
-            try {
-                this.validateProperties();
-            } catch (e) {
-                return Promise.reject(e);
-            }
-
-            try {
-                const data = this.constructor.wrapJSON(this.toJSON());
-
-                let res;
-
-                if (this.id) {
-                    res = await api.put(`${this._url || this.constructor._url}/${this.id}`, data);
-                } else {
-                    res = await api.post(this._url || this.constructor._url, data);
-                }
-
-                this.mapProps(res.body);
-                return this;
-            } catch (e) {
-                throw e;
-            }
-        }
-
-        /**
-         * Retrieve a record from the API.
-         */
-        async retrieve() {
-            if (this.id) {
-                const res = await this.constructor.retrieve(this.id);
-                const props = res.toJSON();
-
-                Object.keys(props).forEach((k) => {
-                    this[k] = props[k];
-                });
-            } else {
-                throw new Error('Cannot retrieve an object without an id.');
-            }
-        }
-
-        /**
-         * Delete a record from the API.
-         * @returns {this}
-         */
-        async delete() {
-            if (this.id) {
-                await this.constructor.delete(this.id);
-                return this;
-            }
-
-            throw new Error('Cannot delete an object without an id.');
-        }
-
-        /**
-         * Converts an object to JSON.
-         * @returns {object}
-         */
-        toJSON() {
-            const idKeys = this.constructor.jsonIdKeys;
-
-            return Object.keys(this.constructor.propTypes).reduce((json, key) => {
-                if (this[key]) {
-                    // If providing an object as a parameter to another object, only pass along
-                    // the ID so the API will use the object reference correctly.
-                    if (idKeys.includes(key) && typeof this[key] !== 'object') {
-                        json[key] = {id: this[key]};
-                        return json;
-                    }
-                    if (idKeys.includes(key) && this[key].id) {
-                        json[key] = {id: this[key].id};
-                        return json;
-                    }
-
-                    // unwrap the json if it's an object instance
-                    if (this[key].toJSON) {
-                        json[key] = this[key].toJSON();
-                        return json;
-                    }
-
-                    json[key] = this[key];
-                    return json;
-                }
-
-                return json;
-            }, {});
-        }
-    };
+        return json;
+      }, {});
+    }
+  };

--- a/src/resources/batch.js
+++ b/src/resources/batch.js
@@ -113,7 +113,7 @@ export default (api) =>
 
       try {
         const url = `${this._url}/create_and_buy`;
-        const response = await api.post(url, { body: newParams });
+        const response = await api.post(url, newParams);
 
         return this.create(response.body);
       } catch (e) {

--- a/src/resources/carrier_account.js
+++ b/src/resources/carrier_account.js
@@ -36,7 +36,7 @@ export default (api) =>
       try {
         // eslint-disable-next-line no-param-reassign
         url = url || this._url;
-        const response = await api.get(url, { query });
+        const response = await api.get(url, query);
         const carrierList = this.unwrapAll(response.body).map(this.create.bind(this));
         return carrierList;
       } catch (e) {

--- a/src/resources/carrier_type.js
+++ b/src/resources/carrier_type.js
@@ -52,7 +52,7 @@ export default (api) =>
       try {
         // eslint-disable-next-line no-param-reassign
         url = url || this._url;
-        const response = await api.get(url, { query });
+        const response = await api.get(url, query);
         const carrierList = this.unwrapAll(response.body).map(this.create.bind(this));
         return carrierList;
       } catch (e) {

--- a/src/resources/refund.js
+++ b/src/resources/refund.js
@@ -27,7 +27,7 @@ export default (api) =>
     static async save(params = {}) {
       const newParams = { refund: params };
       try {
-        const response = await api.post(this._url, { body: newParams });
+        const response = await api.post(this._url, newParams);
         return response.body;
       } catch (e) {
         return Promise.reject(e);

--- a/src/resources/tracker.js
+++ b/src/resources/tracker.js
@@ -44,7 +44,7 @@ export default (api) =>
       const newParams = { trackers: params };
       try {
         const url = 'trackers/create_list';
-        await api.post(url, { body: newParams });
+        await api.post(url, newParams);
         // This endpoint does not return anything so true is returned here
         return true;
       } catch (e) {

--- a/src/resources/user.js
+++ b/src/resources/user.js
@@ -75,7 +75,7 @@ export default (api) =>
         const newParams = { brand: params };
         const userData = this.constructor.wrapJSON(this.toJSON());
         const url = `${this.constructor._url}/${userData.user.id}/brand`;
-        const res = await api.put(url, { body: newParams });
+        const res = await api.put(url, newParams);
         return res.body;
       } catch (e) {
         return Promise.reject(e);

--- a/test/cassettes/Batch-Resource_4123662849/buys-a-batch_1852613799/recording.har
+++ b/test/cassettes/Batch-Resource_4123662849/buys-a-batch_1852613799/recording.har
@@ -4,7 +4,7 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "6.0.4"
+      "version": "6.0.5"
     },
     "entries": [
       {
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -44,7 +44,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 500,
+          "headersSize": 498,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -61,7 +61,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 332,
-            "text": "[\"H4sIAAAAAAAAA4SPzU7EMAyE3yXnrpRtuq2aI8/ACYQiN3W2gTQJ+Tmt9t1xKQUOSNwy45nPzo3ZmUk2QdGLEhpwMKMAFKYzwzjheLnwsR963RkUgjUsTK+oCzUetgYZa5iRZMFcSOUCZZM6IRTrr2T5uqq82LiiL5nJc8MSGkzoNQV9da7Z0zgr2MAtb9sTF6dz/9hyKQbZjU+EqXH+N5M1eGVCWg/wr73PL/t1ld63YyOTvGHvFSuBqadiTXqBjJ/+/odARLDuKxsDMa74Hfzb/WncaWj1W43HRQ4mdKomtxv3DwAAAP//AwBsnj50gAEAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SPzVLEIBCE34VztorEuAkcfQZPWhY1wGQTJYD8nLb23Z0Yox6s8kb3dH8zXNlimWQaipkV3HFubT9qDaIXoxjNZC0MfBIwnPUgWMOCfkVTqPGwNchYg0WSBXMhlQuUTZqEUBZ/IcvXVeV5iSv6kplsG5ZwwoTeUNBX55o9jVbBBu541514f+rax/Ys217eD0+EqdH+m8kGvJpCWg/wr73PL/t1ld7XYyOTvGHvFSuBqadiTWaGjJ/+/odARFjcVzYGYlzwO/i3+9O40XAxbzUeFznQ6FRNbjduHwAAAP//AwCjMh1ygAEAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5df62324a9de78a13e9000e368f"
+              "value": "1a07d7cd62618301e779940e000ecff4"
             },
             {
               "name": "cache-control",
@@ -111,11 +111,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f88396cbed48f16c1166e925ec769917\""
+              "value": "W/\"6934f6fbfc35967e58cca9889af33bcb\""
             },
             {
               "name": "x-runtime",
-              "value": "0.036212"
+              "value": "0.053950"
             },
             {
               "name": "content-encoding",
@@ -127,23 +127,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -154,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:37:48.850Z",
-        "time": 249,
+        "startedDateTime": "2022-04-21T16:14:56.671Z",
+        "time": 539,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,15 +165,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 249
+          "wait": 539
         }
       },
       {
-        "_id": "9c9e5f321844569d23aacc2ae13c513d",
+        "_id": "58aa427b0e593c3db113d20dceb82f38",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -194,22 +190,31 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 522,
+          "headersSize": 539,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/batches/batch_3cae7f93ae3f4f79be95509676c4fe33/buy"
+          "url": "https://api.easypost.com/v2/batches/batch_a300dd48bba949898cfdda70f9a76b79/buy"
         },
         "response": {
           "bodySize": 408,
@@ -217,7 +222,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 408,
-            "text": "[\"H4sIAAAAAAAAA4SQy26DMBBF/8VrIgHmEbPsN3TVqrLMeAw0vOrHKsq/dxwCrdRI3TGXM9d37pUNmjWsVR56yUFhbQRXyE1hatGiKMtUVHUFhUHOWcKW9hPB08ZL3CBhWjTS6NF5mpxXPo5gkT40KXOYpOuHdcLZO9ZkCbNo0OIMxM1hHJMdlir65mmen1J+yqrXPG143RTijWzCqv9lHKhZmsVOu/Gvd9+vjxtjwkAC+woYyJB4uQYLvXJIHhs0oXOqOwL+SeytgsswdxLu12/ivUjXrxKrVom80CWiKLKiFKkwGWrgOjvDuczZ7WNrKua4Hl3Fbp6FatJHRcNC56lhjCxp60IeHR7gc/Vn40Y/B7iEdQ88qhZHGey4CbdvAAAA//8DAJpsm0oMAgAA\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQzW7CMBCE38VnkJxgSJxjn6GnVpW1Xm9ISv7qnxPi3bsmQCsVqbfs5Nvx7JxF70QjLETsDOykdE7V1oJWutY1ts5BJVsN1cFWWmzEbD8JI2+85A0WxtkRj5FC5ClEiHlET/zhWJnSaELXLyNNMYim2AhPLXmakLkpDcPmDhvIvqUsy61U27J4LQ5NoZp99cY2aXH/MgFhMu3sx7vxr3ffz7cbc8LEgvhKlNiQebMkjx0EYo8VGikEOD4C/kkcPeCpn44Gr9ev4rXI0C1GlihlhXW7w0JpSbqtSO/VrlagLblaXD7WpnKO86Or3M2zUI28VdTPfB70Q2ZZW2b2ONIDfK7+bFz4Z4+ntNwDD2BpMMkPq3D5BgAA//8DAM62udoMAgAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +252,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e662324a9de78a13ea000e36a3"
+              "value": "1a07d7cf62618301e779940f000ed01c"
             },
             {
               "name": "cache-control",
@@ -267,11 +272,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"7bf674d1671d99fbf98dc74509774e78\""
+              "value": "W/\"b7765218f93865e3177d6eecc4a12901\""
             },
             {
               "name": "x-runtime",
-              "value": "0.045518"
+              "value": "0.048400"
             },
             {
               "name": "content-encoding",
@@ -283,11 +288,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -295,7 +300,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -306,14 +311,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:37:49.111Z",
-        "time": 255,
+        "startedDateTime": "2022-04-21T16:14:57.217Z",
+        "time": 530,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -321,7 +326,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 255
+          "wait": 530
         }
       }
     ],

--- a/test/cassettes/Batch-Resource_4123662849/creates-a-scanform-for-a-batch_397052124/recording.har
+++ b/test/cassettes/Batch-Resource_4123662849/creates-a-scanform-for-a-batch_397052124/recording.har
@@ -4,7 +4,7 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "6.0.4"
+      "version": "6.0.5"
     },
     "entries": [
       {
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -44,7 +44,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 500,
+          "headersSize": 498,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -56,12 +56,12 @@
           "url": "https://api.easypost.com/v2/batches"
         },
         "response": {
-          "bodySize": 335,
+          "bodySize": 332,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 335,
-            "text": "[\"H4sIAAAAAAAAA4SPzVLEIBCE34VztgrIunE5+gyetCxqgMkmSgD5OW3tuzsxRj1Y5Y3u6f5muLLZMcUMVDtpO8AwuB64AziKszTA7wfD3R23p/EMknUsmle0lRoPa4OMJTokWbFUUqVCXaXNCHUOF7JCW3SZ5rRgqIUp0bGMI2YMloKhed9taXQaVrDkUh54fxCnR8nVUSjRPxGmJfdvplgIeox52cG/9j6/bNc1el/3jUzxjr03bASmnk4t2wkKfvrbHyIRYfZf2RSJccHv4N/uT+NGw9m+tbRf5MGg1y37zbh9AAAA//8=\",\"AwBohWUJgAEAAA==\"]"
+            "size": 332,
+            "text": "[\"H4sIAAAAAAAAA4SPzW7DIBCE34WzIxnHsRuOfYaeWkWIn3VMi4ECe4ry7l3XddtDpR6QmGHm2+XGnGWCaVXNLNtpPHJtR235sQetVX8ep7MewNKBfmANi/oVTKXG49ogY4kWSFYolVSpqq7SZFDVhStZARdZZpcWCLUwwRuWYYIMwVAwoPfNlgYr1Qru2q47tP2h4098EPwk+MMzYTDZfzPFqCCnmJcd/Gvuy2XbDul+2ycy0TbsHQEJTD2ZMJtZFfj0tz9EIirnv7IpEuMK38G/3Z/GnR6decO0b+SVBi8x+824fwAAAP//AwCMaeOXgAEAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e062324b69e78a7de2000e725c"
+              "value": "1a07d7d062618316e779942a000ed7ce"
             },
             {
               "name": "cache-control",
@@ -111,11 +111,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"75b0eb80145b39460eeb4357cccfd83d\""
+              "value": "W/\"d3364282cb192032500661173602e16b\""
             },
             {
               "name": "x-runtime",
-              "value": "0.039038"
+              "value": "0.040057"
             },
             {
               "name": "content-encoding",
@@ -127,19 +127,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -150,14 +154,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 784,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:13.390Z",
-        "time": 512,
+        "startedDateTime": "2022-04-21T16:15:17.920Z",
+        "time": 545,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -165,15 +169,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 512
+          "wait": 545
         }
       },
       {
-        "_id": "780bbc94553f744e066515c96d9b9186",
+        "_id": "3a669a7c0e1b6bb15bd4cdaccde033ae",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -190,22 +194,31 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 522,
+          "headersSize": 539,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/batches/batch_c7a77d3a0daa4192ba087b0d50c6f9a2/buy"
+          "url": "https://api.easypost.com/v2/batches/batch_0f731bd7bd134ebba497f9b6edb6ee46/buy"
         },
         "response": {
           "bodySize": 408,
@@ -213,7 +226,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 408,
-            "text": "[\"H4sIAAAAAAAAA4SQyW6EMBBE/8VnRjKGYTvmG3JKFFmN3SwZtng5If497WEgkTJSbnTxulxdK+s1q1gNTnVS5ZDnOgGuAdK4FDXwIq+5vnKVNSUIFrG5/kTlaOMlbJAwzhppdGgdTdaBC6MySB+alMmP0nb9MuLkLKviiBls0OCkiJv8MEQHLCH4Ci7EhSeXOHsVvErjKk7eyMYv+l/GKphkM5vxMP717vv6uDEk9CSwL4+eDImXizeqA4vksUMjWgvtGfBPYmdA3fqplep+/S7ei7TdIkWsr8hTyJuap40WAKiTsig4NYuaZ2z72JsKOdazq9DNs1AVf1TUz3Qe9ENgSVtm8mjxBJ+rPxsb/ezVzS9H4AFqHKQ3wy5s3wAAAP//AwBs3TuzDAIAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4RQy27DIBD8F86OZBxiBx/7DT21qhAsS+zGr/I4Rfn3LnGcVmqkHpDYYXaYmQvrLWuZ0RE6Vbpmz41tjOV7gcZoIRsnTY2WDoqaFWw2nwiRNl7yBgHjbJHGiCHSFKKOeQSPdLGETGlUoeuXEacYWMsL5tGhxwmIN6VhKDay0lm3KqtqV4pdxV953fJDy49vJJMW+y8ngJ6Um/24Cf/69/1yz5gdJgLYV8JEgsRXS/LQ6YCksZJGDEGfHgb/OI5ew7mfTgpu6VfwVmToFuWcq0GCk3tjRQPyKDVKYYSEpjHGHdj1Y20q+7g8usrdPDPVlveK+pni6X7IXMKWmTRO+CA+R382rvTYwzktm+FBGxxU8sMKXL8BAAD//wMAVwwAmQwCAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -243,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e262324b6ae78a7de3000e7280"
+              "value": "1a07d7c962618316e779942b000ed7ff"
             },
             {
               "name": "cache-control",
@@ -263,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"133021b84ada1058ecd27d6beec8b2ed\""
+              "value": "W/\"2439ce23ca5765dc3f8cc3c4e71de0e0\""
             },
             {
               "name": "x-runtime",
-              "value": "0.050428"
+              "value": "0.050509"
             },
             {
               "name": "content-encoding",
@@ -279,19 +292,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -302,14 +319,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 784,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:13.910Z",
-        "time": 265,
+        "startedDateTime": "2022-04-21T16:15:18.471Z",
+        "time": 527,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -317,15 +334,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 265
+          "wait": 527
         }
       },
       {
-        "_id": "c000e7669eaa6a256b564f822a98005a",
+        "_id": "47ed3cea4401306e7f3a0fd9a6d1f1e3",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -342,30 +359,39 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 528,
+          "headersSize": 545,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/batches/batch_c7a77d3a0daa4192ba087b0d50c6f9a2/scan_form"
+          "url": "https://api.easypost.com/v2/batches/batch_0f731bd7bd134ebba497f9b6edb6ee46/scan_form"
         },
         "response": {
-          "bodySize": 560,
+          "bodySize": 564,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 560,
-            "text": "[\"H4sIAAAAAAAAA5RSSY7bMBD8C88aoEnJ2o455APJKYMB0SKbtma0hcshMPz3NKPYngXIIuigblUXu6p4FqMVvRgwmpM2DTaNLREsYiU7NSC0zQD2AKZ2HSpRiHV4JhN54lOe4Ma8WuIyUohchYgxl1vy5oSBLPeWNOtwGreZlhhELwvhyZGnxTBySdNUCOOJ56zGzKxAqQcoH2T9VUFfyV6W35gmbfZPmDpjgsFFu9XPoj/vwoLTilgN1PVhIKrImbZxoMCVBocGuw5fq/rCBJ/z/F93qv91p+jRvIzLURt2ivU/PhUCrfUUwlV+di1xtZ/J2Owr/8fjzaEsSic/vandOJGOP7Ybao/x/xI16+JGP/O567LzXHije16P599cty23lT+PpF+HvEPeLf0h5zdeMFNXAcj8dmUt+VGtlAdguj2706aVtAeCChs3QOWsQiRbdm0LrIks1OLydPfvfA1N9FCI74kSZ8NO3Tb91d9NXvmiIPu3Yz9Kyvf0ffc+wRZto3lJ21XZhANN94AuPwEAAP//AwBW5HiIWAMAAA==\"]"
+            "size": 564,
+            "text": "[\"H4sIAAAAAAAAA5RSy27bMBD8F54VQJRo0tSxh/xAe2oQEHwsbSV6lY9DYfjfuyxrO06AtAUkQLuaHe7M8ERGRwZidLJH1XrRU+OEcbRnYIxmUnhpODh8gXHSkNW8gE048aVMYGNeHWCZICasYtKplFsO9qgjOOwteVbxOG4zLCmSgTYkgIcAi0XkkqepITYAzjmlC3PXdt1Dyx46+o3yge4Guv+ONHlzn2A6WjDR6kX5NcxkOFVh0avedJx2VPZ8L5jzXHstLZfUCqB8192p+ooEj2X+bzvV8/5lpxS0fR2Xg7LoFOp/em6Idi5AjBf5xbWMVT0TscVX/K8PV4eKKJXDdFf7cQKVfm5XVI3x/xK16+LHMOO561J5zrjRLa+n0x+u65bbip8HUG9DrpB3S3/I+c4LZJKsbWl5MBxKKW97IdgO6Wp2x01577mV1sveOCas3EsNkhkmrRDG+B05P9/8O11CI0PbkB8ZMmaDTl03/d2vJq94UTT6V7EfJZV7+r57m0CLttG+5u2ibNIGpltA518AAAD//wMAShWVu1gDAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -395,7 +421,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e062324b6ce78a7de4000e7326"
+              "value": "1a07d7c962618319e779942c000ed8ea"
             },
             {
               "name": "cache-control",
@@ -415,11 +441,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f4972cc4c0d1926f74a4a0d902287225\""
+              "value": "W/\"517322d2b376e8f68699f05074922e81\""
             },
             {
               "name": "x-runtime",
-              "value": "0.059478"
+              "value": "0.080863"
             },
             {
               "name": "content-encoding",
@@ -431,11 +457,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -443,7 +469,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -454,14 +480,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:16.184Z",
-        "time": 270,
+        "startedDateTime": "2022-04-21T16:15:21.010Z",
+        "time": 572,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -469,7 +495,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 270
+          "wait": 572
         }
       }
     ],

--- a/test/cassettes/Batch-Resource_4123662849/generates-a-label-for-a-batch_2376202846/recording.har
+++ b/test/cassettes/Batch-Resource_4123662849/generates-a-label-for-a-batch_2376202846/recording.har
@@ -4,7 +4,7 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "6.0.4"
+      "version": "6.0.5"
     },
     "entries": [
       {
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -44,7 +44,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 500,
+          "headersSize": 498,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -61,7 +61,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 332,
-            "text": "[\"H4sIAAAAAAAAA4SPzW7DIBCE34WzIwGO3NjHPkNPqSLEzzqmxUD5OUV596zrOO0hUiQOzDDz7XIh1pCBKFn0JFTf9hxMxxhr97Qzh36kByW1US2l5s2QhgT1Bbpg431poDEHAygL5IIqF1kWqRPIYv0ZLV9nkScbZ/Alk4E1JMEICbzGoK/ONWsajJALmFPOd7Tdse6D02HP8BwRU6N5mclaejGGNG/gf3M/T+t2Fe+XbSIZaEN+KlQEY0/EmvQkM/z66x8CEqV192wMyDjDI/jc/Wtc8dHq7xq3jZxU4ERNbjWuNwAAAP//AwArHEi4gAEAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA4SPzW6DMBCE38VnIhkDJnDsM/TUKrL8swRaY7v+OUV59yyltD1U6s0zO/Pt+kYWQ0aiZNaz0FwxRSXvz8DbvmXDZKZz1wxdr2gjh55UxKs30BkbT1sDjdUbQJkhZVQpy7xJHUHmxV3RcmUVaV7CCi4nMtYViTBBBKcx6Iq11Z4GI+QGZpSxE21PrH6u+Vh3Y8NfEFOC+TeTtHRi8nE9wL/2vl726wq+b8dGMtKKfBQoCMaeCCXqWSb49Pc/eCTKxX5lg0fGFb6Df7s/jTsOF/1ewnGRlQqsKNHuxv0BAAD//wMAcOHVN4ABAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e062324b85e78a7e04000e78f0"
+              "value": "1a07d7cb62618328e779942f000ede7a"
             },
             {
               "name": "cache-control",
@@ -111,11 +111,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"85f90c7008dd8a734e1a6c84c0f71aee\""
+              "value": "W/\"31b125da27368fd801968ae2aa501d72\""
             },
             {
               "name": "x-runtime",
-              "value": "0.040723"
+              "value": "0.039165"
             },
             {
               "name": "content-encoding",
@@ -127,11 +127,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -139,7 +139,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb1nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -150,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:40.786Z",
-        "time": 305,
+        "startedDateTime": "2022-04-21T16:15:36.216Z",
+        "time": 506,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -165,15 +165,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 305
+          "wait": 506
         }
       },
       {
-        "_id": "71b5eec646960eeac7183b55cb213296",
+        "_id": "3b97fdbc48c8e5dd67c156eec6d322f9",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -190,22 +190,31 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 522,
+          "headersSize": 539,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/batches/batch_b9392ed61113406d89f08bacdb300d7d/buy"
+          "url": "https://api.easypost.com/v2/batches/batch_c6b2b0a678e647429fdf853957b03a97/buy"
         },
         "response": {
           "bodySize": 408,
@@ -213,7 +222,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 408,
-            "text": "[\"H4sIAAAAAAAAA4RQSW7DMBD7i84OINmOa/nYN+TUohC0jJdGXqrlZPjvHcWJW6ABCuigoUiKw5UMhjREyaB7oXjBczAVY6woaWVq3tJaSW1UQal5MSQjs/oEHVDxmhQIjLMBHAP4gJMPMqRRO8BLEkxxFL4flhGm4EnDMuKgBQeTRt4Urc0eZCGTb07z/ESLE6suOW1KhucNbeJi/uV4LSfRzm58GP/6932975gSRgTIV4SIhsgXS3S6lx7QYyeN4L3sjoB/Egcn9XWYOqFv2+/grUjfL4LWTJWlKVlLdWl4UXPOcq7OoIwpzqwl28feVMqxHl2lbp6Faui9omHG9eRgExexZUaPDg7ic/RHseHjoK9xeQS2UoEV0dkd2L4BAAD//wMAGQuFyAwCAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA4SQyW6EMBBE/8VnRrLNao75hpwSRZYxzUDGLPFyQvx72sNAImWk3Ojidbm6VjK0pCaN8rqXumh4Q1VRVlBkZcZF13ZVnoq8bGiqREkSMjefoD1uvMQNFMa5BRw9OI+T88rHUVvAjxaVKYzS9cMywuQdqVlCLHRgYdLITcGY5IClir6ccn6h2YWzV1bULK/T4g1twtL+yzitJtnNdjyMf737vj5ujAkDCuQrQEBD5OUSrO6VA/TYoRGcU9cz4J/E3ip9G6ar1Pfrd/FepOsXmectL7HElGqRlZoJygQvhKpoBznjKdk+9qZijvXsKnbzLFRNHxUNM56nBhNZ1JYZPa5wgs/Vn40Nfw76FpYjsFENGBms2YXtGwAA//8DAK0jDNgMAgAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -243,7 +252,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e362324b85e78a7e05000e7908"
+              "value": "1a07d7cf62618329e7799430000edeab"
             },
             {
               "name": "cache-control",
@@ -263,11 +272,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0ee4a8422ddfe9c59088cfd065b24000\""
+              "value": "W/\"abe240c53c521b501e051f3b7aaef72f\""
             },
             {
               "name": "x-runtime",
-              "value": "0.051186"
+              "value": "0.050742"
             },
             {
               "name": "content-encoding",
@@ -279,11 +288,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -291,7 +300,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb1nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -302,14 +311,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:41.097Z",
-        "time": 258,
+        "startedDateTime": "2022-04-21T16:15:36.727Z",
+        "time": 534,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -317,11 +326,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 258
+          "wait": 534
         }
       },
       {
-        "_id": "5c33d6d4413d34ca5d753c73f489880d",
+        "_id": "245a8d9c8efc093c80be08e2e7bc6111",
         "_order": 0,
         "cache": {},
         "request": {
@@ -342,11 +351,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -357,7 +366,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 544,
+          "headersSize": 542,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -366,15 +375,15 @@
             "text": "{\"file_format\":\"ZPL\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/batches/batch_b9392ed61113406d89f08bacdb300d7d/label"
+          "url": "https://api.easypost.com/v2/batches/batch_c6b2b0a678e647429fdf853957b03a97/label"
         },
         "response": {
-          "bodySize": 440,
+          "bodySize": 444,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 440,
-            "text": "[\"H4sIAAAAAAAAA3xRy07DMBD8F59Tya+WOEe+gRMIWX5smtC88OMU9d9ZNw0gKiH54J2dWe+MV9J70hBrkuu0VUJx8CfGmJD05GvV0toa562g1D95UpHZfoBLqHguCgTG2QOWCWLCKiaTSjkYC4M+wwTBpH46Y2vKo45dv4wwpUgaVpEALQSYHAqmPAwVcQFQ7rUpD3DK+YGKAzu9cNpIhucVx+TF/8cRhROdmXQ7h3Ef/Ovdt/VutqyaESDLjNcz6CUH15kIxeZGGSFG7OxTHvZNwbgLutNuC0FJSlk5SpQMGa8Z5zWOu2Ucu0XTmlkpvWQtddIrUSvFuLJHsN6LI2vJ9X0LsWy27oGQhlbkM0NG32jre9MbfuP0Mxo2/XDnPloqef9FfxRXbPbukpfd2fZ/OQwbcP0CAAD//wMA9CWAmScCAAA=\"]"
+            "size": 444,
+            "text": "[\"H4sIAAAAAAAAA3xRy27DIBD8F86uxMPGxsd+Q0+tKoRhHbvxqzxOUf69Sxy3VSNV4sDOzg47w4WMjrSkM9EO2sqOd9TIugFZ1iVXveubSqiq7qgwqiYFWbsPsBEnnvMEAvPqAMsIIWIVoom5nEwHkz7BAt7EcTlha0mzDsO4zbDEQFpWEA89eFgsDixpmgpiPeC40yY/wCnnT7R84uyFyZZVrZCvKJM29x9HZU6wZtH96udD+Ne7b5e72bxqQoBsK15PoLfk7WACOFTYKTOEgJ1D5WHf6I09oztt9xBUSSnLRwnJGJNU1A2VKHfLOAybrirHa8xXUKvK2jJFmeJSmYb2UDEuyPV9DzFvdjkCIS0tyGeChL7R1vemN/zGGVc0bMbpzn20lPP+i/5MXLE52nPaDmf7/yU/7cD1CwAA//8DAOzc+oUnAgAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -404,7 +413,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e562324b87e78a7e06000e7987"
+              "value": "1a07d7ce6261832be7799431000edf74"
             },
             {
               "name": "cache-control",
@@ -424,11 +433,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"6348c9da61975f467dc39956207d0293\""
+              "value": "W/\"e5ff82e2a232733033ef1d0cac9819e4\""
             },
             {
               "name": "x-runtime",
-              "value": "0.038037"
+              "value": "0.041517"
             },
             {
               "name": "content-encoding",
@@ -440,11 +449,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -452,7 +461,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -463,14 +472,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:41:43.367Z",
-        "time": 252,
+        "startedDateTime": "2022-04-21T16:15:39.268Z",
+        "time": 526,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -478,7 +487,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 252
+          "wait": 526
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/buys-a-pickup_1934475561/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/buys-a-pickup_1934475561/recording.har
@@ -173,7 +173,7 @@
         }
       },
       {
-        "_id": "706d39187ca87077da77e80655cd0fe8",
+        "_id": "21c9e272bc0e97360942ac70f042f62f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,11 +194,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -215,7 +215,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-12\",\"max_datetime\":\"2022-04-12\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_bfa432a6f3d74d15a3a962fe76cabcc2\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-22\",\"max_datetime\":\"2022-04-22\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_bfa432a6f3d74d15a3a962fe76cabcc2\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -226,7 +226,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 728,
-            "text": "[\"H4sIAAAAAAAAA6xUTY/TMBD9K1GusMhx89XeViwcOKCKlgtoFU3sMZimduQ4u1uq/nfGSTYty6EgEeWQGb/5evOcY6xlvIpbLXZ9W5U1KxRPsrIURZpztgRMgSkoFU+FLFj8Orb1DxSeQtZDCHmEQ/AoKwhezji/YelNkmyTcpWmK1Z+IUzfyquYvZVIpx47T1bnwfcd2b3ZGftoyOVQoUMjCGX6pqEIbaqQ1+s9XublW8ZWwzvkhae/QOmuAiFsb3wFUjrsqLaCpkM6Mp13vfDamm4ePAIfKWeNj6S1LpShEPiGhPh6T6RYo7TbQwh6bnfOexxJB+mqDEFBhqpeiiJJUNRlugCRqLwWRb3I+SXjt1P8VcqLV8NY13k/Aw0M5HwAsYs2LThnH0Mdu2/BHOjgHXSHtZ024xB9Qs5FWUZb2k2HRkab8xkPzbY+4iGz0D4k2ICJ3jswQnfCTvsNFd/ekvFTt/S5TBNWDFVpCy4Efd6Q2X63JiCz+SEn7kE3sw5+U46g7jW6SoHQzVB8RBF3WqLxGuZAhRIdNJUniYSVjN6htRe+B3RaaQGTCI6n07nQpJtp89NVcpQjeI4vdY3uQQcJxx/xyd/BIQh7pIK9GVYhehdUPs5/9x8v2NTvkHc9MDu2+o9/gAt4aLyCkvEsW9SFSPN0WSY1CORc8iRndc4g//On8SnMe7o//QIAAP//AwCLvCqTfQQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA6xUTY/TMBD9K1GusCh2Ppr0tmLhwAFVtFxAq2hij8E0tSPH2d1S9b8zTkK2LIddJKIcMuM3X2+ec4q1jNdxp8V+6OomURWmueJVvsqqJG8qlZYsZzKvVMkZj1/HtvmBwlPIZgwhj3AIHmUNwcsTzq+S7IqzHSvWPFlz/oUwQyefxRysRDr12Huyeg9+6MkezN7Ye0MuhwodGkEoM7QtRWhTh7xeH/AyL98lyXp8x7zw8AKU7msQwg7G1yClw55qK2h7pCPTezcIr63pl8Ej8JFy1vhIWutCGQqBb0iIr7dEijVKuwOEoN/tLnlPE+kgXa1YLhtWFIKVyBiKBoQCwVTRiFUjRXHJ+PUc/zzlr8axXsD7AjQwkvMBxD7aduCcvQ917KEDc6SDd9AfN3bejEP0jJxpWUY72k2PRkbbxzMemu18xENmoX1IsAUTvXdghO6FnfcbKr69JuOn7uizyliyGqvSFlwI+rwls/tuTUDmy0NOPIBuFx38oRxB3WskakHodiw+oYg7LdF4DUugQokO2tqTRMJKJu/Y2hPfHTqttIBZBKfz+bHQrJt58/NVcpQjeE5PdY3uTgcJxx/xwd/AMQh7oiJ5M65CDC6ofJr/5j9esLnfMe9mZHZq9R//ABfw0Hidp4RTVZJBVWYpZJUSRVnIlIOsCi7Lv38an8K859vzLwAAAP//AwCG1oh6fQQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -256,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb57625476f7e786b7f900240245"
+              "value": "1a07d7d062618445e7799788000f42e2"
             },
             {
               "name": "cache-control",
@@ -276,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"08545198b5784ec5276ba2d953f42f8b\""
+              "value": "W/\"5bd594f2174722163a5f8e421cc6c33a\""
             },
             {
               "name": "x-runtime",
-              "value": "0.830233"
+              "value": "0.816015"
             },
             {
               "name": "content-encoding",
@@ -292,11 +292,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -304,7 +304,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -315,14 +315,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:07.738Z",
-        "time": 1018,
+        "startedDateTime": "2022-04-21T16:20:21.574Z",
+        "time": 1271,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -330,11 +330,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1018
+          "wait": 1271
         }
       },
       {
-        "_id": "20e09c4e447bdbee47616af6d90663f7",
+        "_id": "f50641e5f53d51a4e714443c65f4ab3c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -355,11 +355,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -379,7 +379,7 @@
             "text": "{\"carrier\":\"USPS\",\"service\":\"NextDay\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_8b07f21588c746209ae4a0fa8f24cd70/buy"
+          "url": "https://api.easypost.com/v2/pickups/pickup_b0f9e35f29574905b9f38151d59f8212/buy"
         },
         "response": {
           "bodySize": 748,
@@ -387,7 +387,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 748,
-            "text": "[\"H4sIAAAAAAAAA6xUXW/TMBT9K1FeYch289W+TRs88IAqWoQEmqIb+5qZpXbkONtK1f/OdRJ1ZUgMJKo81Nfn3I9zT3JIjUpXaWfk3dDVVcNKLXheVbLMCsGWgBkwDZUWmVQlS1+nrvmOMhBlPVIoIj1CQFVDjAomxAXLLjjf8mqVZStWfSHM0Kk/YDiLmJ1TSLcB+0CnPkAYejr38hbV0KKioEeNHq0knB3aljjG1jFzMDs8zyy2jK3GZ8wMj3+BMn0NUrrBhhqU8thTdQ1tj3Rl++AHGYyz/Wn0BEKivbMhUc75WIYo8A0J8fWGZHFWG7+DSCLO5+1Vwcsyq0RU8VTgMOkPytc5goYcdbOUJecomypbgOS6aGTZLApxLv7lzH9R/fLVON+LKzgDWhhVeg/yLtl04L17iHXcrgO7p4u30O/Xbl6SRwycgouqSrbuwfZoVbJ5uhOx2S4k49TShJhgAzZ558FK00s3rzpWvLqkww/T0d9lxlk5VqV1+Ej6tKFjd+tsROanHwVxB6Y9GeIXE0nq3qCvNUjTjsUnFGlnFNpg4ETUqNBDWwfySlzJFB1bexa7R2+0kTC74XA8PhWaDTRbYH6rPOWIkcNzi6O/N9HL6Qd8DNewjw6fpGBvxlXIwUe7T/Nf/5d3bcLM/Y5516OyU6v/+DE4g8fGa6iYyPNFU8qsyJYVb0CiEErwgjUFg+L378fHOO/x5vgTAAD//wMAffrPhYgEAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA6xUTY/TMBD9K1GvsCh2Ppr0ttqFAwdU0SIk0Cqa2GPWbGpHjrMfVP3vjJ2oLYvEgkSUQzx+b2b85jn7hZaL1aLX4m7smzZVNWaF4nWxzOu0aGuVVaxgsqhVxRlfvF7Y9jsKT5R1pFBEOASPsoEQ5SnnF2l+wdmWlSuerjj/Qpixl3/C5AGzsxJp1+PgaTV48ONA60Hcohw7lBR0qNChEYQzY9cRR5smZPZ6h+eZ+TZNV/GNmeHxL1B6aEAIOxrfgJQOB6quoBuQtszg3Si8tmY4Hj0BnyhnjU+ktS6UIQp8Q0J8vSFZrFHa7SCQiPN5e1Wy5bJkaUnQY4H9pD9I1yhWyJaVpWAVMoaiBaFAMFW2YtlKUZ6LfznzX1b/VTzfyyM4AQ1Eld6DuEs2PThnH0Idu+vBPNHGWxie1nYekkP0jIJZVSVb+2AGNDLZnPZ4aLb3CQ+ZhfYhwQZM8s6BEXoQdh51qHh1SYsfuqfPOmfpMlalcbhA+rShZX9rTUAWx4eCuAPdHQ3xi4kEda+RpAWhu1h8QpF2WqLxGo5EhRIddI0nr4SRTNHY2rPYPTqttIDZDfvD4VRoNtBsgflWOcoRIvvnFkd3r4OXFx/w0V/DU3D4JEX6Jo5CjC7YfTr/9f+5axEz9xvzrqOyU6v/+DM4g4fGmyIjnKrTHOoqzyCvlSirUmYcZF1yWf3+//gYznu4OfwEAAD//wMAnzeK3ogEAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -417,7 +417,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb50625476f8e786b7fa0024029c"
+              "value": "1a07d7cf62618447e7799789000f4364"
             },
             {
               "name": "cache-control",
@@ -437,11 +437,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"a31512a6f2b75eb1be9e7b8e7aa9f4b1\""
+              "value": "W/\"9562897a2d94a61a6083706390fc76f0\""
             },
             {
               "name": "x-runtime",
-              "value": "1.132447"
+              "value": "1.344584"
             },
             {
               "name": "content-encoding",
@@ -453,11 +453,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -465,7 +465,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -476,14 +476,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:08.763Z",
-        "time": 1319,
+        "startedDateTime": "2022-04-21T16:20:22.850Z",
+        "time": 1802,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -491,7 +491,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1319
+          "wait": 1802
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/cancels-a-pickup_4207662041/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/cancels-a-pickup_4207662041/recording.har
@@ -4,7 +4,7 @@
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
-      "version": "6.0.4"
+      "version": "6.0.5"
     },
     "entries": [
       {
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -56,12 +56,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2222,
+          "bodySize": 2192,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2222,
-            "text": "[\"H4sIAAAAAAAAA+xYbW/bNhD+K4a+LnFIinrzN69NtnTLy2IXXTsUAkVSNlNZEiiqqVPkv++oF8d22sZAsmTYEgRIeLw7kfc8PPLuq8O1ZEaKmBln5BBEyD6i+xhPcTiidITRB2fPUVWspal17oxSllVyz1nIqmIzWTmjvz7CqBASrI2sDGgXpVFFDlNfHV5rLXO+hMm3k9cwV7LlQubGzpllaY0mh6evDy+cmz1HwDpiJj6znMMEAomWqbT2MMzrLNtzKsNMDZ6dOv+UF1c5eDSa8U8qn8W8XUREEcL2N3J9jDH1CAk9Cop1KX60UWw3mjDD57ES/ffacf/VdVkXgF7I68oUiypWeVr0slQXC9iP0KBqN2zdOkzo2Ec4ZF4YJhEPMJY8CUXCOE79hAeJ6xMbw+RScrvQcWe/dy9QPyE0Quj+jd4q5mxhI/YGAjiYlEzr4sp+p1iULLeQHbJqeV40mFZGS2kwCN0wHEwh9JXMxWByO0fsYkszINYzV8Y6mLB8cKQBT1Xxwmnhs198NYbBtSobuDAKmq/WudEtUSxP5kVuNb3VDwjlgqmsj+4m5zisXkkdp4yrrPl4qwWxUwIIp9jKMJVCapbFhn1ZQ7pZ2pbss9QqVZz1dL4BSqq8qnXLUMdDwyaOhQaPa3YQSi6zFeSl5lkcJpwmiXSZSBMaeihhmEvpkyDABEXEX8f8vLW/H/IPO6BtdTKZz8zcgdEQ7TlXSthBaP+fSzWbgyW1g1JDaFKVg7cSOLFG76tODXtDuhl6CEkJFAHdOGNJu+vbjbQzvzcTe100sjgKIyy9KAk9yaiXSpZQiAaihHkEuzJ9nJ03B3orp1j8jJzpxi4t9AIsc8s0iJFdZCxagn4vjo0OcKrIaksKZ+Qi1IsrdW1N6Rd/pdmlOAgqqzM=\",\"sxKnKpP9nFpAgA7KfLaarTUE0ZkbU1ajgwMJZ9AGeN8aVcPKHdbV/hVEfp8M2YJdFzm7qoZwZg8ahYMNMA7sPhDF+ID5KELYJ24ggIc0TEJGo4SkXpqEAVByuL6CUqTtKlrwW+F1md0VyjIjd6V2Ja3E5nCIqL0musNgh7Hni4j53AJPqOenLJJpmCIv4QRDYkzWD8OFReTxjsJm2qik/qyas3yuVaFt4ljlkiYVndtkpFtSBEO3yVTbdxpcjZCX4k4rHAboVnhHOVOViTcdNqI7ikJmChLQEii5hPjhDYlZncwNYTyrGSQnI6VY3dSw0fiur2quSnsRN1kLRmXMgyAVrogkSiNKI8yon4pQpIRGJBXCX0uyjDfZurXlLPYSFnDm+i7hHmVCJjhggiYc7jSXhxGCJLGOPhYUhRzOvIdd4CYPEQlSzCLgIfajJH0O9JuMO5GZ/eqPGEDI/QzotHZjQKO6EwPIIzKAPDMDvAjSD+bUYwEVqRu53EsRk0kIPKA8egYGHCld/Qh6uPii+6HvtHaBvlP9v0EfiCDyQ+GGJAL4UZTgRHLGfLj40yAk4TNAf/il7J/Y3wGfuMPAux99Egzprrm/d7kT/t9A+yEU6F68T8uCj005V+diq5yqOMu7p1gnaLIwYNlG6p/NG3jXh+RL3nj6vNHW9jaoHQmM/hSDHncZphRqaEoQZ5hxCaB5lOAEIb7OgWlnvw3fzj2Db/QbWhFExzTF6NrMY1GtUjNbgiXL7eqrHW1hc4vqQ+C55e0qNu0Ouw5PKvteT49nH4Cu5K2TTPGt2qVxNewrmKZIEZeHvvj1jf6THH85JSfX76eH6PT1IX0//WN58svp/OTd0eWH6fHVyeVbdHJ5pE5e/3zZMKH4XifFF5jKvpMSEXfVSSGY0KfupIxf/TaYnI8vLs7ebXZSxpP352eT6d1Oytm7U9sBG0ymg/H5tO2erBoqXW+pa6aMTwdHF+PTV8eTV2c/aKbsY7+pQJ6io2J0LR/SUbHrpvZvVXPegNt6lFoXuiPcioddQdlzf1ezr1CVGmVquzk3GAaB50EBlBX5rBPuY0KGbuRHAfBMLWR83UZqvIDVcnbwe1HF43wG11Ll3NzYJlBdlVWnhZusXev8pdP3H+v0JfXSXlsvWecl6/w7so59JG9ex2ut1iNpX7tdU7FpuLYStrCAgMz2qlFDGz5nemYfe+3y21f56vFny7Vve+26uVt+7Xv0YX6P+5b6nRUTbyfPH7vW8o5PntUqJt2Dybn5GwAA//8=\",\"AwCBBTQoBxsAAA==\"]"
+            "size": 2192,
+            "text": "[\"H4sIAAAAAAAAA+xYbW/bNhD+K4a+LnH4JlHyN6NNtmZrksUeunQoBIqkbLayJFBSU7vIf99Rkh3HSRMDLZphbRAg4fF4Ot7z8Mi7z560WtRaxaL2Rh5BhBwidkjwFAcjgkbEf+sdeKaKra4bm3ujVGSVPvAWuqrETFfe6J93MCqUhtW1rmrQLsraFDlMffZkY63O5RIm/5q8hLlSLBc6r91cvSzdosnx2cvjS+/mwFPgRyzUR5FLmEAgsTrVbj0M8ybLDryqFnUDlr0m/5AX1zlYrK2QH0w+i2XnRMQQwu43ogHGOEAMYYZBsSnVYxsN3EYTUct5bNT6e914/dVtWR+AtVA2VV0sqtjkabGWpbZYwH6UBVW3YWfWE8rGKaU8DBItcagx1jKSERESp0EiOcGEuRgm77V0jo779QdPAvULQiOEnt7orWIuFi5ipxDAwaQU1hbX7jvFohS5g+xYVMuLosW0qq3WNQYhDcPBFEJf6VwNJrdzxDlb1gPiLEtTOwMTkQ9OLOBpKll4HXzuiy/GMFiZsoULI95+tclr2xHF8WRe5E7T3/yAUC+EydbRvcs5Cd4bDaEV0mTtxzstiJ1RQDgjNgtTrbQVWVyLT1tIt67tyD5qa1IjxZrON0BJk1eN7Rjq+WjYxrGwYHFrHYRS6mwDeWllFqsoQFinSCZ+xKTwowBHypcJZ1yEPpXbmF9065+G/O0eaDudTOezeu6NMDh84F0b5Qah+3+uzWwOK5kblBZCk5ocrJXAiS16X/dq2B+yu6GHkJRAEdCNM5F0u77dSDfzRztx0Ecji1PEkYBDGfkoYJjLJEBRkqAo9FMuSES/zc7bA72TUxx+tZ7Zdl1a2AWszB3TIEbOyVh1BP1SHFsd4FSRNY4U3ogitBZXZuWWsk/BRrNPcRBU0WT1RpyaTK/nzAICdFTms81sYyGI3ryuy2p0dKThDLoAH7pF1bCiw6Y6vIbIH5KhWIhVkYvraghn9qhVOLoDxpHbB2IEHyGuWSQoCvw0YAkniaY0SAmVCYFkFPHhtgelSjsvOvA74arM7gt1mZH7UudJJ3E5HCLqron+MNgWEJ4gyqQvuSJMER2qgKcyQVz4XBKstw/DpUPk2x2Fu2mj0vajac/y8adynWe7VNJmoguXi2zPCTrkLgvdu9PgaoS8FK/V+JChW+k97cxUdbxjspXd01Q6M5CClkDK5eb22RLW+kFhPGsEZKhaa7W5rmG38YPmqrkp3YXcZi8YlTERSZTCadRcwVXqq5CGShJGgUFKqjTYSrZCtlm7WytF7CeCS0EDSqTPhNIJ5kKxRMLdRmUYIUgW2yxgIkGCMSxEKJjyUZIGqSJhSlkgAqb9Z2BBl3knOnNf/TIV+JCQp5nQa+1DhF51Lx6Qb0gC8rwM0JCKmCRUKEhPfhiEjEj4jyckpMpP2DMw4MTY6jHo4QKMnoa+19oH+l71R4NecMpoEoQUkZDhkAka8pRE0keERsR/lsNvTWHd2/Gxg0/50+iHQ77vDdAb3At9/A3Rx98d/XdtOdfkaqecqqTI+6dYL2izL2DYhehnvvhh80VX27ug9iSo7Yc45DT1wyTBKeWM+FA4E8UFvCFYSHHEo20OTPv1u/Dt3TN4oN/QiSA6dVuMbs08QbVg35qlMjNXgiXL3eqrG+1gc4vq18Bzy9tNbLod9h2eVK97PWs81wHoS94myYzcqV1aU8N1BdMWKer9caB+O7V/r2b0NbnC57+emtdvrlZnqz+XZ9PT+dXq9MMZOZlfTWfo/OXrT+dT6bdMKL7USfEFSvzbTkqYPmcnZfzi98HkYnx5ef7mbidlPLm6OJ9M73dSzt+cuQ7YYDIdjC+mXfdk01Dpe0t9M2V8Nji5HJ+9eDV5cf5IM+UQB+318z06KrVt9Nd0VJzfzP2tGilbcDuL2trC9oTb8LAvKNfc33fZZ6hKa1M3bnOUDzn3fbj9siKf9cJDTMiQRkHEgWdmoeNVF6nxAryV4uiPoorH+Qyupcq7uXFNoKYqq14Lt1m7sfnPTt//rNOXNEt3bf3MOj+zzn8j67hH8t3reKvVeqLda7dvKrYN104iFg4QkLleNWppI+fCztxjr3O/e5VvHn+uTHvYat/N3bHr3qNfZ/fVuqV+z2Pi72X5Xd9a3vPJs/Fi0j+YvJt/AQAA//8DAKfrQGEHGwAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb52625476fae786b7fb00240328"
+              "value": "1a07d7cb62618449e779978b000f440b"
             },
             {
               "name": "cache-control",
@@ -107,7 +107,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_c77fd3d9e0f94491a46fd8df2492fdd6"
+              "value": "/api/v2/shipments/shp_2ab9fbb0e7d9405d838dc24307edcdf6"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"983b70d141356f3683d79744a1edd43d\""
+              "value": "W/\"32c6e1185d7cc8ee381dc0c5e3b31e82\""
             },
             {
               "name": "x-runtime",
-              "value": "1.125110"
+              "value": "1.241754"
             },
             {
               "name": "content-encoding",
@@ -131,11 +131,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -143,7 +143,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -154,14 +154,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 832,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_c77fd3d9e0f94491a46fd8df2492fdd6",
+          "redirectURL": "/api/v2/shipments/shp_2ab9fbb0e7d9405d838dc24307edcdf6",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-04-11T18:44:10.092Z",
-        "time": 1317,
+        "startedDateTime": "2022-04-21T16:20:24.662Z",
+        "time": 1707,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,11 +169,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1317
+          "wait": 1707
         }
       },
       {
-        "_id": "064f18df548fc87ec9e99fdcd42f092b",
+        "_id": "539ec41a98f458ee56668a06ac86e421",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,11 +194,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -215,7 +215,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-12\",\"max_datetime\":\"2022-04-12\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_c77fd3d9e0f94491a46fd8df2492fdd6\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-22\",\"max_datetime\":\"2022-04-22\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_2ab9fbb0e7d9405d838dc24307edcdf6\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -226,7 +226,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "[\"H4sIAAAAAAAAA5RUTY/TMBD9K1GusMhO0zbtbcXCgQOqaLmAVtFkPAbT1I4cZ3dL1f/OOMl2y3JoiXLIjN98vXnOITUqXaaNwW3XlLMZzvOFAirEIlcTqrQuMsxkMS3EPKum6dvUVb8IA4es+hD2oCcIpEqI3kxk2Y3Ib6TcyGKZ50spvzGma9RFzM4p4tNAbWCrDRC6lu3Obq17tOzypMmTRUbZrq45wtgy5g1mR+d5s40Qy/7t88LTFSjTloDoOhtKUMpTy7U11C3xkW2D7zAYZ9vT4AmERHtnQ6Kc87EMh8APYsT3eybFWW38DmLQc7unvIeBdFC+nAmS1RSyaoFzKQkrXBSAUs8qAUJJOmf8doy/TPmbfqwreD8BLfTkfALcJusGvHePsY7bNWD3fPAB2v3KjZvxREGyc1IUyYZ305JVyfrlLIvNNiHJYmY0ISZYg00+erBoWnTjfmPF97ds/DYNfy5yKeZ9Vd6Cj0Ff12w2P52NyOnpYSftwNQnHfylHOTuDflSA5q6Lz6gmDujyAYDp0BNijzUZWCJxJUM3r61V74H8kYbhFEEh+PxpdCom3Hz41XynCN6Dq91Tf7BRAmnn+kp3ME+CnugQrzrV4Gdjyof5r+7vO3sigvWY8Z++7yrntmh1f/8A5zBY+OlIpgRQp6LCeQ4rQqt9GKCmBPqfCrFvz+NL3He4/3xDwAAAP//AwAsNuJ0fQQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUTY/TMBD9K1GusMhxPpr0tmLhwAFVtFxAq2hqT8A0tSPH2d1S9b8zdrLZshxaohwy4zdfb55zjJWMl3GnxG7o6rIqGKsYk3LBsiyBsklKkckMUglc5Cx+G5vtLxSOQlYhhDzCIjiUNXgvZ5zfsOyGJ5ukWHK25MU3wgydvIjZG4l06rB3ZPUO3NCTPeidNo+aXBYbtKgFofTQthShdO3zOrXH87x8w9gyvCEvPF2BUn0NQphBuxqktNhT7QbaHulI984Owimj+3nwCFzUWKNdJI2xvgyFwA8kxPd7IsXoRtk9+KDndue8x5F0kLZushQkFlwkJSYJipJDCSJpiq1YbNOCnzN+O8VfpvxNGOsK3meghkDOJxC7aN2BtebR1zH7DvSBDj5Af1iZaTMW0SXkTMsy2tBuetQyWr+ccd9s5yLuMwvlfII16OijBS1UL8y0X1/x/S0Zv1VHn1WWsEWoSluwPujrmszup9Eemc8POXEPqp118JdyBHWvkKgFodpQfEQRd0qidgrmwAYlWmhrRxLxKxm9obVXvge0qlECJhEcT6eXQpNups1PV8lSDu85vtY12gflJRx/xid3Bwcv7JEK9i6sQgzWq3yc/+7ythdXXLCAmfoNeVeB2bHV//wDnMF943Va5TITUFVQyWxRylLkOYisTBdbyXIo//1pfPHznu5PfwAAAP//AwB3h96/fQQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -256,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb57625476fbe786b7fc0024045b"
+              "value": "1a07d7cc6261844ae779978c000f4499"
             },
             {
               "name": "cache-control",
@@ -276,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"ff3fdefb3bcfdcd4fe3c869906146bb1\""
+              "value": "W/\"2844d64b23490e9d5b1cd551efc33b6e\""
             },
             {
               "name": "x-runtime",
-              "value": "0.786871"
+              "value": "0.903222"
             },
             {
               "name": "content-encoding",
@@ -292,11 +292,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -304,7 +304,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb2nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -315,14 +315,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:11.417Z",
-        "time": 981,
+        "startedDateTime": "2022-04-21T16:20:26.377Z",
+        "time": 1363,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -330,11 +330,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 981
+          "wait": 1363
         }
       },
       {
-        "_id": "f7e7fe58c963233e4855a08c34d152bd",
+        "_id": "7264dfb8e8cff7ccc44776e11a8577bf",
         "_order": 0,
         "cache": {},
         "request": {
@@ -355,11 +355,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -379,7 +379,7 @@
             "text": "{\"carrier\":\"USPS\",\"service\":\"NextDay\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_66c749dae8094d3ebff82c21858072b5/buy"
+          "url": "https://api.easypost.com/v2/pickups/pickup_89600900dd70441a8f18c4d4a3da2c50/buy"
         },
         "response": {
           "bodySize": 748,
@@ -387,7 +387,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 748,
-            "text": "[\"H4sIAAAAAAAAA5RU32/TMBD+V6K+wpDtpm3at2mDBx5QRYuQQFN0OZ+ZWWpHjrOtVP3fOadRW4ZER5SH3Pn77ufn7EZWjxajxuJD15TTKc7yuQYqxDzXY6qMKRQqWUwKMVPVZPR25KufhJEpy57CHgwEkXQJyauEUlciv5JyLYtFni+k/MaYrtH/wowTZuM18WmkNrLVRohdy3aL96S7mjQ7AxkK5JBxrqtr5lhXpsjRbug8sloLsejfPjI8vwJl2xIQfediCVoHajm7gbolPnJtDB1G6117bD2DmJngXcy09yGlYQr8IEZ8v+OxeGds2EAiMefr+mYqZ7O8UIqhxwS7w/xBh3IqSFYTUNUcZ1ISVjgvAKWZVgKElnQ+/OuBf3n6b/r+Lq/gBHTQT+kj4EO2aiAE/5Ty+E0DbssH76HdLv2wpEAUJTvHRZGt/ZNryelsdTpTqdgmZipFRhtTgBW47EMAh7ZFP6w6Zby5ZuOXbfhznksx67PyOkIifVmx2dx7l5CT48NO2oCtj4L4Q0TI1VsKpQG0dZ/8gOLZWU0uWjgSDWkKUJeRtZJWcvD2pb3wPVKwxiIMatjt96dEg4AGCQy3KnCM5Nm9lDiFR5u0PPpEz/EWtknhh1GId/0qsAtJ7of+by9vW73irvWYod4+7rKf7KHU//wZnMFT4aUmmBJCnosx5DipCqPNfIyYE5p8IsXf/4/Pqd/93f43AAAA//8DABuEoc6IBAAA\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUy27bMBD8FcHXNgVFy3r4FiTtoYfCqF0UaBEI6+WqYSOTAkUlcQ3/e5e0YLspUKeGDuZyZh+zI+0mWk3mk07jw9DVZZULUQmhVCGyLIWySUvMVAZTBRJnYvJ2Ytc/CT1TFpHCEXQEnlQNISqFlFciu5LpKs3nUsxl/o0xQ6f+hakCZmMV8a2n3vOp9+CHns893pMaWlIcdNSQI4OMM0PbMkebOmT2ekPnmeVKiHl8YmZ4fgVK9zUg2sH4GpRy1HP1Btqe+Mr03g3otTX9cfQEfNI4a3yirHWhDFPgBzHi+x3LYk2j3QYCiTlfVzd5WhR5KoOKxwK7g/6gXN1kU1CUS0xLSlPCUkIJmDb5Gov1NJfn4l+P/Mvqv4nzXV7BCWggqvQR8CFZduCcfQp17KYDs+WL99BvF3ZckiPyKQenZZms7JPpyahkebqTodnOJ3Fq1D4kWIJJPjgwqHu046pDxZtrPvzSHf+tslQUsSqvwwXSlyUfu3trAnJ2/HGQNqDboyH+MBFy95pYWkDdxuIHFGunFRmv4UhsSJGDtvbslbCSQzS29iL2SE43GmF0w26/PxUaDTRaYHyrHOcIkd1Li5N71MHLk0/07G9hGxx+kEK8i6vAwQW7H+a/vbzt4hXvWsSM/ca8i6jsodX//BicwUPj9bSaqQyhqqBSWVGqEmczwKycFmslZlD+/f34HObd3+1/AwAA//8DAH6UUwqIBAAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -417,7 +417,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb54625476fce786b7fd002404bf"
+              "value": "1a07d7c96261844ce77997a5000f450a"
             },
             {
               "name": "cache-control",
@@ -437,11 +437,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"22fbb14775379bc8e7ab90221814aa0c\""
+              "value": "W/\"132a8174a91c9a2a3ff91451f98cb0ed\""
             },
             {
               "name": "x-runtime",
-              "value": "0.866336"
+              "value": "1.302502"
             },
             {
               "name": "content-encoding",
@@ -453,11 +453,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -465,7 +465,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -476,14 +476,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:12.409Z",
-        "time": 1064,
+        "startedDateTime": "2022-04-21T16:20:27.746Z",
+        "time": 1797,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -491,15 +491,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1064
+          "wait": 1797
         }
       },
       {
-        "_id": "9aaa8a496a26d9ed3f4883efd9fcbc91",
+        "_id": "1001400bb83c1e6be21165dd272e92f4",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -516,22 +516,31 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 524,
+          "headersSize": 543,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_66c749dae8094d3ebff82c21858072b5/cancel"
+          "url": "https://api.easypost.com/v2/pickups/pickup_89600900dd70441a8f18c4d4a3da2c50/cancel"
         },
         "response": {
           "bodySize": 748,
@@ -539,7 +548,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 748,
-            "text": "[\"H4sIAAAAAAAAA5RU32/TMBD+V6K8wpDtum3at2mDBx7QRIuQQFN0OZ/BLLUjx9kYVf93zmnUjSGxEeUhd/6++/k5+9KZcl12Dm+Grl4scKlXBqgSK21m1FhbKVSymldiqZp5+boMzQ/CxJSrkcIejASJTA3Zq4RSZ0KfSbmV1VrrtZRfGDN05l8YnTG7YIhPE/WJrT5BGnq2ETxSS4Z9kSxFYrNc+6FtmeJ8nQMnt6PHgdVWiPX4joHh5wtQrq8BMQw+1WBMpJ6TW2h74iPfpzhgcsH3p84LSIWNwafChBBzGqbAN2LE12ueSvDWxR1kEnM+by8WcrnUlVIMPSXYH8cPJtYLQbKZg2pWuJSSsMFVBSjtohEgjKTHsz+f+M8P/9XY3/MbeAB6GKf0HvCm2HQQY7jLecKuA3/PB2+hv78K044iUZLsnFVVsQ13vidvis3DmcrFdqlQOTK6lANswBfvIm/V9RimTeeMF+ds/HIdf660FMsxK68jZtKnDZvd9+Azcn562Ek7cO1JEH9oCLl6R7G2gK4dkx9RPDtnyCcHJ6IlQxHaOrFW8kqO3rG0J75bis46hEkN+8PhIdEkoEkC06WKHCN79k8VTvHWZS2XH+hnuoT7rPDjKMSbcRU4xCz3Y/+Xz29bveCqjZip3jHu1TjZY6n/+S94BM+F14ZgQQhaixlonDeVNXY1Q9SEVs+l+Pv38TH3e7g+/AYAAP//AwCSdmydhwQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUTY/TMBD9K1GusMh20nz0ttqFAwdU0SIk0Cqa2hMwm9qR4+xuqfrfGTtRtywShSiHzPjN15vnHFKt0mXaa3k/9k1VF4zVjClVsjznULW8krnKIVMg5IKlr1O7/YHSU8gqhpBHOgSPqoHgFUyIK5ZfCb7hxVKwpSi+EGbs1V8wGQuYnVVIpx4HT9bgwY8D2RKMxA4V+Ry26JDMdGnGrqMQbZqQ2OsdnicWG8aW8Y2J4ekfUHpoQEo7Gt+AUg4HKt5CNyAdmcG7UXptzXCaPAGftM4anyhrXShDIfANCfH1jlixptVuByGIYj5vbgpelgUXgcRTgcNEPyjXtHkGCgsheYWco6wEVCB5W2xluc0Kcc799Rx/mfxXcb6LGzgDGogsvQd5n6x7cM4+hjp214PZ08FbGPYrO+/IIXpOzqyqko19NAMalayfz0RotvdJnFpqHxKswSTvHG1VD9LOmw4Vb67J+Kl7+qxzzspYldbhQtCnNZn9d2sCcnF6yIk70N1JEL9pSFL3GolakLqLxScUcacVGq/hFNiiQgdd40krYSWTN7b2wveATrdawqyGw/H4XGgW0CyB+VI5yhE8h5cKR/egg5bTD/jkb2EfFD5Rwd7EVcjRBblP899e3nZ5+apNmLnfmHcVmZ1a/c9/wRk8NN5k9ULlEuoaapWXlarkYgEyr7Jyq9gCqj9/Hx/DvMe74y8AAAD//wMA4WYI2YcEAAA=\"]"
           },
           "cookies": [],
           "headers": [
@@ -569,7 +578,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb50625476fde786b7fe00240567"
+              "value": "1a07d7cc6261844de77997a6000f458c"
             },
             {
               "name": "cache-control",
@@ -589,11 +598,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"850668d596b34eb21b6ba8dd0b8e75bc\""
+              "value": "W/\"e44d887a2be93a314c4fe529d41eae20\""
             },
             {
               "name": "x-runtime",
-              "value": "0.968573"
+              "value": "0.846330"
             },
             {
               "name": "content-encoding",
@@ -605,11 +614,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -617,7 +626,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -628,14 +637,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:13.480Z",
-        "time": 1170,
+        "startedDateTime": "2022-04-21T16:20:29.546Z",
+        "time": 1321,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -643,7 +652,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1170
+          "wait": 1321
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/creates-a-pickup_320342919/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/creates-a-pickup_320342919/recording.har
@@ -173,7 +173,7 @@
         }
       },
       {
-        "_id": "bad81f8920be2776fcb8d95769f130b7",
+        "_id": "fb48b26f16566d05f79d5fcc9623e82c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,11 +194,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -215,7 +215,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-12\",\"max_datetime\":\"2022-04-12\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_9aad53415326407ebb153ee1870ac3c1\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-22\",\"max_datetime\":\"2022-04-22\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_9aad53415326407ebb153ee1870ac3c1\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -226,7 +226,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "[\"H4sIAAAAAAAAA5RUTY/TMBD9K1GusChO3Xz0tmLhwAFVtFxAq2hiT8A0tSPH2d1S9b8zdrLZskJqiXKIx2/ejN885xgrGa/iTond0FV1JuRywZZ5LhecJ1mRY5kvIWtqKZscivhtbOpfKBylrEMKRYRFcCgr8NE0SdObhN8wtmXFivNVkn4jzNDJi5i9kUi7DntHq96BG3paD3qnzaOmkMUGLWpBKD20LWUoXXlep/Z4zptuk2QV3sALT1egVF+BEGbQrgIpLfZUu4G2R9rSvbODcMrofj54BC5qrNEuksZYX4ZS4AcS4vs9iWJ0o+wefNJzuzPvcRQdpK2WNWQpPXUpcsZQlElRgmBNVos8ZSk/V/x2yr8s+ZtwrCt0n4EagjifQOyiTQfWmkdfx+w70Afa+AD9YW2myVhExyi4KIpoS7PpUcto87KX+mY7F6WeWSjnCTago48WtFC9MNN8fcX3t7T4rTr6LDlL8lCVpmB90tcNLbufRnvkcn4oiHtQ7eyDv5wjqHuFtmpAqDYUH1GknZKonYI5sUGJFtrKkUX8SMZoaO1V7AGtapSAyQTH0+ml0OSbafLTVbLE4SPH175G+6C8hePP+OTu4OCNPUqRvAujEIP1Lh/Pf3d52vyKCxYwU7+Bdx2UHVv9zz/AGdw3Xi1zzrCp82yRcZ7Jsi4KnnFZs0IQBf/HT+OLP+/p/vQHAAD//wMALd68530EAAA=\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUTY+bMBD9K4hruxV2IEBuq2576KGKmvTSaoUGe2jdEBsZs7tplP/esWHZdHtIijgw4zdfb545xkrGq7hTYjd0lciWOV/KZFmIOk0hKdNlkZWZyGteYlbU8dvY1L9QOApZhxDyCIvgUFbgvTzh/CZJbzjbsuWKJyuWfSPM0MmLmL2RSKcOe0dW78ANPdmD3mnzqMllsUGLWhBKD21LEUpXPq9TezzPy7dJsgpvyAtPV6BUX4EQZtCuAikt9lS7gbZHOtK9s4Nwyuh+HjwCFzXWaBdJY6wvQyHwAwnx/Z5IMbpRdg8+6LndOe9xJB2krVDWKeZJLViBjKEoQTQgWLOsRc4ZT88Zv53iL1P+Jox1Be8zUEMg5xOIXbTpwFrz6OuYfQf6QAcfoD+szbQZi+gYORdFEW1pNz1qGW1ezrhvtnMR95mFcj7BBnT00YIWqhdm2q+v+P6WjN+qo88yZUkeqtIWrA/6uiGz+2m0R2bzQ07cg2pnHfylHEHdK7QV8ajaUHxEEXdKonYK5sAGJVpoK0cS8SsZvaG1V74HtKpRAiYRHE+nl0KTbqbNT1fJUg7vOb7WNdoH5SUcf8YndwcHL+yRiuRdWIUYrFf5OP/d5W0XV1ywgJn6DXnXgdmx1f/8A5zBfeMVpmmWJwXpVpak5RxSWCCybMEww0Uh/v1pfPHznu5PfwAAAP//AwAJYULcfQQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -256,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb51625476f2e786b7dc00240023"
+              "value": "1a07d7cc6261843fe7799785000f40da"
             },
             {
               "name": "cache-control",
@@ -276,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"ddf2bc7ea949f8fa56ad247b391a9cf9\""
+              "value": "W/\"f720f27b043bed4b4d8cd1b7e07d18b9\""
             },
             {
               "name": "x-runtime",
-              "value": "1.156451"
+              "value": "2.379561"
             },
             {
               "name": "content-encoding",
@@ -292,11 +292,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -304,7 +304,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -315,14 +315,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:02.638Z",
-        "time": 1352,
+        "startedDateTime": "2022-04-21T16:20:15.414Z",
+        "time": 2861,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -330,7 +330,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1352
+          "wait": 2861
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/retrieves-a-pickup_3320623723/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/retrieves-a-pickup_3320623723/recording.har
@@ -173,7 +173,7 @@
         }
       },
       {
-        "_id": "487ad039a327205d845420b51de9d93f",
+        "_id": "40cc029a2c45bb9e7aceeb62dbe40cda",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,11 +194,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -215,7 +215,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-12\",\"max_datetime\":\"2022-04-12\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_36a544a7bc4c4a53b9991f9f5ba7f46f\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-04-22\",\"max_datetime\":\"2022-04-22\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_36a544a7bc4c4a53b9991f9f5ba7f46f\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -226,7 +226,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "[\"H4sIAAAAAAAAA5RUTY+bMBD9K4hru5XNGkhyW3XbQw9V1KSXVis02OPWDbGRMfvRKP+9Y2DZdHtIipBgxm8+/ObZh9SodJW2Ru76tsqWulhiXWuWSVHUuOAlX9ZKQVYuhFY6fZu6+hfKQCHrIYQ80iMEVBVEb8ay7IqJK863fLESYsXyb4TpW3UWs3cKaTVgF8jqAoS+I7u3O+seLLk8avRoJaFs3zQUYWwV8wazx9O82Zax1fAOeeHxApTpKpDS9TZUoJTHjmpraDqkJdsF38tgnO3mjScQEu2dDYlyzscyFAI/kBDf74gUZ7Xxe4hBz+3OeQ8j6aB8lavsGkRe1EtZco6yrhmA5LqgL1McTxm/meLPU/5m2NYFvM9ACwM5n0Dukk0L3ruHWMftW7BPtPABuqe1mybjEQMn5/VikWxpNh1alWxe1rLYbBuSLGaWJsQEG7DJRw9Wmk66ab6x4vsbMn6bln6XgrNyqEpT8DHo64bM9qezEZnPDzlxD6aZdfCXciR1b9BXGqRphuIjirgzCm0wMAdqVOihqQJJJI5k9A6tvfLdozfaSJhEcDgeXwpNupkmPx0lTzmi5/Ba1+jvTZRw+hkfwy08RWGPVLB3wyhk76PKx/3fnp92ccEBGzBTv0Pe9cDs2Op/3gAn8Nh4JYVYyKwUGlkuQEgQjLO8LAtWZsBB/HtpfIn7Pd4d/wAAAP//AwBr50RTfQQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUTY+bMBD9K4hruxV2CJDcVt320EMVNeml1QoN9rh1Q2xkzH40yn/v2LBsuj1ki0DgmTcffvPwMdUyXaedFvuhq+UScVWVrISK5csqr9gyYwVTKlP0rMr0bWqbXyg8hWxiCFmEQ/AoawhWnnF+leVXnO1YsebZmlXfCDN08iLmYCWS12PvadV78ENP68Hsjb03ZHKo0KERhDJD21KENnXI6/UBz/PyXZat4x3zwsMrULqvQQg7GF+DlA57qq2g7ZFcpvduEF5b088bT8AnylnjE2mtC2UoBH4gIb7fEinWKO0OEIKe2p3zHkfSQboaVSGLFUfBKmQMRQPlAgRTRSPKRorinPHrKf4y5W/itl7B+ww0EMn5BGKfbDtwzt6HOvbQgXkkxwfoHzd2moxD9IyMi6pKdjSbHo1Mts8+HprtfMJDZqF9SLAFk3x0YITuhZ3mGyq+v6bFb93R5ypnWRmr0hRcCPq6pWX305qAXM4XGfEAup118JdyBHWv0dUKhG5j8RFF3GmJxmuYAxVKdNDWniQSRjJaY2svbHfotNICJhEcT6fnQpNupslPv5KjHMFyfKlrdHc6SDj9jA/+Bh6DsEcqsndxFGJwQeXj/m8uTpuzyz/YiJn6jXk3kdmx1f88Ac7gofFacVhmi3zRFIrnDb1VkS1KiQzKSq548++h8SXs93R7+gMAAP//AwDyRCclfQQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -256,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb51625476f5e786b7df00240144"
+              "value": "1a07d7cc62618442e7799786000f41ce"
             },
             {
               "name": "cache-control",
@@ -276,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"9d4aa0da6a4544bbbbbf550f3f0089a0\""
+              "value": "W/\"e533a5008229c20bc72853d6246985f2\""
             },
             {
               "name": "x-runtime",
-              "value": "0.897364"
+              "value": "2.269433"
             },
             {
               "name": "content-encoding",
@@ -292,11 +292,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -304,7 +304,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb1nuq fde591f008, intlb2wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -315,14 +315,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:05.143Z",
-        "time": 1087,
+        "startedDateTime": "2022-04-21T16:20:18.289Z",
+        "time": 2765,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -330,11 +330,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1087
+          "wait": 2765
         }
       },
       {
-        "_id": "caff2d9e31f181cf8acff00e1d512550",
+        "_id": "16ec6f5117ee1b92b76e623373e5a49c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -355,11 +355,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/17.8.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "host",
@@ -370,7 +370,7 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_29f69ebbf02c46be81719bdda2784fdf"
+          "url": "https://api.easypost.com/v2/pickups/pickup_d5ee98717a8145848150161ff0fff097"
         },
         "response": {
           "bodySize": 732,
@@ -378,7 +378,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "[\"H4sIAAAAAAAAA5RUTY+bMBD9K4hru5XNGkhyW3XbQw9V1KSXVis02OPWDbGRMfvRKP+9Y2DZdHtIipBgxm8+/ObZh9SodJW2Ru76tsqWulhiXWuWSVHUuOAlX9ZKQVYuhFY6fZu6+hfKQCHrIYQ80iMEVBVEb8ay7IqJK863fLESYsXyb4TpW3UWs3cKaTVgF8jqAoS+I7u3O+seLLk8avRoJaFs3zQUYWwV8wazx9O82Zax1fAOeeHxApTpKpDS9TZUoJTHjmpraDqkJdsF38tgnO3mjScQEu2dDYlyzscyFAI/kBDf74gUZ7Xxe4hBz+3OeQ8j6aB8lavsGkRe1EtZco6yrhmA5LqgL1McTxm/meLPU/5m2NYFvM9ACwM5n0Dukk0L3ruHWMftW7BPtPABuqe1mybjEQMn5/VikWxpNh1alWxe1rLYbBuSLGaWJsQEG7DJRw9Wmk66ab6x4vsbMn6bln6XgrNyqEpT8DHo64bM9qezEZnPDzlxD6aZdfCXciR1b9BXGqRphuIjirgzCm0wMAdqVOihqQJJJI5k9A6tvfLdozfaSJhEcDgeXwpNupkmPx0lTzmi5/Ba1+jvTZRw+hkfwy08RWGPVLB3wyhk76PKx/3fnp92ccEBGzBTv0Pe9cDs2Op/3gAn8Nh4JYVYyKwUGlkuQEgQjLO8LAtWZsBB/HtpfIn7Pd4d/wAAAP//AwBr50RTfQQAAA==\"]"
+            "text": "[\"H4sIAAAAAAAAA5RUTY+bMBD9K4hruxV2CJDcVt320EMVNeml1QoN9rh1Q2xkzH40yn/v2LBsuj1ki0DgmTcffvPwMdUyXaedFvuhq+UScVWVrISK5csqr9gyYwVTKlP0rMr0bWqbXyg8hWxiCFmEQ/AoawhWnnF+leVXnO1YsebZmlXfCDN08iLmYCWS12PvadV78ENP68Hsjb03ZHKo0KERhDJD21KENnXI6/UBz/PyXZat4x3zwsMrULqvQQg7GF+DlA57qq2g7ZFcpvduEF5b088bT8AnylnjE2mtC2UoBH4gIb7fEinWKO0OEIKe2p3zHkfSQboaVSGLFUfBKmQMRQPlAgRTRSPKRorinPHrKf4y5W/itl7B+ww0EMn5BGKfbDtwzt6HOvbQgXkkxwfoHzd2moxD9IyMi6pKdjSbHo1Mts8+HprtfMJDZqF9SLAFk3x0YITuhZ3mGyq+v6bFb93R5ypnWRmr0hRcCPq6pWX305qAXM4XGfEAup118JdyBHWv0dUKhG5j8RFF3GmJxmuYAxVKdNDWniQSRjJaY2svbHfotNICJhEcT6fnQpNupslPv5KjHMFyfKlrdHc6SDj9jA/+Bh6DsEcqsndxFGJwQeXj/m8uTpuzyz/YiJn6jXk3kdmx1f88Ac7gofFacVhmi3zRFIrnDb1VkS1KiQzKSq548++h8SXs93R7+gMAAP//AwDyRCclfQQAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -408,7 +408,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "0991fb53625476f6e786b7e0002401b8"
+              "value": "1a07d7ce62618445e7799787000f42b3"
             },
             {
               "name": "cache-control",
@@ -428,11 +428,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"9d4aa0da6a4544bbbbbf550f3f0089a0\""
+              "value": "W/\"e533a5008229c20bc72853d6246985f2\""
             },
             {
               "name": "x-runtime",
-              "value": "0.080603"
+              "value": "0.038409"
             },
             {
               "name": "content-encoding",
@@ -444,11 +444,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202204082123-da17cc1ac2-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -456,7 +456,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq fde591f008, extlb2nuq fde591f008"
+              "value": "intlb2nuq fde591f008, intlb1wdc fde591f008, extlb3wdc fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -467,14 +467,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-04-11T18:44:06.239Z",
-        "time": 271,
+        "startedDateTime": "2022-04-21T16:20:21.060Z",
+        "time": 504,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -482,7 +482,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 271
+          "wait": 504
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/refunds-a-shipment_2011747091/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/refunds-a-shipment_2011747091/recording.har
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -44,7 +44,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 502,
+          "headersSize": 500,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -56,12 +56,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2215,
+          "bodySize": 2230,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2215,
-            "text": "[\"H4sIAAAAAAAAA+xYbU/jOBD+K1W+HrR+SZyk33q86NjbBZZyx8FpFTm20wbSJHKShbLiv984L6Uvy1KJveV0C0ICj8eT8TyPZ+z5YgmteKlkwEtraBFEyC6iu5idEzSk3tCmV9aOFReBVmWlU2sY8aRQO9ZMFQWfqMIa/v0JRplUsLpURQnaWV7GWQpTXyxRaa1SMYfJP8b7MJfz+UylpZkr57lZND443j84sx52LAl+BFx+5qmACQQSrSJl1sMwrZJkxypKXlZg2arSmzS7TcFiqbm4idNJIBonfBshbH59yjD8EA/5rg+KVS6/tVHbbDTkpZgGsey+14y7ry7L2gB0QlEVZTYrgjiNsk4W6WwG+5EaVM2GjVmLSx1g4rDI45Q7zMdYCe6riAscsVC4oRTMxDC8VsI4OmrX7zwL1C8IDRF6fqOPiimfmYi9gwD2xjnXOrs138lmOU8NZAe8mJ9mNaZFqZUqMQip5/XOIfSFSmVv/DhHjLN52SPGsohLY2DM096hBjzjQmRWA5/54t4IBvdxXsOFkVt/tUpL3RDF8GSapUbTWfyAUM14nHTRXeWcAO9jpQOIY5zUH2+0IHaxBMLFfLEwUlJpngQlv1tCunZtTfZZ6TiKBe/o/ACUjNOi0g1DLQf16zhmGiwurYNQCpUsIM+1SALsSYIl4rATanOPcuUhHlGBXI9IzMUy5qfN+uchv9oCbaOTqHRSTq0hBod3rNtYmoFn/p+qeDKFlbYZ5BpCE8UpWMuBE0v0vm3VsNO3V0MPIcmBIqAbJDxsdv24kWbmfT2x00YjCYDnnpKwfyakTYQdMol84WPP5ZGtKHt+5/YWO6911nKKwa9UE12vizI9g5WpYRrEyDgZyIagT1hrdIBTWVIZUlhDilAnLuJ7s9S+YwvNNsVBUHmVlAtxFCeqm4tnEKBBnk4Ws5WGIFrTssyL4WCg4AyaAO+aRUW/oP2q2L2FyO+SPp/x+yzlt0UfzuygVhisgDEw+0AUs4ET0ogz5lHGsI2Y73vKcWkkHSYFZEjWX/Ygl1HjRQN+I7zPk02hyhOyKTWeNBKTwyGipky0h8EMA08pxRzX9iQNbT/yQjgVTDgRomFoIydcPgxnBpHvR4jVtFEo/Tmuz/JhrJcTSZ2HTk0m0g0jgPimiGwUNKiLkJSCVa1WuKGcxEW5plqLNhSlSmLIPnPg4xyCR1Yk5eJYrgiDScUhM5VKyUWZhl0Gm7aKaZybKlynLBjlQSRRiBwc+hFhduTaPuEMkhTGHpQpaqOlDMtFnaqbtYIHTshdwSmjRDg2lyrELpd2KKCgUeH5CDLEMvSCOaHPWQiHP7QFcjwX29hzOHWwRwXHrwD9wV3eldgnwCe07zrPo0/cfh2qbeDvTG6F/1fQfgkF2or3iixgEfUQdn0Whr7N/ND3XLgGuRz5YShCyl6BBU3RHavEfPVpKrh9Qp5nQqu1DRFa1Z8tD9AQLkQRERQrZCMJI8/2GEKE+5Irn74GA3ScaXN3/Bb61H0efa/vbpsGWoNboY+/I/r4h6P/qX7OValce04VgqftVawV1EcQMGxC9HZv+GnvDc3b3gS1JUGpbwIRqZAoQSShwnYk9gWKfF9GDFMlsL1SOs7b9evwbd0z+Eq/oRFBdMr6Mbo0872oVsQT8wQL5+uvr2a0hs0jqi+B55G3i9g0O2w7PJHqej0dnl0A2idvFSaxWHu71Kb63QumfqTI6wMmf3un/yLHs6uLo/nVxYf51f7R/eX9R3y1f+Bc3v86OzlPbq6uL+8+kD+vP5x/JDUTsqc6KQ5yXb/rpHieSxadFMrIv9tJsTc6KaO933vj09HZ2cnFaidlNL48PRmfb3ZSTi6OTQesNz7vjU7Pm+7JoqHS9pbaZsrouHd4NjreOxrvnXyjmQIO1uXnR3RUSl2pl3RUjN+2+VtUQtTgNhaV1pluCbfgYfug7Li/7bIv8Cot47Iym6Nu33UdB6pfkqWTVriLCelTn/ku8CyeqeC+idRoBt4KPnifFcEonUBZKqyHB9MEqoq8aLVwnbUrnb51+v5nnb6wmpuy9ZZ13rLOfyPrmEvyajlearUeKnPbbZuKdcO1kfCZAQRkpleNatqIKdcTc9lr3G9u5YvLn3mmfd1q281ds2vuoy+ze9S11Dc8Js5Wlj+1reUtrzwLL8bthcl6+AcAAP//\",\"AwA69lsnBxsAAA==\"]"
+            "size": 2230,
+            "text": "[\"H4sIAAAAAAAAA+xYbW/bNhD+K4a+LnH4old/M/KCtWuTNPbWJUMhUCRls5UlgaKaOkX++456cWynTQykS4ctQYBEx7sjec/DI+++OlxLZqSImXFGDkGE7CN3n+ApoiMvGKHoytlzVBVraWqdO6OUZZXccxayqthMVs7orw/wVQgJ1kZWBrSL0qgih6GvDq+1ljlfwuDvkyMYK9lyIXNjx8yytEaT49Oj4wvnds8RsI6Yic8s5zCAQKJlKq09fOZ1lu05lWGmBs9OnX/Ki+scPBrN+CeVz2LeLiJyEcL2N6I+xtiLAuzSCBTrUjywUYzsRhNm+DxWop+v/e5nXZd1AeiFvK5MsahiladFL0t1sYD9CA2qdsPWrcOEjrEkacBZyDEJMJY8oTRlHKd+ghgSWNoYJh8ltwsdd/Z7jwL1C0IjhB7d6JpizhY2Yq8hgINJybQuru08xaJkuYXsmFXL86LBtDJaSoNBSMNwMIXQVzIXg8ndGLGLLc2AWM9cGetgwvLBiQY8VcULp4XPzng4ho8bVTZwYRQ0s9a50S1RLE/mRW41vdUPCOWCqayP7ibnOKxeSR1DHFXWTN5qQeyUAMIptjJMpZCaZbFhX9aQbpa2JfsstUoVZz2db4GSKq9q3TLU8dCwiWOhweOaHYSSy2wFeal5FkcppS4LJfUpdxnlkcSun6bSRczzXZysY37e2j8O+dUOaFudTOYzM3eA5EO051wrYT9C+/9cqtkcLF37UWoITapy8FYCJ9bofd2pYW/oboYeQlICRUA3zljS7vpuI+3Im2Zgr4tGFiMUpSlOBYfpXBHyJOIsTSMauDSVjKNHd94e1l0O9FZOsfgZOdONXVroBVjmlmkQI7vIWLQE/Y63Vgc4VWS1JYUzogj14krdWFP3i7/S7FIcBJU=\",\"1ZlZiVOVyX5MLSBAB2U+W43WGoLozI0pq9HBgYQzaAO8b42qYUWHdbV/DZHfJ0O2YDdFzq6rIZzZg0bhYAOMA7sP5BJ8kOKIShpGERDPDXwv8UTEqJcwiiIS+mi4voJSpO0qWvBb4U2Z3RfKMiP3pXYlrcTmcIiovSa6w2A/Yyk4pTIkaZS6LseCUTeB4+Bi4gIXfLJ+GC4sIj/uKGymjUrqz6o5y+daFdomjlUuaVLRuU1GuiVFMKRNptq+0+BqhLwUd1rhMEB3wnvKmapMvOmwEd1TFDJTkICWQMklxA9vSMzqZG4I41nNIDkZKcXqpoaNxvd9VXNV2ou4yVrwVcaMCl+kfoAFgnPoeSHzsCdc5gdBGPg8XEuyjDfZurXlLAYawXUGmY1wz2VCJjhgwk043GmUhxGCJLGOPks40M9LIh8gp9hnkU9CESUBTbn0m/vj2dFvMu5EZnbWhxhAyOMM6LR2Y0CjuhMDyA9kAPm5DEhS4nFEJXF5ACc+imhEgoBRFkVhgrj4CQw4Ubp6CHq4+KLHoe+0doG+U/2/QY+TAF6/cPVjItzU9yMf5koCDEkhwDKiPwH64y9l/8T+DviEDgPvcfRJMHR3zf29y53w/wbaT6FA9+J9XhZ8aMq5Ohdb5VTFWd49xTpBk4UByzZS/2je2P0h+ZI3nj9vtLW9DWpHAqM/xdiTyA+jRFKXuyQkIROIQA1tDb1EeOscmHb22/Dt3DP4Rr+hFUF0TFOMro38KKpVamZLsGS5XX21X1vY3KH6FHjueLuKTbvDrsOTyr7X0+PZB6AreeskU3yrdmlcDfsKpilSxMdjX/z6Wv95c4yvpmNydpSpq+lbdHnzbnl29Mq9fP/u+u3ij4+Xi9P5JehcLt7hhgnF9zopgmIuV50UDsV100nhQUI3C4nn6KSMD38bTM7HFxdn7zc7KePJ5fnZZHq/k3L2/tR2wAaT6WB8Pm27J6uGStdb6pop49PBycX49PDV5PDsgWbKPvabCuQ5OipG1/IpHRW7btf+rWrOG3Bbj1LrQneEW/GwKyh77u9q9hWqUqNMbTdHg2EQeB4UQFmRzzrhPiZkSCM/CoBnaiHjmzZS4wWslrODN0UVj/MZXEuVc3trm0B1VVadFm6ydq3zl07ff6zTl9RLe229ZJ2XrPPvyDr2kbx5Ha+1Wk+kTSZdU7FpuLYStrCAgMz2qlFDGz5nemYfe+3y21f56vFny7Vve+26uVt+7Xv0aX5f9S31eysm3k6eP3St5R2fPKtVTLoHk3P7NwAAAP//\",\"AwCjy001BxsAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e162324ad3e78a7a48000e4687"
+              "value": "f6c5a4e76260d615e8eddec5004e2d9f"
             },
             {
               "name": "cache-control",
@@ -107,7 +107,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_fd0b051b9f264f7492a6a831188a3340"
+              "value": "/api/v2/shipments/shp_a3d6df671d0743558a515d4a677876c8"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"3bec54c4174e4fb5bacd0db9ed3c70db\""
+              "value": "W/\"723941bd446eb279db1d6cdb3cb2dff8\""
             },
             {
               "name": "x-runtime",
-              "value": "0.942894"
+              "value": "1.189989"
             },
             {
               "name": "content-encoding",
@@ -131,11 +131,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -143,7 +143,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, extlb1nuq fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -156,12 +156,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_fd0b051b9f264f7492a6a831188a3340",
+          "redirectURL": "/api/v2/shipments/shp_a3d6df671d0743558a515d4a677876c8",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-03-16T20:38:43.655Z",
-        "time": 1155,
+        "startedDateTime": "2022-04-21T03:57:09.359Z",
+        "time": 1382,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,15 +169,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1155
+          "wait": 1382
         }
       },
       {
-        "_id": "0da87d573e540aeb6c811bb559278e83",
+        "_id": "5b5d844082458a16fd02b9af7ec1de6e",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -194,30 +194,39 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 525,
+          "headersSize": 542,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_fd0b051b9f264f7492a6a831188a3340/refund"
+          "url": "https://api.easypost.com/v2/shipments/shp_a3d6df671d0743558a515d4a677876c8/refund"
         },
         "response": {
-          "bodySize": 2623,
+          "bodySize": 2627,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2623,
-            "text": "[\"H4sIAAAAAAAAA+xZW2/cuA7+KwO/7mQiW77mbTZJ0ey2SZqZ3bY5KAxZkidqPbYhy00nRf/7UpLtzKVp5qC3g7MNAiSiKIn8SFEk/dGhkhPFWUqUc+R4yPMOED5ww7mHjnB85ONrZ+yIJpVctbJ0jnJSNHzsLHnTkAVvnKP/vIFRxTisVrxRwF3VSlQlTH10aCslL+kKJv+ancBcTVZLXio9p1a1XjQ7PT85vXI+jR0GcqSEvSclhQkEFMlzrtfDsGyLYuw0iqgWdnba8l1Z3Zawo5KEvhPlIqVWiMRHyNW/CQ5d+PFilEQJMLY1+5KigVY0I4repIL159lxf+o6rQOgJ9K2UdWySUWZVz0tl9US9GESWLXCeluHMJm6XhDmMcEkCBPX5ZQkPCfUzcOMRhmjocYwe8upFnTarR8/aqjfEDpC6HFF7xlLstSI/QEAjmY1kbK61edUy5qU2mSnpFldVsamjZKcKxeIOI5Hc4C+4SUbze7nPC1srUae3pkKpTeYkXL0RII9RUMrx5pPn3g8hcGdqI25XBSZU9tSSeso2k9uqlJzBsMPEPmSiKJHd9PnKEgvuEwBR1GYwy0XYCcYOJwgw8KcMy5JkSryYc3SRrQt2nsuRS4o6d35E7ikKJtWWg91AjQxOFYSdlxbB1BSXgwmryUtUjdmnssQAU2wT2JMeIxIjimKYo+5hK7b/NKuf9zk13tYW/MUvFyoG+fIBYHHzq1gehDr/2+4WNzASl8PagnQ5KKE3WrwiTX3vu3Y3GDib0IPkNTgIsCbFiSzWt8rYmeemYlxh0aRgp/HnIH+IWW+R/0sZCihiRtHJPc5Dh/X3N9Dc8OzFVO0/RRfSLMur+QSVpba0wAjLWTKrIM+sJvlAZ+qilY7hXOEEerJjbjTS/0P4cDZhTgAlbSFGsi5KHg/J5YA0GFdLobZVgKIzo1SdXN0eMjhDmqAD/SiZtLgSdsc3ALyB96ELMldVZLbZgJ39tAwHG4Y41DrgbAbHgYZzkkYxjgMXR+FSRLzIMI5C0JGIUKGk3UJapZbKazxLfGuLnaJvC68XaqWxFJ0DAdE9TPRXQY9TGPOeRhEfsxw5id5nMGtCGmQI5xlPgqy9ctwpS3y7RxiM2w0XL4X5i4/EXI9kJg4dKkjkbQeAY6vH5GdBw3eRQhK6SZXR9xhLkSjtlgNaYeR8UJA9FmBP64APG+DooZruUFMFy2ByKQ4Z8MzDVqmu3s1N6LWr7AJWTCq05yhDAVuluRe6OeRn3gkhCDlujE8U9hHaxGWUBOq7VpK0iAjESU4xB4NfMJ45kaE+RmFBw3TOEEQIdZNT8MgS0iYweXPfIqCOHJ9Nw4IDtwYU+L+BNOffqj7J/YB43t4EgWPW9+LJgaqfczfb7mX/T9j7a9xge7F+4leEOY4Rm6UhFmW+GGSJXEEaVBEUJJlNMPhT/AC++jOeKFPfdgVoonnPe4JHdc+jtCx/tviAM4gIco9il2OfMRgFPtxiJBHEkZ4gn+GB0hRSZ07fsn6OHrc+vEk2jcMdBvuZX33G1rf/eHWf2PKubZkQznlNG22FArMpc1ASdllZF14MjcRTGmR+pU+/GvTB1via1A7J1DyXUpznnmceszD1A+Ym1CUJwnLQxdz6vobL8i8W79tvr1bB4PHQqKQwqqyEWogA0LK1KX92PrRN3S6Rix0TZattssxO9qy0pcKmK8x3b1PD7hZzW12v4k2zJ5YWIZekYmw/GDWiTA6K/NqNNP/qWrU7cx4Q6WobW211fL577DXf5RY3mPh7WBRtdLc3e7s3kOtM9jDB02LyrYBNsrbXtNn/WTf+FhrKQwNor6/YYem+WEqJP0s7oOdxq2GqZGppkfH1re+O2bRHCVQ9n9/zJynF3/N5hfna22i+Svn88A5UYRC7HzSj0rO+y5kL0yv39qpx3ZqgHUrcB8cF6RpRpe26QFOaWf14SWsKGFTW64/cOGMqsVnpzWem9OQYyxEuYZOr/lo/mo8As2QKYIs1w8E03iSEqXZaV2846fTq2enRsLZ8XjkQZh0nU3uz4hpT7h/VLZDlJ0nheKy1BDaNl1uAo2dE6XQfbv7hQRyhWWthtZC3WaFoFsNEyPKpG+bmM4Ie3sasqd/yFfe+fL65dnq+uXz1fXJ2d3ruxfu9clp8Pru9+XFvHh3/fb1h+fe32+fz1945t2pHmrfBiiKkr59G8eRN7Rvceg537V96++0b6fHf45ml9Orq4uXzkb7djp7fXkxmzs77duLl+e67T6azUfTy7lt2Q5d3C5edR3c6fnoydX0/PhsdnzhPNzBBQFNzvsj2rhKtvxr2rhabl//bVpKjXHtjlzKSnaxZHjZOlfrfXDfZR+dAs5TrVYOR5MoCgJIuYuqXHTEA9fzJjgJkwj8TMeIO4vUdAnSUnL4rGrSabmAJLiBOKc7z21TNx2Xa3LEVpa/Pi/8n31eyNqVTpJ/RZ1fUed/I+rokrw7psu01vKPJ1wnSd2XDJOXWgpZaoMATX8gQ8Zt6A2RC11aWvFtK2AoNTeS4I1du09IW/vq6vfr9j3rv+PtSOwFe+38pvuetWcRNUjR1z/Op38AAAD//w==\",\"AwBxhbppfB8AAA==\"]"
+            "size": 2627,
+            "text": "[\"H4sIAAAAAAAAA+xZbW/bOBL+K4a+XuyIol79zUhStHvdJI2916aHQqBIymYrSwJFNXWK/vcdkpJiO03jRbvp4q5BgITDITl85uGQM/rsUMmJ4iwlypk6nut5Y9cfe2jh4mkQTd3krXPkiCaVXLWydKY5KRp+5Kx505Alb5zpf99Bq2IcRiveKNCuaiWqEro+O7SVkpd0A51/zE+hryabNS+V7lObWg+an52fnl05X44cBnakhH0kJYUOFySS51yPh2bZFsWR0yiiWpjZacsPZXVTwoxKEvpBlMuUWiMS33WR/k1wiBAKkgj5OAHFtmbf2ChCeqMZUXSVCtavZ9v9qtuyDoBeSNtGVesmFWVe9bJcVmvYD5Ogqjesp3UIkyniXh5RElPkRQhxmmGcE4ryMHOJyxDXGGbvOdWGzrrxR4866l+uO3XdRze6pViStUbsNwBwNK+JlNWNXqda16TULjsjzeayMj5tlORcIRDiOB4tAPqGl2w0v+vztLG1Gnl6ZiqUnmBOytEzCf4UDa0c6z694skMGreiNu5CbmRWbUslLVE0T1ZVqTWD4QeEfE1E0aO7yzkK1gsuU8BRFGZxqwXYCQaEE2QYmHPGJSlSRT5tedqYtif7yKXIBSU9nb8AJUXZtNIy1AncicGxkjDj1jiAkvJicHktaZEmOcY+iTkOMfUJpglHfpjn3HdJEPoo2/b5pR3/uMvfHuBtrVPwcqlWzhSBwUfOjWC6Eev/V1wsVzDS141aAjS5KGG2GjixRe+bTg0FE38XeoCkBoqAblqQzO76biO256XpOOrQKFLXTfIc5YzCcj6LaZZQkucJjnycc0LdR3eO3Md3bnX2Yor2n+JLacbllVzDyFIzDTDSRqbMEvSB2awOcKoqWk0KZ4pdtxc34lYP9T+Fg2YX4gBU0hZqEOei4H2fWANAx3W5HHpbCSA6K6XqZnp8zOEMaoDHelAzafCkbcY3gPzYm5A1ua1KctNM4MweG4XjHWcc6324vg==\",\"h45zlGCO4yQB4vlRGGQBSwgOMoLdxItDd7JtQc1ya4V1vhXe1sV9Ia8L775UW2IlOoYDovqa6A6DbqacUYx57OVJ7vsUMYL9DI6DjzwfuBB624fhSnvkxx2F3bDRcPlRmLN8KUUldeAYYokJRZc6GElLimiCTaTav9PgaoS4lHZa8SRy74T3lAvRqHR3QiO6p8h4ISAAbYCSG8AP7UjUcDJ3hOmyJRCcFOdsuKlho+n9uZqVqPVFbKIWtOqUYBayPIwQc+EcBkFMAhQwn4RRFEchjbeCLKEmWtuxlKRAI7jOILJ5NPAJ4xmKCPMzCncapnHiQpDY9j7JKNAvyJIQXI5RSJLQi1mSRTinPDT3x5N730TcOS/0qt9igOc9zoBO6zAGGNWDGOD9QAZ4P5cBWe4F1MXc82kEJz5JcOJFEcEkSeLMpewnMOCZkM23XA8XX/K46zutQ1zfqf6/uR5lEbx+4epHHvPzMExCWCuLEASFCPEE/wTXn32q+yf2A8738CQKHve+F038Q2N/P+VB/v+Kt7+HAt2L92lZ8M6kc23JhnTKadpsLRS4TbuDkrJ7kXXmmWAMLrWA/a3h4/D35K/w8fThw6b4GtSOBEp+SFHA3TBOMo596nuxFxPmepBK64FBxoJtDiy68fvuO7h0MDAWAkUKo8pGqEEMCCmTl/Zty6MfSLpGLHVOlm320zHb2vPStxKY73HdHacH3OzO7et+F23oPbWwDLUi88jm43lnwuhFmVejuf5PVaNuZsYbKkVtc6u9ks9fw17/UWJ9hwW+h0XVSnN2u7V7hloy2MWHnRaVLQPspLf9Tl/2nX3hY6ukMBSI+vqGbZrih8mQ9PV4CHYatxq6RiabHp1Ybj0BZiicYv/vx8x5fvHHfHFxvlUmWrxxvg6cE0VuiJ0v+lLJeV+F7I3p97e16ontGmDdC9zjk4I0zejSFj2AlLZXL17CiBImten6AwfObLX4arfGc7cb0sylKLfQ6Xc+Wrw5GsHOXOQMWk8IpmGSEqWZadu8k+ezq5dnxsL5ydHIgzCJnF3tr5hpV7i7VPZDlO0nheKy1BDaMl1uAo3tE6XQdbu7gQTeCutaDaWFus0KQfcKJsaUSV82MZUR9v4sZM9/k29uz9Dbxcy7OC3E28Xv7vXtq83F6Qv/+vWrm9/X/3l/vT5fXYPO9foVMvdO9VD5lmFE+VC+pdS35VsaZXi3evEU5dvZyb9H88vZ1dXFa2enfDubX19ezBfOvfLtxetzXXYfzRej2eXClmyHKm4Xr7oK7ux89Oxqdn7yYn5y4TxcwR2j0JQ9nqKMq2TLv6eMq+329d+mpdQ4187IpaxkF0uGm62jWs/BQ4d9dgpYT7V6cziaRFEQIHitVeWyE46R501wEiYR8EzHiFuL1GwN1lJy/LJq0lm5hEdwA3FOV57bpm46LWTeiK0sf31e+B/7vJC1G/1I/hV1fkWdf0bU0Sl5t0z30tp6fzzjOph0XzLMu9RKyFo7BGT6A5lraENXRC51amnNt6WAIdXceQTvzNp9QtqbV2e/3zfvi/473j2LveCgmd9137MOTKIGK/r8x/nyJwAAAP//AwCwyhJofB8AAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e162324ad5e78a7a49000e46ee"
+              "value": "401d18da6260d616e8eddec6004c0231"
             },
             {
               "name": "cache-control",
@@ -267,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"e2e234d66faeaea8569683ad06d2b508\""
+              "value": "W/\"d09b3eef7e44f3f5748d44051731a09b\""
             },
             {
               "name": "x-runtime",
-              "value": "0.143506"
+              "value": "0.145159"
             },
             {
               "name": "content-encoding",
@@ -283,11 +292,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -295,7 +304,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb1nuq fde591f008, extlb2nuq fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -312,8 +321,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:38:44.817Z",
-        "time": 353,
+        "startedDateTime": "2022-04-21T03:57:10.747Z",
+        "time": 284,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -321,7 +330,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 353
+          "wait": 284
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
@@ -29,11 +29,11 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
             },
             {
               "name": "content-length",
@@ -44,7 +44,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 502,
+          "headersSize": 500,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -56,12 +56,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1814,
+          "bodySize": 8599,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1814,
-            "text": "[\"H4sIAAAAAAAAA+xYUW/bNhD+K4aeNswNKIoSJb91bTp0D11Qdy8bAoEijzZXmdJIKalb5L/vKMuKnaaLhwXI0NVP4vHuSN733R3pT5F0IDpQpeiiRUQJpc9I8izO3lGySPJFwn+L5pHxpYOudzZaaFF7mEcb8F6swEeL3y9x1ChA6w58h9pN25nG4tSnqBYV1KVu3GZwf/Hmp+DNXjVGQmn7TQUOxTFNUCx758DKLQp+Xb5EQSu2G7Bd8NNt27DA8vzNy/O30c08UrjnUqgrYSVOEJQ40BDsYXLoO9H1uI2ot+9tc21R1Dkh3xu7KuWwY9vX9TzqW/VgBCrRyXVp1N5mN96vcCgbI7MXyt53zcaXxuomnCS4iKTvwrhMRcWAxlKlTDFOiOBVxmma0lwkRcGzEMzqD5BhYy92jl4HP/OTUDvlXLKxHcbYl/ChrYUVATnUPpwZY78BJ9fCKuMhuj2WBNcZjZh1rodbsTcrO0C77OAKZj+6vg5WgGRotUT5m1/Oz1/PEnKW8O/E9zhlG1sqqM0VuG25YxCqjawL6PrOGRnEiN0m8GKK++HcuFn0FtY75qUCWQs3HvEOOh1sApcP8EFJSQGKLGOJAMZZSmleAI8TwpMYMpIRdh8+aPeI+Cjw0pl9OJbXAN3Mr43D08+jNYIjnNH6NpWylCU0DvtyZmVCrHrbuV1OofTPXlg8Go7pPLoSdR/CQ5MzmuLkNZjVGvcSx2ck4H+bIcdx3AjbayERmbDkPpD75N2NQcopyK0zNpwz4NYoXB3zCPEz2uztby4xgbVrNpjSCuH0U6YI5UoCecoo0yLNijgGWeVaCRnrrJKcxvQIheej/cMI/EDIgpATYJgUrdiEKPyMJWS2bIVzzfWQJ5tW2BDhc+G3F80QIiQkIhWjMMnz2Ts=\",\"LD4erJotb+do2GzbzWjwLAdIoqWws1cOS5rxshkLWFjxxXMcfDQtfhYsJnxY9QjXdh0Iv4jS6ReybSNMfT+EEneP0S8RRlMPi0+ptMNGTIYaFDhRI9M+HNS/YWt3ZJi6iKkU++p/cxNqve/drkjvlBqH7g6MMI4S6gnv1knsFzxRCjjXSSwYSJHnuqIqzyv8jgGOAL/Y2T9extVgV90as4CELLg2Kgzy8L0e84OFQeswLtpY9NYiIQ4q/pRG6Rk7jjvGo0V+oG45NMYp6ripg+oThqVUuaqwxICgklGgeZ4InhUVZwVnRB3F4G2gyeNF4JgqHtyVGbrqK+MOyTNw7yKwz+1oiuct7uvjWMSRiOWx1ij8TLk2vrujOog+U5yahRJbP9SzA0k3oXEkLFc9NgAsRqCmmwyesvzcF9bYNjSZgak4asuYgdaJ5oxJxoqYiyqFNIE8Bq50lvKDrBJySM+drRRlWgkuRZIlVKZMKKjQWrFKYhFLZF4QJMYh9IUqZEEqIDzNmYzzPKN5prMMqiTNkyp+AujPP7T7svoF8LGJ8PRh9Ck/Y+RE+PcuT8L/HrT/DQXGKveELMgy1FeaSUqAsThD8FNFBJEpR36I6glYcOEMXiuwW3yZBhwvdA+zID/jp5JgdHgSB+JHJED8tOinSVKkKpNFlVZMx6RAM6V1mnASZ+xp0B867RLqsOrfMYDShxkwap3GgEH1f9AFLodXbG/VnYell8IOj+hJMICAOLqDMw5v29sbedd86TKdMCiq/WVaFLneX6YrJY+enN8u0/+ty3TvW19+HDYXz8e38bcX01cGctVvQ/H4lrpfFaqheo9/lmrY/236T7rKhOxy7EnRzV8AAAD//w==\",\"AwAU2hLLvBUAAA==\"]"
+            "size": 8599,
+            "text": "[\"H4sIAAAAAAAAA+xda49kt3H9K4v5lCCywEeRLO43x5YDB4EjeJ0vCYRBkVXUdjzbM+mekSwb+u851TM7u5Ila4MIVOBYEKTp2933sutx6hw+/3Q1Tyb3ptdyf/XyKoWUfhboZyn+LuSXqb4M+d+vPro6nK9Pdv9wOl69XHJzto+u3tj5LJ/b+erlf/zpasrpdLATvv9vn77Cx59eX8uctw/H++uD4q0p11YbBZ2de65Eq3AviWVoTZK1quGr91/dGT58QpOu7XS6PV09PwuXf338Qm4O+uLnc+Lai385TDue7cXx4c3A47/+6MObklOeEpetVie1WMZQxt8r6Qg52tjYlKpRZfSwclRqsEWp2VrtKwQrtdSNTUlNktLsLdGkpZnDaBY1ZOEhhddOq2QlrmXxipOoUi/Uuq1gRMPMZGNT5iKWxksJDpKZOM6yNNUaZLGttLEpLCqWl2mxSYhapkxaS0o2clUNG5sSVuMinfOIg7Q15lDjmsNCmp3qzqb0YjRz61MTAAbemn2yGjIqyBjUNzaFtAjHNFrLaEqOwJUVrS6bSkFsJ8TNOVKNkXLRTLLaoFgrow2InxBX24krMktUm2IqlOoUChR51DIpFOK8sSkLQJLJ5mhVCDHSYaRSkEE5a8xxZzKXPldZGVVxCeUQpGo11B5klI2xFfhbgxFUJAULlId1JHJHGUIaLSbaGbaLazBT4w7gNxlODQZr4iWA3Mk7kzn3GWsaAZFCwqsP00iJiKaCOewshzDF7LpKbLQoRUSteBlAZUSC96obmyKpgCNNsITKVFPrIpFmy4C7ZYV3UqcQyCIngHzG4xUBDDrJIE3WQh2TdtYgwDuBs5iHR+wTNTEkbiuVgBbWrdwWRhld8ijLqK/IqqO0RTYi8IbLToirpfdZEtgkg1I2JNEI4Curs1KWuJM6jYSqN70YN6o8mVMI0WCjDuI9dwI/6h7ukQsoC1GJWbKtOgZH0Cb4aCfEdTCmPkadjSeVQh3RWs3L0QoMiNnYFAU5WYuCgbZRQnnWMNkLIbRQ1LizKT2OEGlQkdnAban3IpWaUtKJMrCzMgeuEVqwpRE71KGwsuWWUBx5zTR2hm3QNGcda6QEjt0hPlJhxC0IP6oQ7WT8MSFIEBiuPlB3lPNKFueISWXNrbgCvhYkjBISQiSDNvUkC2Q3LpocZadQZQMr6KGNWQO1HIWD5ZgrhFkeY2xl/EDbTF6DV6LsjtI2UZfrIC4977QKMLVOG2VAsIJFlQ5KCeJtrK2OzDupUy0D8Lpgl5qIjcfMgN1V11pSSt2ZzLEz1z6aSiPqzWT1jkb0OiCGsu4kCVyLogoHCNZG05hnQPmpFNegUXlnOYygtAuSjOwStvBOUs0qWhPkYt+ZQTLgFQXJrqBOMXdppXIg5w2929ZODbBZnm3F0gZYWySU45q6zDhGyqY7HTQTiYHsG6dEqNIjaExgMGC6rYyxk2bj92ceujrUOkSZdh5Sm3lnXAP+7qxBgPgs0xUIaDUPE4hnCgC+Bj4Hh+3sSSB18V4jkATiY/RcFkQ8tDzU0IhbrQLiNAqziQySZKMDTgTScClkCe0M25TD4NEB/VOotsVTEMR9hRIXStBOtI1R4Rhoj1w7QffwXKsPkExFcS66sxyiKs8SZpkg29DOIqH2yWgduHapYadVcs86A4OpgLb0KRKbVhvBaDja7UTblg1ctkxhzkR1dlQkaqmU0iLq81ZCGbKVaR2FR2l4j22etWZk+OwKjNmpDgdZDEBZM+9CJgHxn3OFPDiH1HaGLbA+koUwF2VKKXGyCaMomsNRt+qgEgfNbuC3IRADZ9WkBKLSupK1nRDHvYw8U0iXbskCXdhtxVG9YZHzTm6bowL156TSC3EFxbWUXaWhPkvbWg6hUVu1lbWTIF6hDjm0aVHGFATvTohTiVA9LVkBVVCgS0vSOgrQBGcJdWe/revBVS1RQvy2CKAD0PaBqIlxVt6JKzRsNNSfbBaoaxiS0qyJAXRsnXcSSg4BuIan1wZTgCRImJbaqA0EXLYO2KH4jTSLVqAaVbSqEth1UbdWZNk6NFWd0aL0FVGSYsjhGmTkIiXXXLbGCp4ZFdGSM1NICh3mA0E5W4MCyTtjBTqwa6plVOoE2AXzr2m11EDmYl87IW50QT0Ews8MCbK6GA/oMVcBwUC1d8ZK0FVDX2kFYIsNCavFWTojgHnGnRnURyw1iQLmE1kFfQFRGOkyBQoZtVUzQyNPNhD+CN6ySgfPXSCSywr0R9jZsZ4EKUOkPtZB1KN0AdwxoN8QKnFnDRqcAB+JWmhCA0SKS6WlrEkKSvVOxg8+MCkGaa0YmD7C1ocz0Yg4hpS6kyQEDqzaYZaVKZYgMEgG7ItqXZp2ztSgNUrzceWVGyGBeitZUqyQrDx0a/+KcQEdyBPasFBu0Mw5LkjmBk2WUtsJcdliTCbJskepJCjo0qDIwCWZU9sJcZlGQgkmdYHKAQkVG+IE9HIOH4PYKclA8GeTDtaixNS6LM02qrWmc42tXcipkWbRMVKhYqVHF2cQHz2VgbbsrEGQ7UOjaQfNBnPpHbgSU07Rmra+0ypj6polRTFKCNvO1afsReu1AOW2UidkDEgbQZjGilIkqMxxBc0DZXna1liBAKORZYYUM9C+InsGhZZjVwbO7OzqicFiGN59kBZRXiKglZPTGPAP0HenUKVlMxcwOcokffTINmYIrWdOvLWHEj9cSSPMsToZCg9DQZdCLGtqs52VWUrjGNpQSDAvhxxkSQTfd62at863VWaKsEeLEVGSRjfUwirRRlk0wtZRMjDayqWXhljJvXcI1QxRVmrtHRJta9gS0jmnZTCPd/VMsUpQywoVQrSTZue2hrsFELfIECtgldUinIYUkrIT4hAamYihgLyzlJhXTgU6TUF2gXE7IS6h2uS5QJPKAGlhaWEUxKwtJPlMOyEOj7QyOozSlSQWAZ2DIgLoJouiO2m2Fopg/NoXhFkBQRlmXXiKr25YvJPFdSj23llB8UEo2SSm1WfKkVpV3RortmZrkIbRECkZpThERSpDCoHxb+6hBGlKha3kEkg5cwY5WDlCvCZk1NaZpcyz+pIg6T5KZj2AOIU6aZbVLe1sSmEkMaSyMyhYpfDkqjHS6IVW2GqVKDKjZpTnGSmgTDOkUG+yWoes3zo3mwP1EX2QAX+ltFgttTyr5VlkbJ3rtKaoWZ3LQiE8Go+3mhRVsflo2U6+QjADRHLOMRaiucR4LloJlKqjTu4shzWBw60gOcMq3g8ILjVyL6AuOe2duJgq5dJ0RAA9gc8y15StLAEMN1pb+22zBRXuVEEoZy0jlzla9g6OZm1uxZW1qoloWkBXriK1+ZyaUlANsm5ddyhpGCrOqD0ZxVV7ltR8jBnMqYHy78QV1GNo5d4HCDd4fm8WGvlkfiE0byd1KoljT1nYx76r+NNXrxWscspS3ik+8HS2FX2aLxi2tpHWgngNEdy2oSBsrcyxLlG0gKBOx+wSal2lLlshpbCzN1vJcl+5DQgxooa6k1UCVHyJs/DWQRhNIcsIw7uzQRKQzT4rbYFlhs4zbw3b3hSpw2t2kJQ0BlFmDRPGSXHEvTM1wBqZIZM1gcWNIcnXVIdSBCpx6+CuFkhjRR0MkylEGAlVuoKxLIV4551o24fmyZMUGoio+5LV6aiSR254uXkW8uwtSgDIoxBTDyH0OluuM461dWEoSSbkbtAmndpQ0ZYS+0gM+PbcShLKULbG1Ekh13Nlp1AVkRsq9xV39sVVuKUvA6SV5vNaeRksw4lRpylsle9gjprDCCVMWEVK950bmlkxjcigrZ0aIw+SrnPCLUVi9xEz4AxUSJAYd4oPH01Wu+A8CmKbwtHXWFOacVHdOgiT1wqjtdor+OwykzQ55J4qcEXq1hV2a6ToA92wihC4QZ+8oAKIRutaeOcUvelbm4y5SkINCk27BRFruRgwN62dwB+GWNWVJV9GyQy4EmIGrgDrNG+dqeHz+Kt6j1yEOEsQp5CLjMbN5kJ67wY5AVGaubAJiSVevDQPrS0qpbRVB83VkSy5m1WqzK7OQOIYthHg7dzZFJIgKVpOkcEUao/gL42n9tIQRjubkhoEmO/jEfKi1CELAbKhjjFbcFa3M4NyD7NDc/iokIDwFxdFUgnYD0K3U3xEg/zBXQxmoFR7nyg/xrqQUQxNtLMpUYDw3BTpSwFCtaqpjuihCyK1dSUMsU2BLmxoSgedrcv3G5ne7QP9sXUtWQ9QG5pTQ9haIxlQhr4fmKAI8VbGP2YGLWm9OONfUXlVrhSR0GWWnnY6aGSI5th0sCcz2hHjChQHMG+NmHd2lkqsuCQg1Gpk0Tu3x0hTUq/m2xnthDjrUF9rdB99TzYuO7RZBI0K4DBbJy6Kr+4GhSs5KIEXoCmNrBoalkEWtg5jQpaG1iSEaeCymcOMbZSOap0XGOVWSQaExUPjQtZUwdOBsWmkvHSOUrdOBBBFtgQQ2gCaH0y8RyEtoD+kUVhb1aEAZsvqUqGEDJW5CZlCm6E4eRfuzho0fJZVKQxtCLTVHqfvYNGCWVtt7cSVmlIHo54zlkAlN+4FXApUWwJ0fdo5Y923c5qaM/ibEmQH9BASKJaRYwDE7cwgX0gWE136mnzqDJBOZ2hVZ6GSts5fsV6DlL6io20eNgC/MftQXdeUw06Iyx3JTLqkQQvNCIZAYC+z4pX1MreOHYLF1mErG3jTSlmQzgjYANkstdHOsM3knaO1QHwkimVyjzKCaSlDfOOPnfIdEl16SW3MCKEqHa9RfvCaIRm3TjBCQfYdlID7KcAni0fWssQXIKIybd3XKXIZKIC9WPQJRYamjGbLQKeyZtuKKzygPEYjH7BTLb51nVGJvevyPRh3Ar+vZSgJwWHQzL4pDbiczwWeOeWYtvY6zUyrVKvO+GtTiA9FVQ4V+lX61s0JFp5ey2qxWqcIjGWDACrSOOVCW9e+txQJFgHt752gm4dCjTG4v6Ai1q0rYZoPSq3sRShSpD7glQK1GopvC7N2doD1mCykmloBoXQlNrsgXp1J+ezFneIjiO8FAKMo1CG4mw8lLtRB8kGiUbZupjTVgo/O2QDawlPiayy8gyVJm1tXY64Ix+SW1HxvQ6RRBa+NIE8Uzadi7ZRkAYWYfI+rNSlXd9aQRr4XWW3QjDubskYtotZ96zofsPN5cnFEwI1qt62aWQOke1ffHI5aQxEsK8Tgm0ZTqbIT+KHTMwC2TJBbatmGb6a6DAlNYc2tW3jTqBBfE6x/VUpDfQFX9hmvqIgMMrOxKcB5Qx77rqBGcwSBJHQp1jmlUrZqZvBq+CJDIINmR++YKwumEYoc+96dRqAHs0EIJVH2rX5BI2OEXIXXetC+00E51ZYCiO3wneej+sw8DaknBYdJWzUzA88max9cvDILJ6pa2Wwt7mvr8hNYJORsKDjcKHSQt4L/tzhnmmPSzv6Vob3yLAOScFDpwpBFDbWgov70sbWrZzUUQxMLPjfbZ7b2BT45M4N0p7V1DmWiPKAy6iqdCNHafaCZLKAS+YDMTlzxNaBVczFffILMHuobN4w0Vi5cty445xrUD9VIOhOl0gbxNJ9bI/Cbbh3cVZQ9Q02eA6U5FWR1KKCULhU7j7BzGFOl+C5BNQxYpeYAShtcL/sqFK5b13zoKNDsq88Yg6+a6qDbCOQEziJ4sXVhaO0ty6gpS6W5YJXUYg7B1Lc93Iq2sV5WPgaQpkWlTKlRwf99RLGhLu5M5t7ZVSAwZHmfQkfqGGqjBS7Al637ZscFsTyGr3qPaIpvjEksSCIuUIxbV8JA9SiCZUY/qgFY26n77g21aGq9bd2sWhGpBaV5mg83OHOTRFzyjFBpdet2ZDZXswbMZYHaGPgrdQaL097K0LB1hV0IrN5Vy74SBpIMItqPn0q9plC3zhbsKwewuNpZQbNhkoEaAOWc0BitW7f3aKJjjTEE3oFViDtEh06Z1TeS27pcFknjgQFoEd/inSTQAJNDMoUCFN4JcSD6C9QpBQVj8ZkaZLWry/k+fO7gzl6niCROPjYGtPUzyjIYXIZa1eareXdKstqqL9WiCPlDy9SnR5QozcfrYuw7HURFyXd6nCaDFAgDGtk0OaokENydGeTb6vaMGCU/MCFmDqEHB5S+ZNjWvZBjC90fW8tlabU/3wfuJuh3bH3tTGZL3cehSq3kOxgBWVriBNaSYlDdup55hCgcM2pwEQqle8+PBV9SXBb+3bqAS3yv37ni5eCVGrulpiy9WUqr8U7GP2eI2mcjIaA+OX+r2fJMroyy7RxuMFc7baAq5kgj+ga3CRzBJ9zOOreumhqXyTx+opIqMD/wLEyguNWXCKW9Z2Muq6NFZDFihWzxSJ00h4WQ9VVuOyuzkybxvYumQAc5/1+tzMFs1UBwd9LsSk3yrMgZn/lVuwHyefhGLGXGurMclu5zfLNYbH4a5mKGcgfnhyQxjVvHmSHb13SWTY2JVxHfpFrxNw2fPL91DmWPY/iBgstgjVi6Ob7Uype1iFuTmf0wmD5yyPBT8Xlp0KzBN9O2snlpdfX9siP1UqwRwEQMhA4CBLXaT4rZeoZdl1YbCAq1jFzyfRJSZt9JW0OlvfskwBEZgdsGGZkfEtBzMO9FiH6Q6c5yCEhrEaHRQpsI2AluO9sYOVrwZW07O8CWr9KiUilAMyfYxc8PBWsQDa2tstMqg0pYvqY5jQiSkLgXtCFUaX6i6d61ZEyAlehnPPnBj1WER5/L5/VEnlt3GtFYG7dW1E8pAM9FS6IlznX5Pmn/+8Hdz/DZW/UP3tv5Ht+8vbs/3B7PVy//dHUDTn9zvW5Pby4nhX/6m3/C+4fjF7e4x/XTDV5exUsfwnw4new4v/If9OqXuHAnX72x473f56mBrz75zS8/+S1+/ZV6U0W/kOPEGwFXTrCtf9+eb3i+l/sHNOPq4fj74+2XR/+hJ5m/Pxw/v56XFh8fbm4+unq487t932HmMfph5kPu5+uLSR+/8/j67RPev/Zst8eL8+F8f/vmfH04rlv/JY9eOd/7azAVA9gPYAqUTy6Lw2XXOF3QzCqXc9pux3/a9Ib94vFGv/b7fPRBB7D/5d/1+Jl5e7yHjc/X9oe7GzmKew6ffv+dJ9u/sdN8LUc9nO3q3c+adro/LPjs/vRg7y6fD58fL659dW9f2It/PD3c+LcMwXC3Jq7/5l8/+eTXL3L4OLe/k7/HW8fb47XazeELO311/RhBHpGPB8i7d8/3p8P0y/DdG4+LZ7u//95TY3E3f94341Jt3sjp6Sd+yzv39ubxWPpn/+DKtfRiEGBaJuAE4MoLer3K6qVzlaLf5R9870f0j9p5ng5vzfHqS7P7F+fXhxN+/UdXr+EcOR3WepdKFXF0WYRyezp8fnBbAQpOjzmFq//1IEf8NLxOH10hqx/cPCl/nLw35Es7fP4abYnx4+D+f5ch37TjGzk+LJnwjD/yrSHfJu/ja5vz2ch3p8PRf6f77VbxdOQR/HdYh7ff//ozJPA63cLiqnDn+TlTRE/Xs0zQsjRmTClGm0OtyYyr+rSzXL+RJT9/+v4Pe+AfQngZwge44fmDR3njVvhnQMiLV3dA29svL3ny5k6ObuFP5PzVp7cXEyEg4amIi5n5xe8APmc76otX795L3ti7+xfJ7zwvLrl6JccXvzoB0g7nefsEYP7EX/wcL/54uMOfneJlq8Rv+fXutQf8y6vy/I9n2xs53Hy3C9/WCrjxcHN5+HMqPfpGnr+4TO0kN4i0P7yHf5emfesaUhc+nfIW/b/+2rH+/HB6BOnHD92ecLv3vgQ7Trt59vfdad5c9wAtrYGz79DIYDd+4s9YESLbGl8q1rPDP338/o+XcTd2/Pz+NbIgeBZ8eVB/wf7366f8IH9xd4Jd1uGIu90hIN5D/Oc0Kh/TN+0Oe9whPvDZ60thfLY6GvUe+lzK8OprJtbW/JhMjuqnFa/RfISE0rqc5PZsg996mPyQBR7r2IfUum+GytlOXxwuVfWTP9y9za131OPVhXucHgMVSHIZ2/uzUg4cRyxev/1Y+/hy4M3T1T/79M3hfH/9rVterv3ZJ58rhspXz/XgvYv39p0Xrz9/QCEAKBnsveTmjNKFX3v9nbcD3N55vXkkVOfXd9ct9tFq7r5pArUROBXlUboqolQu8Pu9AxiVfPF6XzoXvjpHUekmmealA2ldmN27KKCIG9bE0Y/q6Zx4VNQeY17TplzmZ+yOgk9PB9QWQMb3h0H7+LKN0Q9EAX/cPjQInm74QTEQf8QAiD+t9yvy3TeDbdmMWIB/y8+rzVoEF1R+Cu9f4PaV3fhT/1IEXKbo/0AEPH3qwyLg8tEPioD0I0ZA+mkjoJDmGMrwcwxoQdfiv1rSusTDWj9FFfjV4XT+S65H1es/7PqnT32I658++v/A9Z9dVOzDUb8lLM9TjhcR/Xzhkn9w4Om933jRtu8Y+f3t95FpDkXaM5kuiR7JdJCg8RsV5W9k+v8WmX44352v/3hpXPzoSRv/TTH9lTl5PHzl4A==\",\"8bfU/avyqqO3S7zP/Eb29Nf/pKo8e/bVU026+vq/AQAA//8DAH+QPk+HkQAA\"]"
           },
           "cookies": [],
           "headers": [
@@ -91,7 +91,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e562324acde78a7a41000e4497"
+              "value": "f6c5a4ed6260cecbe8edd221004c8a87"
             },
             {
               "name": "cache-control",
@@ -107,7 +107,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_14eff3f744c44917ab5e53e81e7df657"
+              "value": "/api/v2/shipments/shp_719b7639c4f747b0825d8b59dd0bfa21"
             },
             {
               "name": "content-type",
@@ -115,11 +115,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"b25a12723bfcffb374a36f7a4527900d\""
+              "value": "W/\"c7722920905dcc3909aa5f40f4a86fb0\""
             },
             {
               "name": "x-runtime",
-              "value": "0.264893"
+              "value": "8.605780"
             },
             {
               "name": "content-encoding",
@@ -131,11 +131,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
@@ -143,7 +143,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, extlb1nuq fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -156,12 +156,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_14eff3f744c44917ab5e53e81e7df657",
+          "redirectURL": "/api/v2/shipments/shp_719b7639c4f747b0825d8b59dd0bfa21",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-03-16T20:38:37.250Z",
-        "time": 651,
+        "startedDateTime": "2022-04-21T03:26:03.075Z",
+        "time": 8791,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -169,15 +169,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 651
+          "wait": 8791
         }
       },
       {
-        "_id": "f3bdc3d91d499137e540127c88c239e1",
+        "_id": "a3b06d179f83f421cc55e3466579aa28",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 0,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -194,30 +194,39 @@
             },
             {
               "name": "user-agent",
-              "value": "EasyPost/v2 NodejsClient/4.0.0 Nodejs/16.14.0"
+              "value": "EasyPost/v2 NodejsClient/5.0.0 Nodejs/17.8.0"
             },
             {
               "name": "x-easypost-client-user-agent",
-              "value": "{\"client_version\":\"4.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v16.14.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+              "value": "{\"client_version\":\"5.0.0\",\"lang\":\"nodejs\",\"lang_version\":\"v17.8.0\",\"publisher\":\"easypost\",\"platform\":\"darwin\"}"
+            },
+            {
+              "name": "content-length",
+              "value": 2
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 525,
+          "headersSize": 542,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{}"
+          },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_14eff3f744c44917ab5e53e81e7df657/rerate"
+          "url": "https://api.easypost.com/v2/shipments/shp_719b7639c4f747b0825d8b59dd0bfa21/rerate"
         },
         "response": {
-          "bodySize": 636,
+          "bodySize": 648,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 636,
-            "text": "[\"H4sIAAAAAAAAA+RUTW/UMBD9LzlvI3/b2TNwrli4gJBlj8fUKN1dOUnFqup/x16lKtDSzaFSDkg5ZN68Gdvznn3fZDfi0Gy/3jcpNNtzaImTjOlOCxBRKEZN55WJEhhK8CqSZtMc/A+EsRR8LAUlhozlJ1hXMUYYuyL8iqpPjGy5Kd+XwpmO4SLn9hCwZMuexhINmO8SVOD9z2PGYagruZwT5oJ93l3vClC3XBvyVsuan3LGPZzOhHc1j6NLvX2k6VaQJ/QZu0/DaP9qecaeMQP26Q7zyQZ3KhPcT33/B1hbvADa75PLbj8ilnlH1w+4acpp7Yvthpt0vMX9aM/iDDdHSwXGyKMWRRzRUe28RMnRUNQhKqmfJmQdwGF6rAVnpXcaHFecgRQuoC/VQXhwQDmYjjQPm99doJUEEpwkhAoRvfJIuGBEADASOoAVXHDtMmC/w76u+m8r6Jaxy06YWUuMMFMX+YC9oQnYug7olOKB8ojUgyDUuELhnZIomPaIfg0H5HTIaTy9qj7Xl9U3rV76DMwNF6lP31B9uq76UukIrBDBRMGMMkjQO85MF0V9B1ZQ/0PKw2sXX7aiuyz9zFoi/Uz9Dy7+t4dfAAAA//8DAErh66UMCAAA\"]"
+            "size": 648,
+            "text": "[\"H4sIAAAAAAAAA+SUTW/UMBCG/0vO28ie2LG9Z+BcsXABIcv2jKlRurtykopV1f+OE7YqZaEbCcQeuGXeeWf88YxzX2U3UF+tP95XCav1HFoOyEgp0RhhhCI0njuvOW8FcKYFVqtq579QGErB21JQ4pCpfKB1kwYM4IqJK+DvWLMGs5biQ/GMezzrud0hlWzZ01CinvJdCpNwndMup+EwLeVyTpSL+H5zvSnCtOcSqbpRU3rMmbbhMOdfTWkaXOrs0aVrxZ7EE3OX+sE+bzhLJ0akLt1RPlh0h3J//JkylW/HrvtJtJ9Hl912ICpXHV3X06oqB7WnvfqbtL+l7WBnKP3N3ipuvGobE0RUQnmmQaL20iAyHx3wp4uxLoTd+FgbnFWFG4IwEUMspcFLdIZcI4JpMYZYPax+pB8dk4Sq+KMQgcgz1MzFMhCScSXlBei/SXlWfode1sKcR390LUF/tC5CD38RPVwWvZegTARotQtClfaMN46jaWITXURxiYfvcqBuQ9206kuPH+D8BBxdyx7/bP3fJoA8NtQSAkYQbYieG9RRYxRMM6PaC0zA66/7TH3/AnxoaiXP0wdVi6X//seWi/j/gvafjMD3yn88BZ8evgEAAP//AwA9kUkYDAgAAA==\"]"
           },
           "cookies": [],
           "headers": [
@@ -247,7 +256,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5f8f5e562324acee78a7a42000e44d6"
+              "value": "f6c5a4e86260cfabe8edd55c004cc9c0"
             },
             {
               "name": "cache-control",
@@ -267,11 +276,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"bb55d7971beaad0d1c03979d7a45c455\""
+              "value": "W/\"90a0e8c5f47fd07b1fffc9bdb42cd7aa\""
             },
             {
               "name": "x-runtime",
-              "value": "0.297111"
+              "value": "6.557183"
             },
             {
               "name": "content-encoding",
@@ -283,19 +292,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202203161942-9b82146167-master"
+              "value": "easypost-202204201907-3f5a844a4c-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 3e97db20d4, extlb1nuq 3e97db20d4"
+              "value": "intlb2nuq fde591f008, extlb1nuq fde591f008"
             },
             {
               "name": "strict-transport-security",
@@ -306,14 +319,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 762,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-03-16T20:38:37.909Z",
-        "time": 507,
+        "startedDateTime": "2022-04-21T03:29:47.709Z",
+        "time": 6774,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -321,7 +334,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 507
+          "wait": 6774
         }
       }
     ],

--- a/test/helpers/fixture.js
+++ b/test/helpers/fixture.js
@@ -153,7 +153,7 @@ export default class Fixture {
   // If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
   // USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
   static basicPickup() {
-    const pickupDate = '2022-04-12';
+    const pickupDate = '2022-04-22';
 
     return {
       address: this.basicAddress(),


### PR DESCRIPTION
# Description

Similar to our [change on the C# library](https://github.com/EasyPost/easypost-csharp/pull/257), this PR removes the developer's ability to indicate where parameters are placed, and instead handles that logic internally to prevent possible user/developer error.

- Let the EasyPost client decide where to put parameters (query or body), rather than developer doing so.

# Testing

Re-ran cassettes

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
