### PR TITLE
fix: gitattributes to ignore cassettes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 
-tests/cassettes/* -diff
-tests/cassettes/* linguist-generated
+tests/cassettes/**/* -diff
+tests/cassettes/**/* linguist-generated


### PR DESCRIPTION
# Description

Properly ignores cassettes since they are actually nested in sub folder.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
