### PR TITLE
docs: remove report Typescript TODO from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ Starting with v5.3.0, this project has bundled Typescript definitions included. 
 
 - Nullability for every field may need additional work
 - Error codes may not be comprehensive
-- Add missing report class
 
 ### Testing
 


### PR DESCRIPTION
# Description

Removes a TODO from the README for Typescript as it was added when we released Typescript.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
