### PR TITLE
add typescript definition for Billing and PaymentMethod and correct return type for Billing functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Adds typescript definition for Billing and PaymentMethod
+
 ## v5.3.0 (2022-07-11)
 
 - Adds bundled Typescript definitions in beta (closes #119, #122, #184, and #243 - big thank you to our awesome community!)

--- a/src/resources/billing.js
+++ b/src/resources/billing.js
@@ -19,7 +19,7 @@ export default (api) =>
      * Fund your EasyPost wallet by charging your primary or secondary payment method on file.
      * @param {String} amount
      * @param {String} primaryOrSecondary
-     * @returns {Promise<never>}
+     * @returns {boolean}
      */
     static async fundWallet(amount, primaryOrSecondary = 'primary') {
       const paymentInfo = await this.getPaymentInfo(primaryOrSecondary.toLowerCase());
@@ -35,7 +35,7 @@ export default (api) =>
 
     /**
      * Delete a payment method
-     * @returns {Promise|Promise<never>}
+     * @returns {boolean}
      */
     static async deletePaymentMethod(primaryOrSecondary) {
       const paymentInfo = await this.getPaymentInfo(primaryOrSecondary.toLowerCase());

--- a/types/Billing/Billing.d.ts
+++ b/types/Billing/Billing.d.ts
@@ -1,0 +1,25 @@
+/**
+ * The Billing class allow you to fund wallet by using primary or secondary payment method,
+ * delete a exisiting payment method, and retrive all payment methods associated to the user.
+ *
+ * TODO: Add link when the Billing API doc is updated
+ */
+export declare class Billing {
+  /**
+   * Fund your EasyPost wallet by charging your primary or secondary payment method on file.
+   * TODO: Add the link to API doc when its updated
+   */
+  static fundWallet(amount: string, primaryOrSecondary?: string): boolean;
+
+  /**
+   * Delete a payment method from your account.
+   * TODO: Add the link to API doc when its updated
+   */
+  static deletePaymentMethod(primaryOrSecondary: string): boolean;
+
+  /**
+   * Retrieve all payment methods.
+   * TODO: Add the link to API doc when its updated
+   */
+  static retrievePaymentMethods(): object;
+}

--- a/types/Billing/index.d.ts
+++ b/types/Billing/index.d.ts
@@ -1,0 +1,1 @@
+export * from './Billing';

--- a/types/PaymentMethod/PaymentMethod.d.ts
+++ b/types/PaymentMethod/PaymentMethod.d.ts
@@ -1,0 +1,68 @@
+import { IObjectWithId } from '../base';
+
+/**
+ * The Payment method object can be either credit card or bank account.
+ *
+ * TODO: Add the link to the API doc once its updated
+ */
+export declare interface IPaymentMethod extends IObjectWithId<'PaymentMethod'> {
+  /**
+   * Country of the bank account
+   */
+  country: string;
+
+  /**
+   * Name of the bank
+   */
+  bank_name: string;
+
+  /**
+   * Brand of the credit card
+   */
+  brand: string;
+
+  /**
+   * Whether the payment method(credit card or bank account) is disabled or not
+   */
+  disabled_at: string;
+
+  /**
+   * Expiration month of the credit card
+   */
+  exp_month: number;
+
+  /**
+   * Expiration year of the credit card
+   */
+  exp_year: number;
+
+  /**
+   * Last four of the credit card
+   */
+  last4: string;
+
+  /**
+   * Name of the credit card
+   */
+  name: string;
+
+  /**
+   * Whether the bank account is verified or not
+   */
+  verified: boolean;
+}
+
+export declare class PaymentMethod implements IPaymentMethod {
+  id: string;
+  mode: 'test' | 'production';
+  object: 'PaymentMethod';
+  country: string;
+  bank_name: string;
+  brand: string;
+  disabled_at: string;
+  exp_month: number;
+  exp_year: number;
+  last4: string;
+  name: string;
+  verified: boolean;
+}

--- a/types/PaymentMethod/index.d.ts
+++ b/types/PaymentMethod/index.d.ts
@@ -1,0 +1,1 @@
+export * from './PaymentMethod';


### PR DESCRIPTION
# Description

Add typescript definition for Billing and PaymentMethod
Correct return type for Billing functions(`deletePaymentMethod`, `fundWallet`)

# Testing
N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
