### PR TITLE
add ability to create shipment for carbon offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Adds `validateWebhook` function that returns your webhook or raises an error if there is a `webhookSecret` mismatch
 - Allows for looser values to the `verify` and `verify_strict` params when creating an address (can accept strings or bools outside of an array)
+- Adds the ability to create a shipment with carbon_offset
+- Adds the ability to buy a shipment with carbon_offset
+- Adds the ability to one-call-buy a shipment with carbon_offset
+- Adds the ability to regenerate a shipment with carbon_offset
 
 ## v5.4.0 (2022-07-18)
 

--- a/src/resources/rate.js
+++ b/src/resources/rate.js
@@ -19,6 +19,7 @@ export const propTypes = {
   delivery_date: T.string,
   delivery_date_guaranteed: T.string,
   est_delivery_days: T.integer, // deprecated
+  carbon_offset: T.object,
   created_at: T.oneOfType([T.object, T.string]),
   updated_at: T.oneOfType([T.object, T.string]),
 };

--- a/src/resources/shipment.js
+++ b/src/resources/shipment.js
@@ -79,10 +79,10 @@ export default (api) =>
 
     /**
      * Create a shipment.
-     * @param {boolean} carbonOffset
+     * @param {boolean} withCarbonOffset
      * @returns {this|Promise<never>}
      */
-    async save(carbonOffset = false) {
+    async save(withCarbonOffset = false) {
       try {
         this.validateProperties();
       } catch (e) {
@@ -91,10 +91,7 @@ export default (api) =>
 
       try {
         const wrappedParams = this.constructor.wrapJSON(this.toJSON());
-
-        if (carbonOffset) {
-          wrappedParams.carbon_offset = carbonOffset;
-        }
+        wrappedParams.carbon_offset = withCarbonOffset;
 
         const res = await api.post(this._url || this.constructor._url, wrappedParams);
 
@@ -109,10 +106,10 @@ export default (api) =>
      * Buy a shipment.
      * @param {object} rate
      * @param {number} insuranceAmount
-     * @param {boolean} carbonOffset
+     * @param {boolean} withCarbonOffset
      * @returns {this}
      */
-    async buy(rate, insuranceAmount, carbonOffset = false) {
+    async buy(rate, insuranceAmount, withCarbonOffset = false) {
       this.verifyParameters(
         {
           this: ['id'],
@@ -131,7 +128,7 @@ export default (api) =>
         rate: {
           id: rateId,
         },
-        carbon_offset: carbonOffset,
+        carbon_offset: withCarbonOffset,
       };
 
       if (insuranceAmount) {
@@ -160,15 +157,15 @@ export default (api) =>
 
     /**
      * Regenerate rates of a shipment.
-     * @param {boolean} carbonOffset
+     * @param {boolean} withCarbonOffset
      * @returns {this}
      */
-    async regenerateRates(carbonOffset = false) {
+    async regenerateRates(withCarbonOffset = false) {
       this.verifyParameters({
         this: ['id'],
       });
       const data = {
-        carbon_offset: carbonOffset,
+        carbon_offset: withCarbonOffset,
       };
       return this.rpc('rerate', data, undefined, 'post');
     }

--- a/test/cassettes/Batch-Resource_4123662849/adds-and-removes-shipments-from-a-batch_444431701/recording.har
+++ b/test/cassettes/Batch-Resource_4123662849/adds-and-removes-shipments-from-a-batch_444431701/recording.har
@@ -8,163 +8,6 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 520,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "accept-encoding",
-              "value": "gzip, deflate"
-            },
-            {
-              "name": "accept",
-              "value": "application/json"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json"
-            },
-            {
-              "name": "content-length",
-              "value": 520
-            },
-            {
-              "name": "host",
-              "value": "api.easypost.com"
-            }
-          ],
-          "headersSize": 493,
-          "httpVersion": "HTTP/1.1",
-          "method": "POST",
-          "postData": {
-            "mimeType": "application/json",
-            "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
-          },
-          "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments"
-        },
-        "response": {
-          "bodySize": 2214,
-          "content": {
-            "encoding": "base64",
-            "mimeType": "application/json; charset=utf-8",
-            "size": 2214,
-            "text": "{\"created_at\":\"2022-06-01T19:48:11Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892759\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c47196c6e1e311eca13eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:11+00:00\",\"updated_at\":\"2022-06-01T19:48:11+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_99376d27c1fe4d36baae30cea6ceee21\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_1cd7a30fdd9b465c96c5aae723323f0b\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:11Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/b19aeefa212d4a04a9c38330fdef33cf.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_cd46a914ae354ab4a43c5fcec6cddc8b\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_faafbf3dec1e4c7d8e4c76d8f2acc280\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_198a58e3176b4faeae05f283c7c8b06f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_900c19f912dd4ffd914934b2e14fad1d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_900c19f912dd4ffd914934b2e14fad1d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:11Z\",\"updated_at\":\"2022-06-01T19:48:11Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_843208f604f84aa58a1ed1cb77c7a3dd\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892759\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:12Z\",\"updated_at\":\"2022-06-01T19:48:12Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzg0MzIwOGY2MDRmODRhYTU4YTFlZDFjYjc3YzdhM2Rk\"},\"to_address\":{\"id\":\"adr_c46fc3c8e1e311eca8f1ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:11+00:00\",\"updated_at\":\"2022-06-01T19:48:11+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c47196c6e1e311eca13eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:11+00:00\",\"updated_at\":\"2022-06-01T19:48:11+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c46fc3c8e1e311eca8f1ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:11+00:00\",\"updated_at\":\"2022-06-01T19:48:11+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\",\"object\":\"Shipment\"}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "x-frame-options",
-              "value": "SAMEORIGIN"
-            },
-            {
-              "name": "x-xss-protection",
-              "value": "1; mode=block"
-            },
-            {
-              "name": "x-content-type-options",
-              "value": "nosniff"
-            },
-            {
-              "name": "x-download-options",
-              "value": "noopen"
-            },
-            {
-              "name": "x-permitted-cross-domain-policies",
-              "value": "none"
-            },
-            {
-              "name": "referrer-policy",
-              "value": "strict-origin-when-cross-origin"
-            },
-            {
-              "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297c27be786c0be00096f46"
-            },
-            {
-              "name": "cache-control",
-              "value": "no-cache, no-store"
-            },
-            {
-              "name": "pragma",
-              "value": "no-cache"
-            },
-            {
-              "name": "expires",
-              "value": "0"
-            },
-            {
-              "name": "location",
-              "value": "/api/v2/shipments/shp_0df18d47a5fe4b60b86e8493a0a42870"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"0540f380f2c8921e39243552f5dbf221\""
-            },
-            {
-              "name": "x-runtime",
-              "value": "0.974371"
-            },
-            {
-              "name": "content-encoding",
-              "value": "gzip"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "x-node",
-              "value": "bigweb1nuq"
-            },
-            {
-              "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
-            },
-            {
-              "name": "x-backend",
-              "value": "easypost"
-            },
-            {
-              "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
-            },
-            {
-              "name": "strict-transport-security",
-              "value": "max-age=31536000; includeSubDomains; preload"
-            },
-            {
-              "name": "connection",
-              "value": "close"
-            }
-          ],
-          "headersSize": 810,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_0df18d47a5fe4b60b86e8493a0a42870",
-          "status": 201,
-          "statusText": "Created"
-        },
-        "startedDateTime": "2022-06-01T19:48:10.860Z",
-        "time": 1244,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 1244
-        }
-      },
-      {
         "_id": "455f0344f3539cbf3cb217d5af4a913a",
         "_order": 0,
         "cache": {},
@@ -318,7 +161,168 @@
         }
       },
       {
-        "_id": "8a432c3e8b62df7ccc100093a50a2f32",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 542,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 542
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 391,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 2228,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2228,
+            "text": "{\"created_at\":\"2022-07-29T22:02:33Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689302\",\"updated_at\":\"2022-07-29T22:02:34Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_25f86bc90f8a11ed9e53ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:33+00:00\",\"updated_at\":\"2022-07-29T22:02:33+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_291c52085b054e45979251f618224a42\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:33Z\",\"updated_at\":\"2022-07-29T22:02:33Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_06b8573b295a4385a595ca76dfc1d1ca\",\"created_at\":\"2022-07-29T22:02:34Z\",\"updated_at\":\"2022-07-29T22:02:34Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:34Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/fd52f55367234438a141b0e7b2cc0641.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_e4723e92c4404954b1366198027742c2\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:33Z\",\"updated_at\":\"2022-07-29T22:02:33Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_be2c99ff4b964b59a622a99e10577495\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:33Z\",\"updated_at\":\"2022-07-29T22:02:33Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_84d2449741944fdbb260506bf7af6eff\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:33Z\",\"updated_at\":\"2022-07-29T22:02:33Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_02f629ce84224bf5882adbd4b9737faf\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:33Z\",\"updated_at\":\"2022-07-29T22:02:33Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_02f629ce84224bf5882adbd4b9737faf\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:34Z\",\"updated_at\":\"2022-07-29T22:02:34Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_f753c2e967db423b88e10bfa13338225\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689302\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:34Z\",\"updated_at\":\"2022-07-29T22:02:34Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2Y3NTNjMmU5NjdkYjQyM2I4OGUxMGJmYTEzMzM4MjI1\"},\"to_address\":{\"id\":\"adr_25f689f50f8a11eda82eac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:33+00:00\",\"updated_at\":\"2022-07-29T22:02:33+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_25f86bc90f8a11ed9e53ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:33+00:00\",\"updated_at\":\"2022-07-29T22:02:33+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_25f689f50f8a11eda82eac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:33+00:00\",\"updated_at\":\"2022-07-29T22:02:33+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "999d146e62e458f9e788dc9e000fda3f"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_47d48dfbc1854570b68446cf8b44cbe5"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"090a9ff4c5b8286b185f8cd6f9997db9\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "1.022335"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb7nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207291722-ecd5579616-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 828,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_47d48dfbc1854570b68446cf8b44cbe5",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-07-29T22:02:33.237Z",
+        "time": 1337,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1337
+        }
+      },
+      {
+        "_id": "c7a1ec63f43c7b26cb3ade1ed5433385",
         "_order": 0,
         "cache": {},
         "request": {
@@ -346,24 +350,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 543,
+          "headersSize": 441,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipments\":[{\"id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\"}]}"
+            "text": "{\"shipments\":[{\"id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\"}]}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/batches/batch_4958cc026bfd48488dbae2cfe9179132/add_shipments"
         },
         "response": {
-          "bodySize": 428,
+          "bodySize": 432,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 428,
-            "text": "{\"id\":\"batch_4958cc026bfd48488dbae2cfe9179132\",\"object\":\"Batch\",\"mode\":\"test\",\"state\":\"created\",\"num_shipments\":1,\"reference\":null,\"created_at\":\"2022-06-01T19:48:12Z\",\"updated_at\":\"2022-06-01T19:48:12Z\",\"scan_form\":null,\"shipments\":[{\"batch_status\":\"postage_purchased\",\"batch_message\":null,\"reference\":null,\"tracking_code\":\"9400100109361121892759\",\"id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\"}],\"status\":{\"created\":0,\"queued_for_purchase\":0,\"creation_failed\":0,\"postage_purchased\":1,\"postage_purchase_failed\":0},\"pickup\":null,\"label_url\":null}"
+            "size": 432,
+            "text": "{\"id\":\"batch_4958cc026bfd48488dbae2cfe9179132\",\"object\":\"Batch\",\"mode\":\"test\",\"state\":\"created\",\"num_shipments\":1,\"reference\":null,\"created_at\":\"2022-06-01T19:48:12Z\",\"updated_at\":\"2022-06-01T19:48:13Z\",\"scan_form\":null,\"shipments\":[{\"batch_status\":\"postage_purchased\",\"batch_message\":null,\"reference\":null,\"tracking_code\":\"9400100109361130689302\",\"id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\"}],\"status\":{\"created\":0,\"queued_for_purchase\":0,\"creation_failed\":0,\"postage_purchased\":1,\"postage_purchase_failed\":0},\"pickup\":null,\"label_url\":null}"
           },
           "cookies": [],
           "headers": [
@@ -393,7 +397,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c27ce786c0c00009700a"
+              "value": "999d146e62e458fae788dc9f000fda9f"
             },
             {
               "name": "cache-control",
@@ -413,11 +417,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"fd3bdfb327c43b493afbc4705ff944ab\""
+              "value": "W/\"67ae82f0660997d790690bd5adfd0ec0\""
             },
             {
               "name": "x-runtime",
-              "value": "0.048267"
+              "value": "0.052058"
             },
             {
               "name": "content-encoding",
@@ -429,11 +433,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -441,7 +445,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -458,8 +462,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:12.332Z",
-        "time": 246,
+        "startedDateTime": "2022-07-29T22:02:34.586Z",
+        "time": 248,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -467,11 +471,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 246
+          "wait": 248
         }
       },
       {
-        "_id": "13dca550d6332eeb1cd122084c144fc6",
+        "_id": "b26ea868aa3a3f1c83014c701726cb09",
         "_order": 0,
         "cache": {},
         "request": {
@@ -499,24 +503,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 546,
+          "headersSize": 444,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipments\":[{\"id\":\"shp_0df18d47a5fe4b60b86e8493a0a42870\"}]}"
+            "text": "{\"shipments\":[{\"id\":\"shp_47d48dfbc1854570b68446cf8b44cbe5\"}]}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/batches/batch_4958cc026bfd48488dbae2cfe9179132/remove_shipments"
         },
         "response": {
-          "bodySize": 328,
+          "bodySize": 344,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 328,
-            "text": "{\"id\":\"batch_4958cc026bfd48488dbae2cfe9179132\",\"object\":\"Batch\",\"mode\":\"test\",\"state\":\"purchased\",\"num_shipments\":0,\"reference\":null,\"created_at\":\"2022-06-01T19:48:12Z\",\"updated_at\":\"2022-06-01T19:48:12Z\",\"scan_form\":null,\"shipments\":[],\"status\":{\"created\":0,\"queued_for_purchase\":0,\"creation_failed\":0,\"postage_purchased\":0,\"postage_purchase_failed\":0},\"pickup\":null,\"label_url\":null}"
+            "size": 344,
+            "text": "{\"id\":\"batch_4958cc026bfd48488dbae2cfe9179132\",\"object\":\"Batch\",\"mode\":\"test\",\"state\":\"purchased\",\"num_shipments\":0,\"reference\":null,\"created_at\":\"2022-06-01T19:48:12Z\",\"updated_at\":\"2022-07-29T22:02:34Z\",\"scan_form\":null,\"shipments\":[],\"status\":{\"created\":0,\"queued_for_purchase\":0,\"creation_failed\":0,\"postage_purchased\":0,\"postage_purchase_failed\":0},\"pickup\":null,\"label_url\":null}"
           },
           "cookies": [],
           "headers": [
@@ -546,7 +550,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c27de786c0c100097078"
+              "value": "999d146f62e458fbe788dca0000fdab3"
             },
             {
               "name": "cache-control",
@@ -566,11 +570,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"4d5cfa72c20634da124d07ef112f45bc\""
+              "value": "W/\"31dfc7047285078e96ee3839551d5f56\""
             },
             {
               "name": "x-runtime",
-              "value": "0.040941"
+              "value": "0.036410"
             },
             {
               "name": "content-encoding",
@@ -582,11 +586,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -594,7 +598,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -611,8 +615,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:12.583Z",
-        "time": 607,
+        "startedDateTime": "2022-07-29T22:02:34.839Z",
+        "time": 235,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -620,7 +624,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 607
+          "wait": 235
         }
       }
     ],

--- a/test/cassettes/Insurance-Resource_2192247349/creates-an-insurance-object_4069302148/recording.har
+++ b/test/cassettes/Insurance-Resource_2192247349/creates-an-insurance-object_4069302148/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2226,
+          "bodySize": 2208,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2226,
-            "text": "{\"created_at\":\"2022-06-01T19:48:28Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892803\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_cea8911ee1e311ecab66ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:28+00:00\",\"updated_at\":\"2022-06-01T19:48:28+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_931584139a744327addc73c2c3e09305\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_9eb96d609e984632a5739cae9abd0ed6\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:28Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/0590321f395e4dd58120d4434582db4a.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_8ee7c14595114b3d91ea95ae50c2db95\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f7b731fa6161439793267b61e42c998d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_a8fe5cf2a453434586f6fb0bb8101d31\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6737284028b1489991aa0162e7f135ae\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_6737284028b1489991aa0162e7f135ae\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:28Z\",\"updated_at\":\"2022-06-01T19:48:28Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_39a10d44c2aa4c3188cf5094e9cf9f5e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892803\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzM5YTEwZDQ0YzJhYTRjMzE4OGNmNTA5NGU5Y2Y5ZjVl\"},\"to_address\":{\"id\":\"adr_cea6558fe1e311ec9c01ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:28+00:00\",\"updated_at\":\"2022-06-01T19:48:28+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_cea8911ee1e311ecab66ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:28+00:00\",\"updated_at\":\"2022-06-01T19:48:28+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_cea6558fe1e311ec9c01ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:28+00:00\",\"updated_at\":\"2022-06-01T19:48:28+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"object\":\"Shipment\"}"
+            "size": 2208,
+            "text": "{\"created_at\":\"2022-07-29T22:02:35Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689319\",\"updated_at\":\"2022-07-29T22:02:36Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_272510e60f8a11ed96d8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:35+00:00\",\"updated_at\":\"2022-07-29T22:02:35+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_15473849b9dd4d5b9497df88da27efdc\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:35Z\",\"updated_at\":\"2022-07-29T22:02:35Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_f394d0abf5ec4e5fbe8df849cf7adccc\",\"created_at\":\"2022-07-29T22:02:36Z\",\"updated_at\":\"2022-07-29T22:02:36Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:36Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/7efeebd14d55484aa2347dc5dcba3517.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_3f0bcfd61d144629bba31c8acba0b6c4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:35Z\",\"updated_at\":\"2022-07-29T22:02:35Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1d70456a23544659ba218f8b186cdefd\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:35Z\",\"updated_at\":\"2022-07-29T22:02:35Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_669495f040c046c1af0cac2967cf9c2c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:35Z\",\"updated_at\":\"2022-07-29T22:02:35Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_25fe8b8b40264bdd84f3dc377db73d5d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:35Z\",\"updated_at\":\"2022-07-29T22:02:35Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_25fe8b8b40264bdd84f3dc377db73d5d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:36Z\",\"updated_at\":\"2022-07-29T22:02:36Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_a079ada9bf744e0f884037999c869071\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689319\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:36Z\",\"updated_at\":\"2022-07-29T22:02:36Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2EwNzlhZGE5YmY3NDRlMGY4ODQwMzc5OTljODY5MDcx\"},\"to_address\":{\"id\":\"adr_2723720b0f8a11ed96d7ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:35+00:00\",\"updated_at\":\"2022-07-29T22:02:35+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_272510e60f8a11ed96d8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:35+00:00\",\"updated_at\":\"2022-07-29T22:02:35+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2723720b0f8a11ed96d7ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:35+00:00\",\"updated_at\":\"2022-07-29T22:02:35+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c28ce786c124000978d4"
+              "value": "999d146b62e458fbe788dca1000fdad6"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_4fea445d13f5421dac66682c4766e665"
+              "value": "/api/v2/shipments/shp_7db48790e1804adeb404ff07a4284bbc"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"278ca7be157ed052f27bc97a2f42d7ea\""
+              "value": "W/\"7663e5bd67c5ad62e2e089d0d6968234\""
             },
             {
               "name": "x-runtime",
-              "value": "1.025233"
+              "value": "1.070888"
             },
             {
               "name": "content-encoding",
@@ -127,7 +127,7 @@
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_4fea445d13f5421dac66682c4766e665",
+          "redirectURL": "/api/v2/shipments/shp_7db48790e1804adeb404ff07a4284bbc",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:27.989Z",
-        "time": 1227,
+        "startedDateTime": "2022-07-29T22:02:35.236Z",
+        "time": 1281,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1227
+          "wait": 1281
         }
       },
       {
-        "_id": "89d4cdf50171829062130f5d5be82c4f",
+        "_id": "1458efe49903aea466e7a5c9a06c0e0c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 494,
+          "headersSize": 392,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"insurance\":{\"amount\":\"100\",\"tracking_code\":\"9400100109361121892803\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"carrier\":\"USPS\"}}"
+            "text": "{\"insurance\":{\"amount\":\"100\",\"tracking_code\":\"9400100109361130689319\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"carrier\":\"USPS\"}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/insurances"
         },
         "response": {
-          "bodySize": 1544,
+          "bodySize": 1551,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1544,
-            "text": "{\"id\":\"ins_d6109b8526c54b58b75173d6178e0f60\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_cf63a7e7e1e311ec9c44ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:29+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_cf685ef3e1e311ecab8eac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:29+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_39a10d44c2aa4c3188cf5094e9cf9f5e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892803\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T19:48:29Z\",\"shipment_id\":\"shp_4fea445d13f5421dac66682c4766e665\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T19:48:29Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T08:25:29Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrXzM5YTEwZDQ0YzJhYTRjMzE4OGNmNTA5NGU5Y2Y5ZjVl\",\"fees\":[]},\"tracking_code\":\"9400100109361121892803\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\"}"
+            "size": 1551,
+            "text": "{\"id\":\"ins_edee737b9b52455ba103f329ae9b2ac2\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_27f235400f8a11ed9ec6ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:36+00:00\",\"updated_at\":\"2022-07-29T22:02:36+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_27f5e6f20f8a11eda8b1ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:36+00:00\",\"updated_at\":\"2022-07-29T22:02:36+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_a079ada9bf744e0f884037999c869071\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689319\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:02:36Z\",\"updated_at\":\"2022-07-29T22:02:36Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:02:36Z\",\"shipment_id\":\"shp_7db48790e1804adeb404ff07a4284bbc\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:02:36Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:39:36Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrX2EwNzlhZGE5YmY3NDRlMGY4ODQwMzc5OTljODY5MDcx\",\"fees\":[]},\"tracking_code\":\"9400100109361130689319\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-07-29T22:02:36Z\",\"updated_at\":\"2022-07-29T22:02:36Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c28de786c1250009798d"
+              "value": "999d146c62e458fce788dcb9000fdb3a"
             },
             {
               "name": "cache-control",
@@ -256,7 +256,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/insurances/ins_d6109b8526c54b58b75173d6178e0f60"
+              "value": "/api/v2/insurances/ins_edee737b9b52455ba103f329ae9b2ac2"
             },
             {
               "name": "content-type",
@@ -264,11 +264,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0166f92898ea510a5a82a8ad3850d65d\""
+              "value": "W/\"9af74741c3a1604745c5b5b11b7e7437\""
             },
             {
               "name": "x-runtime",
-              "value": "0.167023"
+              "value": "0.224326"
             },
             {
               "name": "content-encoding",
@@ -280,19 +280,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -303,14 +307,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 811,
+          "headersSize": 829,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/insurances/ins_d6109b8526c54b58b75173d6178e0f60",
+          "redirectURL": "/api/v2/insurances/ins_edee737b9b52455ba103f329ae9b2ac2",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:29.222Z",
-        "time": 358,
+        "startedDateTime": "2022-07-29T22:02:36.521Z",
+        "time": 604,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +322,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 358
+          "wait": 604
         }
       }
     ],

--- a/test/cassettes/Insurance-Resource_2192247349/retrieves-an-insurance-object_1368608920/recording.har
+++ b/test/cassettes/Insurance-Resource_2192247349/retrieves-an-insurance-object_1368608920/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2231,
+          "bodySize": 2238,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2231,
-            "text": "{\"created_at\":\"2022-06-01T19:48:29Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892827\",\"updated_at\":\"2022-06-01T19:48:30Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_cf9c0a6ce1e311ecb602ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:29+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_899525f45c3f4b88962334e8064fc7b4\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_f176b100734d49a79171f05de7077945\",\"created_at\":\"2022-06-01T19:48:30Z\",\"updated_at\":\"2022-06-01T19:48:30Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:30Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/d1eb5be2c2054a5cbb319616a76f9633.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_ae9ab78a39424fc78b63cd84b9b28b3f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_856cf2233a7d4127a40bb2b461b95764\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_a3fa8a43b31541519210a71bfda1690a\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:29Z\",\"updated_at\":\"2022-06-01T19:48:29Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d86fc54e7c794be9a3a33bde98f1e851\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:30Z\",\"updated_at\":\"2022-06-01T19:48:30Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_d86fc54e7c794be9a3a33bde98f1e851\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:30Z\",\"updated_at\":\"2022-06-01T19:48:30Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_df8a71d1027e4a61a0086856ab757ee7\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892827\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:31Z\",\"updated_at\":\"2022-06-01T19:48:31Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2RmOGE3MWQxMDI3ZTRhNjFhMDA4Njg1NmFiNzU3ZWU3\"},\"to_address\":{\"id\":\"adr_cf9a4aa5e1e311ecb601ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:30+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_cf9c0a6ce1e311ecb602ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:29+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_cf9a4aa5e1e311ecb601ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:29+00:00\",\"updated_at\":\"2022-06-01T19:48:30+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"object\":\"Shipment\"}"
+            "size": 2238,
+            "text": "{\"created_at\":\"2022-07-29T22:02:37Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689326\",\"updated_at\":\"2022-07-29T22:02:38Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2844847c0f8a11ed9ee2ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:37+00:00\",\"updated_at\":\"2022-07-29T22:02:37+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_163c9b438de1462bbbb6bad94218754d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_9523f5ea8d5a4eaab732836cc631298b\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:38Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:37Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/ffbda9eea12149b59be3a2642ca1bbd2.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_bb8af3adf19e41d881a763694935a832\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b39d96140154462dab9d7f200b7031c7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_02f91fb409294cbb8823326252cafa35\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c194fb3890764a859219324686dd6eaf\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_bb8af3adf19e41d881a763694935a832\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:37Z\",\"updated_at\":\"2022-07-29T22:02:37Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_f31414cf8a1c4855bbb3a6d60f3f75c0\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689326\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:38Z\",\"updated_at\":\"2022-07-29T22:02:38Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2YzMTQxNGNmOGExYzQ4NTViYmIzYTZkNjBmM2Y3NWMw\"},\"to_address\":{\"id\":\"adr_284306a50f8a11eda8c3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:37+00:00\",\"updated_at\":\"2022-07-29T22:02:37+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2844847c0f8a11ed9ee2ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:37+00:00\",\"updated_at\":\"2022-07-29T22:02:37+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_284306a50f8a11eda8c3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:37+00:00\",\"updated_at\":\"2022-07-29T22:02:37+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0486297c28de786c126000979ca"
+              "value": "999d146f62e458fde788dcba000fdb69"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_64907a08bfda4196a0a55f12c66366da"
+              "value": "/api/v2/shipments/shp_c91071aa7c5b4a0bbd4af9278c968462"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"be8e722ab46afa5fb6e489cfb4181444\""
+              "value": "W/\"1e8842acd29984ceb97cb0af2413130f\""
             },
             {
               "name": "x-runtime",
-              "value": "1.227903"
+              "value": "1.124764"
             },
             {
               "name": "content-encoding",
@@ -123,19 +123,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 828,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_64907a08bfda4196a0a55f12c66366da",
+          "redirectURL": "/api/v2/shipments/shp_c91071aa7c5b4a0bbd4af9278c968462",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:29.594Z",
-        "time": 1454,
+        "startedDateTime": "2022-07-29T22:02:37.135Z",
+        "time": 1329,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +165,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1454
+          "wait": 1329
         }
       },
       {
-        "_id": "82769ee84ad343d5eba5e000b4fad8f7",
+        "_id": "ebb7a76a414cb09c38ac4ca762031ae2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +197,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 494,
+          "headersSize": 392,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"insurance\":{\"amount\":\"100\",\"tracking_code\":\"9400100109361121892827\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"carrier\":\"USPS\"}}"
+            "text": "{\"insurance\":{\"amount\":\"100\",\"tracking_code\":\"9400100109361130689326\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"carrier\":\"USPS\"}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/insurances"
         },
         "response": {
-          "bodySize": 1558,
+          "bodySize": 1555,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1558,
-            "text": "{\"id\":\"ins_bea390afd34b4ca7a231d99facdb9bd1\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_d07aa5aae1e311eca5d5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:31+00:00\",\"updated_at\":\"2022-06-01T19:48:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_d07e92ece1e311ec9cb0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:31+00:00\",\"updated_at\":\"2022-06-01T19:48:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_df8a71d1027e4a61a0086856ab757ee7\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892827\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T19:48:31Z\",\"updated_at\":\"2022-06-01T19:48:31Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T19:48:31Z\",\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T19:48:31Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T08:25:31Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrX2RmOGE3MWQxMDI3ZTRhNjFhMDA4Njg1NmFiNzU3ZWU3\",\"fees\":[]},\"tracking_code\":\"9400100109361121892827\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-06-01T19:48:31Z\",\"updated_at\":\"2022-06-01T19:48:31Z\"}"
+            "size": 1555,
+            "text": "{\"id\":\"ins_47214a6748c44d35ad0301d98ad5bde6\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_291274a20f8a11eda8f5ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:38+00:00\",\"updated_at\":\"2022-07-29T22:02:38+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_291655070f8a11ed9f18ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:38+00:00\",\"updated_at\":\"2022-07-29T22:02:38+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_f31414cf8a1c4855bbb3a6d60f3f75c0\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689326\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:02:38Z\",\"updated_at\":\"2022-07-29T22:02:38Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:02:38Z\",\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:02:38Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:39:38Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrX2YzMTQxNGNmOGExYzQ4NTViYmIzYTZkNjBmM2Y3NWMw\",\"fees\":[]},\"tracking_code\":\"9400100109361130689326\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-07-29T22:02:38Z\",\"updated_at\":\"2022-07-29T22:02:38Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +244,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c28fe786c12700097aa0"
+              "value": "999d146e62e458fee788dcbb000fdbca"
             },
             {
               "name": "cache-control",
@@ -256,7 +260,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/insurances/ins_bea390afd34b4ca7a231d99facdb9bd1"
+              "value": "/api/v2/insurances/ins_47214a6748c44d35ad0301d98ad5bde6"
             },
             {
               "name": "content-type",
@@ -264,11 +268,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"977391ec2ad00393549cd6ca13691ae5\""
+              "value": "W/\"79f000ad5e43fe2292a08ff00ae21a5a\""
             },
             {
               "name": "x-runtime",
-              "value": "0.128851"
+              "value": "0.132736"
             },
             {
               "name": "content-encoding",
@@ -280,11 +284,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -292,7 +296,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,12 +309,12 @@
           ],
           "headersSize": 811,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/insurances/ins_bea390afd34b4ca7a231d99facdb9bd1",
+          "redirectURL": "/api/v2/insurances/ins_47214a6748c44d35ad0301d98ad5bde6",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:31.055Z",
-        "time": 319,
+        "startedDateTime": "2022-07-29T22:02:38.472Z",
+        "time": 327,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,11 +322,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 319
+          "wait": 327
         }
       },
       {
-        "_id": "dbccb7d46146b16b294b1b53af99b3c5",
+        "_id": "36036939d9ab2d417fd0c9aa1f33720f",
         "_order": 0,
         "cache": {},
         "request": {
@@ -346,19 +350,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 509,
+          "headersSize": 407,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/insurances/ins_bea390afd34b4ca7a231d99facdb9bd1"
+          "url": "https://api.easypost.com/v2/insurances/ins_47214a6748c44d35ad0301d98ad5bde6"
         },
         "response": {
-          "bodySize": 1551,
+          "bodySize": 1562,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1551,
-            "text": "{\"id\":\"ins_bea390afd34b4ca7a231d99facdb9bd1\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_d07aa5aae1e311eca5d5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:31+00:00\",\"updated_at\":\"2022-06-01T19:48:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_d07e92ece1e311ec9cb0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:31+00:00\",\"updated_at\":\"2022-06-01T19:48:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_df8a71d1027e4a61a0086856ab757ee7\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892827\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T19:48:31Z\",\"updated_at\":\"2022-06-01T19:48:31Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T19:48:31Z\",\"shipment_id\":\"shp_64907a08bfda4196a0a55f12c66366da\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T19:48:31Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T08:25:31Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrX2RmOGE3MWQxMDI3ZTRhNjFhMDA4Njg1NmFiNzU3ZWU3\",\"fees\":[]},\"tracking_code\":\"9400100109361121892827\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-06-01T19:48:31Z\",\"updated_at\":\"2022-06-01T19:48:31Z\"}"
+            "size": 1562,
+            "text": "{\"id\":\"ins_47214a6748c44d35ad0301d98ad5bde6\",\"object\":\"Insurance\",\"mode\":\"test\",\"reference\":null,\"status\":\"pending\",\"amount\":\"100.00000\",\"provider\":\"easypost\",\"provider_id\":null,\"to_address\":{\"id\":\"adr_291274a20f8a11eda8f5ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:38+00:00\",\"updated_at\":\"2022-07-29T22:02:38+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"from_address\":{\"id\":\"adr_291655070f8a11ed9f18ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:38+00:00\",\"updated_at\":\"2022-07-29T22:02:38+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"shipment_id\":null,\"tracker\":{\"id\":\"trk_f31414cf8a1c4855bbb3a6d60f3f75c0\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689326\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:02:38Z\",\"updated_at\":\"2022-07-29T22:02:38Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:02:38Z\",\"shipment_id\":\"shp_c91071aa7c5b4a0bbd4af9278c968462\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:02:38Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:39:38Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"finalized\":true,\"is_return\":false,\"public_url\":\"https://track.easypost.com/djE6dHJrX2YzMTQxNGNmOGExYzQ4NTViYmIzYTZkNjBmM2Y3NWMw\",\"fees\":[]},\"tracking_code\":\"9400100109361130689326\",\"fee\":{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false},\"messages\":[],\"created_at\":\"2022-07-29T22:02:38Z\",\"updated_at\":\"2022-07-29T22:02:38Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -388,7 +392,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297c28fe786c12800097acd"
+              "value": "999d146962e458ffe788dcbc000fdbdf"
             },
             {
               "name": "cache-control",
@@ -408,11 +412,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"19664322cfe4602d8d1908c9e5a81b1c\""
+              "value": "W/\"5e211168ef44eee3f84174560015a37b\""
             },
             {
               "name": "x-runtime",
-              "value": "0.061586"
+              "value": "0.123376"
             },
             {
               "name": "content-encoding",
@@ -424,11 +428,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -436,7 +440,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -453,8 +457,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:31.382Z",
-        "time": 254,
+        "startedDateTime": "2022-07-29T22:02:38.805Z",
+        "time": 500,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -462,7 +466,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 254
+          "wait": 500
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/buys-a-pickup_1934475561/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/buys-a-pickup_1934475561/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2227,
+          "bodySize": 2223,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2227,
-            "text": "{\"created_at\":\"2022-06-01T19:49:59Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121893053\",\"updated_at\":\"2022-06-01T19:50:00Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_04c5b1b5e1e411ecb177ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:59+00:00\",\"updated_at\":\"2022-06-01T19:49:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_de0b926e81474f79a5721a269155a327\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_83f8dca7f4834061bde68afbd556e980\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:50:00Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:59Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/23d2c0255df84f01821f1a14d3288c10.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_2c3a83bf8b3d4854834524d43c1b1697\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e400a955e46841ed8c3bcf88cacd6ce3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ca6a7aedd7ec48d1a45755b2e2a8089f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b6f404a45b4c4becb3edb4ca8e266188\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_b6f404a45b4c4becb3edb4ca8e266188\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:59Z\",\"updated_at\":\"2022-06-01T19:49:59Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_6565e0762f8844ac933ade9b1b3d9c9a\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121893053\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:50:00Z\",\"updated_at\":\"2022-06-01T19:50:00Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzY1NjVlMDc2MmY4ODQ0YWM5MzNhZGU5YjFiM2Q5Yzlh\"},\"to_address\":{\"id\":\"adr_04c465fee1e411ecbad0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:59+00:00\",\"updated_at\":\"2022-06-01T19:49:59+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_04c5b1b5e1e411ecb177ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:59+00:00\",\"updated_at\":\"2022-06-01T19:49:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_04c465fee1e411ecbad0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:59+00:00\",\"updated_at\":\"2022-06-01T19:49:59+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_5ebba3a2014942c58f13d70fb4180204\",\"object\":\"Shipment\"}"
+            "size": 2223,
+            "text": "{\"created_at\":\"2022-07-29T22:04:08Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689531\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_5e59019d0f8a11eda391ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:08+00:00\",\"updated_at\":\"2022-07-29T22:04:08+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_caeff998a4f9452ea31c21ca79fd39c0\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_cb1e94c11b9d475daedb8cc87344e38d\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:04:08Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/c8b53a2c5ec64f8794c6578d0a33abd9.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_f3a5e606a65f4f1d938c706335d77fb7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6e6d7ef4fa274e19bab040a1a962da59\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f927b1c10ceb4484bd0325584c82a802\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c25cfae778084e8e956acf8d02a4953d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_f3a5e606a65f4f1d938c706335d77fb7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:08Z\",\"updated_at\":\"2022-07-29T22:04:08Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_6684db2085724b9a86fc24876914efb1\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689531\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:04:09Z\",\"updated_at\":\"2022-07-29T22:04:09Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzY2ODRkYjIwODU3MjRiOWE4NmZjMjQ4NzY5MTRlZmIx\"},\"to_address\":{\"id\":\"adr_5e5707800f8a11edb997ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:08+00:00\",\"updated_at\":\"2022-07-29T22:04:08+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_5e59019d0f8a11eda391ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:08+00:00\",\"updated_at\":\"2022-07-29T22:04:08+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_5e5707800f8a11edb997ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:08+00:00\",\"updated_at\":\"2022-07-29T22:04:08+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2e7e786c5650009b6f3"
+              "value": "999d146b62e45958e788dda2000ff5f8"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_5ebba3a2014942c58f13d70fb4180204"
+              "value": "/api/v2/shipments/shp_07ae2c5ae4114ebdb128a12c67eb218a"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"e9e1f10ae03d9b3a59c6c3ebfc1d824a\""
+              "value": "W/\"2ee398c08e856ab161e4e1340f051107\""
             },
             {
               "name": "x-runtime",
-              "value": "1.292180"
+              "value": "1.012008"
             },
             {
               "name": "content-encoding",
@@ -123,23 +123,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -150,14 +146,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 828,
+          "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_5ebba3a2014942c58f13d70fb4180204",
+          "redirectURL": "/api/v2/shipments/shp_07ae2c5ae4114ebdb128a12c67eb218a",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:58.783Z",
-        "time": 1490,
+        "startedDateTime": "2022-07-29T22:04:07.861Z",
+        "time": 1206,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -165,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1490
+          "wait": 1206
         }
       },
       {
-        "_id": "879857d1919236d777bff564c00b5ec2",
+        "_id": "bde12830fdfa3dda2448a57fb8f5f154",
         "_order": 0,
         "cache": {},
         "request": {
@@ -197,13 +193,13 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 491,
+          "headersSize": 389,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-06-03\",\"max_datetime\":\"2022-06-03\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_5ebba3a2014942c58f13d70fb4180204\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-08-01\",\"max_datetime\":\"2022-08-01\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_07ae2c5ae4114ebdb128a12c67eb218a\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -214,7 +210,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 728,
-            "text": "{\"id\":\"pickup_f6c11111c5f142d89c45c76b8c130b5c\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:00Z\",\"updated_at\":\"2022-06-01T19:50:00Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_05a8e67ce1e411ecb1d6ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:00+00:00\",\"updated_at\":\"2022-06-01T19:50:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:01Z\",\"updated_at\":\"2022-06-01T19:50:01Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_f6c11111c5f142d89c45c76b8c130b5c\",\"id\":\"pickuprate_df690aa3254d45d28a507c3cb784b506\",\"object\":\"PickupRate\"}]}"
+            "text": "{\"id\":\"pickup_924d0437a5b44b659eda1d3b9527cfee\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:09Z\",\"updated_at\":\"2022-07-29T22:04:09Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_5f1120540f8a11edab2aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:09+00:00\",\"updated_at\":\"2022-07-29T22:04:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:09Z\",\"updated_at\":\"2022-07-29T22:04:09Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_924d0437a5b44b659eda1d3b9527cfee\",\"id\":\"pickuprate_afb674e720a048118145bf63b1810774\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -244,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2e8e786c5660009b80b"
+              "value": "999d147062e45959e788dda3000ff65e"
             },
             {
               "name": "cache-control",
@@ -264,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"7a07a604fcb07c6c2f33fda5433dc5b9\""
+              "value": "W/\"6f15d39048f23db264e4ae5bdb17752c\""
             },
             {
               "name": "x-runtime",
-              "value": "0.894266"
+              "value": "0.697439"
             },
             {
               "name": "content-encoding",
@@ -280,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -292,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -309,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:00.280Z",
-        "time": 1090,
+        "startedDateTime": "2022-07-29T22:04:09.074Z",
+        "time": 1050,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,11 +314,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1090
+          "wait": 1050
         }
       },
       {
-        "_id": "b2d5d9499d40aaea5cc3240d278d39f2",
+        "_id": "096d0cfa43157b0e874055a7c40b7250",
         "_order": 0,
         "cache": {},
         "request": {
@@ -350,7 +346,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 534,
+          "headersSize": 432,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -359,15 +355,15 @@
             "text": "{\"carrier\":\"USPS\",\"service\":\"NextDay\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_f6c11111c5f142d89c45c76b8c130b5c/buy"
+          "url": "https://api.easypost.com/v2/pickups/pickup_924d0437a5b44b659eda1d3b9527cfee/buy"
         },
         "response": {
-          "bodySize": 748,
+          "bodySize": 752,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 748,
-            "text": "{\"id\":\"pickup_f6c11111c5f142d89c45c76b8c130b5c\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:00Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"mode\":\"test\",\"status\":\"scheduled\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61819780\",\"address\":{\"id\":\"adr_05a8e67ce1e411ecb1d6ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:00+00:00\",\"updated_at\":\"2022-06-01T19:50:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:01Z\",\"updated_at\":\"2022-06-01T19:50:01Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_f6c11111c5f142d89c45c76b8c130b5c\",\"id\":\"pickuprate_df690aa3254d45d28a507c3cb784b506\",\"object\":\"PickupRate\"}]}"
+            "size": 752,
+            "text": "{\"id\":\"pickup_924d0437a5b44b659eda1d3b9527cfee\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:09Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"mode\":\"test\",\"status\":\"scheduled\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61992422\",\"address\":{\"id\":\"adr_5f1120540f8a11edab2aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:09+00:00\",\"updated_at\":\"2022-07-29T22:04:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:09Z\",\"updated_at\":\"2022-07-29T22:04:09Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_924d0437a5b44b659eda1d3b9527cfee\",\"id\":\"pickuprate_afb674e720a048118145bf63b1810774\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -397,7 +393,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c2e9e786c5670009b8b2"
+              "value": "999d146d62e4595ae788dda4000ff6b2"
             },
             {
               "name": "cache-control",
@@ -417,11 +413,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"143bc70bef181badeec6b134e0930e74\""
+              "value": "W/\"e8e374ec65eacc57ef5b02e434f4c2e0\""
             },
             {
               "name": "x-runtime",
-              "value": "0.969458"
+              "value": "1.124591"
             },
             {
               "name": "content-encoding",
@@ -433,11 +429,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -445,7 +441,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -462,8 +458,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:01.380Z",
-        "time": 1166,
+        "startedDateTime": "2022-07-29T22:04:10.128Z",
+        "time": 1417,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -471,7 +467,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1166
+          "wait": 1417
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/cancels-a-pickup_4207662041/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/cancels-a-pickup_4207662041/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2242,
+          "bodySize": 2234,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2242,
-            "text": "{\"created_at\":\"2022-06-01T19:50:02Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121893060\",\"updated_at\":\"2022-06-01T19:50:03Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_07064158e1e411ecb905ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:02+00:00\",\"updated_at\":\"2022-06-01T19:50:02+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e3d0e785e79d42eda46219e8937c2e1d\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:50:02Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_b296ae789bc545a28bac1f2a1559e20b\",\"created_at\":\"2022-06-01T19:50:03Z\",\"updated_at\":\"2022-06-01T19:50:03Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:50:03Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/aee4c781e3a447e18a21f7fb39ca3285.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_9fb1968049dd4ac1a821df2888158484\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:02Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_68bc9551a8a542349a39d3625d67ce16\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:02Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c15b311b3489469abb2c8d3f3db65b08\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:02Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_99325b60f6a749afb812f19a847cbdb0\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:02Z\",\"updated_at\":\"2022-06-01T19:50:02Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_c15b311b3489469abb2c8d3f3db65b08\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:03Z\",\"updated_at\":\"2022-06-01T19:50:03Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_4026a08ecd0a47498c105b052b4668ea\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121893060\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:50:03Z\",\"updated_at\":\"2022-06-01T19:50:03Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzQwMjZhMDhlY2QwYTQ3NDk4YzEwNWIwNTJiNDY2OGVh\"},\"to_address\":{\"id\":\"adr_07047f5ae1e411ec8c06ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:02+00:00\",\"updated_at\":\"2022-06-01T19:50:03+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_07064158e1e411ecb905ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:02+00:00\",\"updated_at\":\"2022-06-01T19:50:02+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_07047f5ae1e411ec8c06ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:02+00:00\",\"updated_at\":\"2022-06-01T19:50:03+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_77d4c2743e694251b78f1828e3928f7b\",\"object\":\"Shipment\"}"
+            "size": 2234,
+            "text": "{\"created_at\":\"2022-07-29T22:04:11Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689555\",\"updated_at\":\"2022-07-29T22:04:12Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_608db3d80f8a11edab86ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:11+00:00\",\"updated_at\":\"2022-07-29T22:04:11+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_4372095e273f428281d0c1b8b825deee\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:11Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_c0c374c05b974b3fa66c152309883021\",\"created_at\":\"2022-07-29T22:04:12Z\",\"updated_at\":\"2022-07-29T22:04:12Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:04:12Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/eefadbcdd8234ef5ba61b2821f1643ab.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_15e9fb153d774eadb6fb99f0189c0cfe\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:11Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_22649c217f1a46748933eda35bcfa545\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:11Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_9fe1961ae4004e4fa2cbb16cebf4b6e4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:11Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_67a6927fb3aa43858abcd31363a84898\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:11Z\",\"updated_at\":\"2022-07-29T22:04:11Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_9fe1961ae4004e4fa2cbb16cebf4b6e4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:12Z\",\"updated_at\":\"2022-07-29T22:04:12Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_c4733127222240f880947adb466dec1b\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689555\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:04:12Z\",\"updated_at\":\"2022-07-29T22:04:12Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2M0NzMzMTI3MjIyMjQwZjg4MDk0N2FkYjQ2NmRlYzFi\"},\"to_address\":{\"id\":\"adr_608b56c30f8a11edab85ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:11+00:00\",\"updated_at\":\"2022-07-29T22:04:12+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_608db3d80f8a11edab86ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:11+00:00\",\"updated_at\":\"2022-07-29T22:04:11+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_608b56c30f8a11edab85ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:11+00:00\",\"updated_at\":\"2022-07-29T22:04:12+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2eae786c5810009b97a"
+              "value": "999d146e62e4595be788dda5000ff735"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_77d4c2743e694251b78f1828e3928f7b"
+              "value": "/api/v2/shipments/shp_796e51f38f8e4ad7a0773c54718d09f3"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"16c71c778344bb7f9355c405babb9eea\""
+              "value": "W/\"3fb0784dbaec3fe43ae599a717e27129\""
             },
             {
               "name": "x-runtime",
-              "value": "0.925162"
+              "value": "0.982230"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_77d4c2743e694251b78f1828e3928f7b",
+          "redirectURL": "/api/v2/shipments/shp_796e51f38f8e4ad7a0773c54718d09f3",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:50:02.569Z",
-        "time": 1114,
+        "startedDateTime": "2022-07-29T22:04:11.556Z",
+        "time": 1218,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1114
+          "wait": 1218
         }
       },
       {
-        "_id": "4f0f9907fd44072ea1cc9c6a2e0d1240",
+        "_id": "b28a9470a6a17feb6d60609866ff0877",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 491,
+          "headersSize": 389,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-06-03\",\"max_datetime\":\"2022-06-03\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_77d4c2743e694251b78f1828e3928f7b\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-08-01\",\"max_datetime\":\"2022-08-01\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_796e51f38f8e4ad7a0773c54718d09f3\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
         },
         "response": {
-          "bodySize": 728,
+          "bodySize": 732,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 728,
-            "text": "{\"id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:04Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_07b0b1a6e1e411ec8c5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:03+00:00\",\"updated_at\":\"2022-06-01T19:50:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:04Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"id\":\"pickuprate_612327744ede424e975394660b9d3ed2\",\"object\":\"PickupRate\"}]}"
+            "size": 732,
+            "text": "{\"id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:13Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_6145d25c0f8a11edabb0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:13+00:00\",\"updated_at\":\"2022-07-29T22:04:13+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:13Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"id\":\"pickuprate_1759698f94454c97be2c0b7815eac0d9\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2ebe786c5820009ba20"
+              "value": "999d146962e4595ce788dda6000ff848"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"298b7bd547630cd022b8c40f757ab6f9\""
+              "value": "W/\"e704e2e4e2cea0ce49a46c0d719be266\""
             },
             {
               "name": "x-runtime",
-              "value": "0.703497"
+              "value": "0.709560"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:03.693Z",
-        "time": 949,
+        "startedDateTime": "2022-07-29T22:04:12.779Z",
+        "time": 916,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,11 +314,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 949
+          "wait": 916
         }
       },
       {
-        "_id": "9d23ac29a3036124b72adbae7fe2ee93",
+        "_id": "63e0f2bb443eab20c808f82c4ef18aea",
         "_order": 0,
         "cache": {},
         "request": {
@@ -346,7 +346,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 534,
+          "headersSize": 432,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -355,15 +355,15 @@
             "text": "{\"carrier\":\"USPS\",\"service\":\"NextDay\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_36f393c423ed47d9b030529a219cb1b1/buy"
+          "url": "https://api.easypost.com/v2/pickups/pickup_fbd9de2d721148ff88433533309ee4d0/buy"
         },
         "response": {
-          "bodySize": 748,
+          "bodySize": 752,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 748,
-            "text": "{\"id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:05Z\",\"mode\":\"test\",\"status\":\"scheduled\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61819762\",\"address\":{\"id\":\"adr_07b0b1a6e1e411ec8c5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:03+00:00\",\"updated_at\":\"2022-06-01T19:50:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:04Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"id\":\"pickuprate_612327744ede424e975394660b9d3ed2\",\"object\":\"PickupRate\"}]}"
+            "size": 752,
+            "text": "{\"id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:14Z\",\"mode\":\"test\",\"status\":\"scheduled\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61992424\",\"address\":{\"id\":\"adr_6145d25c0f8a11edabb0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:13+00:00\",\"updated_at\":\"2022-07-29T22:04:13+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:13Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"id\":\"pickuprate_1759698f94454c97be2c0b7815eac0d9\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -393,7 +393,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2ece786c5830009bad1"
+              "value": "999d146d62e4595de788dda7000ff8c2"
             },
             {
               "name": "cache-control",
@@ -413,11 +413,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"407af014b02ddc4599ad757f5e0cb651\""
+              "value": "W/\"e834c6d44f583496f74bbcdc9605132c\""
             },
             {
               "name": "x-runtime",
-              "value": "1.028339"
+              "value": "0.684660"
             },
             {
               "name": "content-encoding",
@@ -429,11 +429,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -441,7 +441,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -458,8 +458,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:04.648Z",
-        "time": 1324,
+        "startedDateTime": "2022-07-29T22:04:13.699Z",
+        "time": 874,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -467,11 +467,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1324
+          "wait": 874
         }
       },
       {
-        "_id": "7d332f02046bdcea8c2b7cf850c51e5a",
+        "_id": "9e2d89a77f9007eea8c80230cb98a22b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -499,7 +499,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 536,
+          "headersSize": 434,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -508,15 +508,15 @@
             "text": "{}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_36f393c423ed47d9b030529a219cb1b1/cancel"
+          "url": "https://api.easypost.com/v2/pickups/pickup_fbd9de2d721148ff88433533309ee4d0/cancel"
         },
         "response": {
-          "bodySize": 748,
+          "bodySize": 752,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 748,
-            "text": "{\"id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"mode\":\"test\",\"status\":\"canceled\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61819762\",\"address\":{\"id\":\"adr_07b0b1a6e1e411ec8c5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:03+00:00\",\"updated_at\":\"2022-06-01T19:50:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:04Z\",\"updated_at\":\"2022-06-01T19:50:04Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_36f393c423ed47d9b030529a219cb1b1\",\"id\":\"pickuprate_612327744ede424e975394660b9d3ed2\",\"object\":\"PickupRate\"}]}"
+            "size": 752,
+            "text": "{\"id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"mode\":\"test\",\"status\":\"canceled\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":\"WTC61992424\",\"address\":{\"id\":\"adr_6145d25c0f8a11edabb0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:13+00:00\",\"updated_at\":\"2022-07-29T22:04:13+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:13Z\",\"updated_at\":\"2022-07-29T22:04:13Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_fbd9de2d721148ff88433533309ee4d0\",\"id\":\"pickuprate_1759698f94454c97be2c0b7815eac0d9\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -546,7 +546,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2eee786c5840009bba1"
+              "value": "999d146d62e4595ee788dda8000ff918"
             },
             {
               "name": "cache-control",
@@ -566,11 +566,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"2c68abf8ad014e4854c8cf599c85e518\""
+              "value": "W/\"5d76f909a6f58365c8649baded02eea6\""
             },
             {
               "name": "x-runtime",
-              "value": "0.944544"
+              "value": "0.780811"
             },
             {
               "name": "content-encoding",
@@ -582,11 +582,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -594,7 +594,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -611,8 +611,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:05.978Z",
-        "time": 1226,
+        "startedDateTime": "2022-07-29T22:04:14.580Z",
+        "time": 978,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -620,7 +620,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1226
+          "wait": 978
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/creates-a-pickup_320342919/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/creates-a-pickup_320342919/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2246,
+          "bodySize": 2231,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2246,
-            "text": "{\"created_at\":\"2022-06-01T19:49:52Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121893022\",\"updated_at\":\"2022-06-01T19:49:53Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_010ab7cce1e411ec8995ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:52+00:00\",\"updated_at\":\"2022-06-01T19:49:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_9c0918f0c7684858a52c083f926bdb60\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:52Z\",\"updated_at\":\"2022-06-01T19:49:52Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_76c7468e2a5342f495d25e728a79ae63\",\"created_at\":\"2022-06-01T19:49:53Z\",\"updated_at\":\"2022-06-01T19:49:53Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:53Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/182da677d4864eeb8c1232ceceef3b7b.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_5247371b61a84be78a2f1faa217d2681\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:52Z\",\"updated_at\":\"2022-06-01T19:49:52Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_49e707a0f9234614b525efb026f4d3b4\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:52Z\",\"updated_at\":\"2022-06-01T19:49:52Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_71335403f23142b2a56686f20592d635\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:52Z\",\"updated_at\":\"2022-06-01T19:49:52Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_fe7e09f6f1934073a4e5c09202afea04\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:52Z\",\"updated_at\":\"2022-06-01T19:49:52Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_71335403f23142b2a56686f20592d635\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:53Z\",\"updated_at\":\"2022-06-01T19:49:53Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_e1fa4d740f7b482eaaa45e701d25b700\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121893022\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:49:53Z\",\"updated_at\":\"2022-06-01T19:49:53Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2UxZmE0ZDc0MGY3YjQ4MmVhYWE0NWU3MDFkMjViNzAw\"},\"to_address\":{\"id\":\"adr_01058a1ee1e411ecb942ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:52+00:00\",\"updated_at\":\"2022-06-01T19:49:53+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_010ab7cce1e411ec8995ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:52+00:00\",\"updated_at\":\"2022-06-01T19:49:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_01058a1ee1e411ecb942ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:52+00:00\",\"updated_at\":\"2022-06-01T19:49:53+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_bafad99d44e9487988118c24b28a5b41\",\"object\":\"Shipment\"}"
+            "size": 2231,
+            "text": "{\"created_at\":\"2022-07-29T22:02:39Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689333\",\"updated_at\":\"2022-07-29T22:02:40Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_299be5270f8a11ed9f32ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:39+00:00\",\"updated_at\":\"2022-07-29T22:02:39+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_c5f6bebb1a694f07ba99f02208efdf39\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:39Z\",\"updated_at\":\"2022-07-29T22:02:39Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_8f3bea1610394d58a93854d0e4365293\",\"created_at\":\"2022-07-29T22:02:40Z\",\"updated_at\":\"2022-07-29T22:02:40Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:40Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/4a01e115b1b5447493ff5665c96908c3.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_dab74c7caac24dc896b4503b3e3ea289\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:39Z\",\"updated_at\":\"2022-07-29T22:02:39Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1950c5ce28a64dae9d8b252b7deaa126\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:39Z\",\"updated_at\":\"2022-07-29T22:02:39Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8d22270e1a824da28281b85b453bfadb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:39Z\",\"updated_at\":\"2022-07-29T22:02:39Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_407afd2dc77d414999c0a06691bb912b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:39Z\",\"updated_at\":\"2022-07-29T22:02:39Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_8d22270e1a824da28281b85b453bfadb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:40Z\",\"updated_at\":\"2022-07-29T22:02:40Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_1b5f94b64ccd447aaa709f6d74c0b583\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689333\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:40Z\",\"updated_at\":\"2022-07-29T22:02:40Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzFiNWY5NGI2NGNjZDQ0N2FhYTcwOWY2ZDc0YzBiNTgz\"},\"to_address\":{\"id\":\"adr_299a075a0f8a11ed9f31ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:39+00:00\",\"updated_at\":\"2022-07-29T22:02:39+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_299be5270f8a11ed9f32ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:39+00:00\",\"updated_at\":\"2022-07-29T22:02:39+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_299a075a0f8a11ed9f31ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:39+00:00\",\"updated_at\":\"2022-07-29T22:02:39+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_55b15f16237448e4911e621fde16d47f\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2e0e786c5600009b27b"
+              "value": "999d147062e458ffe788dcbd000fdc05"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_bafad99d44e9487988118c24b28a5b41"
+              "value": "/api/v2/shipments/shp_55b15f16237448e4911e621fde16d47f"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"62d3f93bf1238276af6c3a3df9a78736\""
+              "value": "W/\"0f3244cb091ab53bdd28c70dc82e1d14\""
             },
             {
               "name": "x-runtime",
-              "value": "1.151798"
+              "value": "0.995623"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_bafad99d44e9487988118c24b28a5b41",
+          "redirectURL": "/api/v2/shipments/shp_55b15f16237448e4911e621fde16d47f",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:52.514Z",
-        "time": 1377,
+        "startedDateTime": "2022-07-29T22:02:39.386Z",
+        "time": 1228,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1377
+          "wait": 1228
         }
       },
       {
-        "_id": "997e4e20ada1956e61b4765cad48e05a",
+        "_id": "d611386480485d4f80784e2b7883b879",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,13 +193,13 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 491,
+          "headersSize": 389,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-06-03\",\"max_datetime\":\"2022-06-03\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_bafad99d44e9487988118c24b28a5b41\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-08-01\",\"max_datetime\":\"2022-08-01\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_55b15f16237448e4911e621fde16d47f\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -210,7 +210,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "{\"id\":\"pickup_fe5db908f45d47d3a04e8e29477f778a\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:49:54Z\",\"updated_at\":\"2022-06-01T19:49:54Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_01d9ebb3e1e411ecb058ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:54+00:00\",\"updated_at\":\"2022-06-01T19:49:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:49:55Z\",\"updated_at\":\"2022-06-01T19:49:55Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_fe5db908f45d47d3a04e8e29477f778a\",\"id\":\"pickuprate_95193e98f7354b5dabf9f14fec708817\",\"object\":\"PickupRate\"}]}"
+            "text": "{\"id\":\"pickup_e8af9d50dccb4a619741094542302eaf\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:04Z\",\"updated_at\":\"2022-07-29T22:04:04Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_5c4112710f8a11edaa73ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:04+00:00\",\"updated_at\":\"2022-07-29T22:04:04+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:05Z\",\"updated_at\":\"2022-07-29T22:04:05Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_e8af9d50dccb4a619741094542302eaf\",\"id\":\"pickuprate_d7b50855b5064ba2841e6d38120965c7\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c2e2e786c5610009b37c"
+              "value": "999d146d62e45954e788dd88000ff4f7"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"a92fd9eb2c24e0f03d8c5727395a1452\""
+              "value": "W/\"5d064d3a5c542695f12b906cead1df40\""
             },
             {
               "name": "x-runtime",
-              "value": "1.478895"
+              "value": "0.848703"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:53.899Z",
-        "time": 1731,
+        "startedDateTime": "2022-07-29T22:04:04.350Z",
+        "time": 1121,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1731
+          "wait": 1121
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/gets-the-lowest-rate_906620131/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/gets-the-lowest-rate_906620131/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2223,
+          "bodySize": 2234,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2223,
-            "text": "{\"created_at\":\"2022-06-01T19:50:07Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121893077\",\"updated_at\":\"2022-06-01T19:50:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_09cfbdcde1e411ec8d5dac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:07+00:00\",\"updated_at\":\"2022-06-01T19:50:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_dc985263b05a468a847b1d038f9945f7\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:50:07Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_c381891d5ca74b70b7649ea114e6100a\",\"created_at\":\"2022-06-01T19:50:08Z\",\"updated_at\":\"2022-06-01T19:50:08Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:50:08Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/8382d53abad34d059c6ec5fd52aab81c.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_c5e2a8e36edf467ebfcaded99a63c726\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:07Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_da6be98a375941638aa96a6c6f8a58c0\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:07Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_80c724164da247a7b17624cd26794a2d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:07Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c468e6ae5d0c4ebd821a119aaef3fb1e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:07Z\",\"updated_at\":\"2022-06-01T19:50:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_c468e6ae5d0c4ebd821a119aaef3fb1e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:50:08Z\",\"updated_at\":\"2022-06-01T19:50:08Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_9109eb0b8a5f48b7bae07b10332b643a\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121893077\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:50:08Z\",\"updated_at\":\"2022-06-01T19:50:08Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_b52e075b5e75415e95079d973b872670\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzkxMDllYjBiOGE1ZjQ4YjdiYWUwN2IxMDMzMmI2NDNh\"},\"to_address\":{\"id\":\"adr_09cdccdce1e411ecb3abac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:07+00:00\",\"updated_at\":\"2022-06-01T19:50:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_09cfbdcde1e411ec8d5dac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:07+00:00\",\"updated_at\":\"2022-06-01T19:50:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_09cdccdce1e411ecb3abac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:07+00:00\",\"updated_at\":\"2022-06-01T19:50:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_b52e075b5e75415e95079d973b872670\",\"object\":\"Shipment\"}"
+            "size": 2234,
+            "text": "{\"created_at\":\"2022-07-29T22:04:15Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689579\",\"updated_at\":\"2022-07-29T22:04:16Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_62f423330f8a11edba47ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:15+00:00\",\"updated_at\":\"2022-07-29T22:04:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_16855389d28741a681c9e1a2e5cd78ee\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:15Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_56a5fad2bc154736bba2620b52415013\",\"created_at\":\"2022-07-29T22:04:16Z\",\"updated_at\":\"2022-07-29T22:04:16Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:04:16Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/85ea2c88e3b44b06bf04e05f553e3b77.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_ba3454f8bf544e01ba8b2fd5688bddb3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:15Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_733fca925c8348879c60c5ca33749ecf\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:15Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2307cdffc77b4c04ae6385eebfc9b03a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:15Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_184e2e96eeb549118ef77a7bfaa2c01c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:15Z\",\"updated_at\":\"2022-07-29T22:04:15Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_184e2e96eeb549118ef77a7bfaa2c01c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:16Z\",\"updated_at\":\"2022-07-29T22:04:16Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_913271ea44af40db9557dabfc9ec13f4\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689579\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:04:16Z\",\"updated_at\":\"2022-07-29T22:04:16Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzkxMzI3MWVhNDRhZjQwZGI5NTU3ZGFiZmM5ZWMxM2Y0\"},\"to_address\":{\"id\":\"adr_62f238490f8a11edb66bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:15+00:00\",\"updated_at\":\"2022-07-29T22:04:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_62f423330f8a11edba47ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:15+00:00\",\"updated_at\":\"2022-07-29T22:04:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_62f238490f8a11edb66bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:15+00:00\",\"updated_at\":\"2022-07-29T22:04:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_dd4c25c04ae045db80ceba732414400a\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297c2efe786c5850009bc77"
+              "value": "999d146d62e4595fe788dda9000ff96c"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_b52e075b5e75415e95079d973b872670"
+              "value": "/api/v2/shipments/shp_dd4c25c04ae045db80ceba732414400a"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"553635aa5c452d3fcba23529be970a0e\""
+              "value": "W/\"7462c3b76aeb8d2e5b73f8f653476d1d\""
             },
             {
               "name": "x-runtime",
-              "value": "0.952320"
+              "value": "1.122680"
             },
             {
               "name": "content-encoding",
@@ -123,19 +123,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 828,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_b52e075b5e75415e95079d973b872670",
+          "redirectURL": "/api/v2/shipments/shp_dd4c25c04ae045db80ceba732414400a",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:50:07.230Z",
-        "time": 1204,
+        "startedDateTime": "2022-07-29T22:04:15.586Z",
+        "time": 1319,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +165,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1204
+          "wait": 1319
         }
       },
       {
-        "_id": "dbf93615fc0cf2a846c331c420ebdd66",
+        "_id": "6512bef57e202971fc843ee0de1baf52",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,13 +197,13 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 491,
+          "headersSize": 389,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-06-03\",\"max_datetime\":\"2022-06-03\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_b52e075b5e75415e95079d973b872670\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-08-01\",\"max_datetime\":\"2022-08-01\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_dd4c25c04ae045db80ceba732414400a\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
@@ -210,7 +214,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 732,
-            "text": "{\"id\":\"pickup_06b91513b4aa4ce2bc1e3d293a979b2e\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:50:08Z\",\"updated_at\":\"2022-06-01T19:50:08Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_0a86ef5ee1e411ecba03ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:50:08+00:00\",\"updated_at\":\"2022-06-01T19:50:08+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:50:09Z\",\"updated_at\":\"2022-06-01T19:50:09Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_06b91513b4aa4ce2bc1e3d293a979b2e\",\"id\":\"pickuprate_4b5be85893454f1f969c7294e98cdc23\",\"object\":\"PickupRate\"}]}"
+            "text": "{\"id\":\"pickup_97aa8b8e83384818a6293d1495dea390\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:17Z\",\"updated_at\":\"2022-07-29T22:04:17Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_63bd8f3c0f8a11edb6a5ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:17+00:00\",\"updated_at\":\"2022-07-29T22:04:17+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:17Z\",\"updated_at\":\"2022-07-29T22:04:17Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_97aa8b8e83384818a6293d1495dea390\",\"id\":\"pickuprate_ed4c02e773fb43f1ad99c66bb3f97ff6\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +244,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2f0e786c5860009bd39"
+              "value": "999d146e62e45961e788ddc1000ff9d5"
             },
             {
               "name": "cache-control",
@@ -260,11 +264,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0b63cc0dee681aad60973dbff445aeb9\""
+              "value": "W/\"c59393772fdb31442375c2780876e78c\""
             },
             {
               "name": "x-runtime",
-              "value": "0.844193"
+              "value": "0.751240"
             },
             {
               "name": "content-encoding",
@@ -276,23 +280,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -303,14 +303,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:50:08.445Z",
-        "time": 1115,
+        "startedDateTime": "2022-07-29T22:04:16.911Z",
+        "time": 951,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1115
+          "wait": 951
         }
       }
     ],

--- a/test/cassettes/Pickup-Resource_1673862587/retrieves-a-pickup_3320623723/recording.har
+++ b/test/cassettes/Pickup-Resource_1673862587/retrieves-a-pickup_3320623723/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2246,
+          "bodySize": 2212,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2246,
-            "text": "{\"created_at\":\"2022-06-01T19:49:55Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121893046\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_02e53ab8e1e411ec8a64ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:55+00:00\",\"updated_at\":\"2022-06-01T19:49:55+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e85991b3f75a46b9bef3bbcdbce4b679\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:55Z\",\"updated_at\":\"2022-06-01T19:49:55Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_f061a6738fe4403fb65a357357e93799\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:56Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/7157d07ff8074f58852b432d0ca5c533.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_89b910d518fe4c14b2301963fc4ed350\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_81293ec5654f4439a504442d32be2adc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_3685582e568547d0906760b2d0ff8c68\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f5f3a828e6b9439eaf5cb15f107c6a16\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_81293ec5654f4439a504442d32be2adc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_9d9b59e50eec457793ab65dca3dc2486\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121893046\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:49:56Z\",\"updated_at\":\"2022-06-01T19:49:56Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzlkOWI1OWU1MGVlYzQ1Nzc5M2FiNjVkY2EzZGMyNDg2\"},\"to_address\":{\"id\":\"adr_02e2eab5e1e411ecb0cbac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:55+00:00\",\"updated_at\":\"2022-06-01T19:49:56+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_02e53ab8e1e411ec8a64ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:55+00:00\",\"updated_at\":\"2022-06-01T19:49:55+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_02e2eab5e1e411ecb0cbac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:55+00:00\",\"updated_at\":\"2022-06-01T19:49:56+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\",\"object\":\"Shipment\"}"
+            "size": 2212,
+            "text": "{\"created_at\":\"2022-07-29T22:02:41Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689340\",\"updated_at\":\"2022-07-29T22:02:42Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2aa7efb40f8a11edb27fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:41+00:00\",\"updated_at\":\"2022-07-29T22:02:41+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_95017c4f943b4a3fa0c8f2efd43065d4\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:41Z\",\"updated_at\":\"2022-07-29T22:02:41Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_ac85e709e6cd480f8345b77088c03c6b\",\"created_at\":\"2022-07-29T22:02:42Z\",\"updated_at\":\"2022-07-29T22:02:42Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:42Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/8accf4568180401d8f31b7cab0525756.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_93dd8fad9bd440b186c10f0cb30383a6\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:41Z\",\"updated_at\":\"2022-07-29T22:02:41Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_df4e85cc1680405cb8d9c64f2e9dca1c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:41Z\",\"updated_at\":\"2022-07-29T22:02:41Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0e2d9eda046c481f96f47fef5b4eb1ea\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:41Z\",\"updated_at\":\"2022-07-29T22:02:41Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e65a220dd3784c6da29b787b6815356b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:41Z\",\"updated_at\":\"2022-07-29T22:02:41Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_e65a220dd3784c6da29b787b6815356b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:42Z\",\"updated_at\":\"2022-07-29T22:02:42Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_3feba1b03001445d9002f70a98a197b6\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689340\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:42Z\",\"updated_at\":\"2022-07-29T22:02:42Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzNmZWJhMWIwMzAwMTQ0NWQ5MDAyZjcwYTk4YTE5N2I2\"},\"to_address\":{\"id\":\"adr_2aa611180f8a11edb27dac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:41+00:00\",\"updated_at\":\"2022-07-29T22:02:41+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2aa7efb40f8a11edb27fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:41+00:00\",\"updated_at\":\"2022-07-29T22:02:41+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2aa611180f8a11edb27dac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:41+00:00\",\"updated_at\":\"2022-07-29T22:02:41+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2e3e786c5620009b4c7"
+              "value": "999d146c62e45901e788dcbf000fdc80"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_6496f7b5dae3494cb134f77fd19a988c"
+              "value": "/api/v2/shipments/shp_262e5347c98b40d1887a083a74bd4f1a"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"71d29aa7a36a9542205a24b38e2a1725\""
+              "value": "W/\"b1340dc03d0b972851b103807f7340a8\""
             },
             {
               "name": "x-runtime",
-              "value": "1.058230"
+              "value": "1.108211"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_6496f7b5dae3494cb134f77fd19a988c",
+          "redirectURL": "/api/v2/shipments/shp_262e5347c98b40d1887a083a74bd4f1a",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:55.642Z",
-        "time": 1247,
+        "startedDateTime": "2022-07-29T22:02:41.132Z",
+        "time": 1305,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1247
+          "wait": 1305
         }
       },
       {
-        "_id": "aeb9574cb5f213310f816cb492849f6a",
+        "_id": "2f5af16ff0a55c42044e20f703116ba6",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 491,
+          "headersSize": 389,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"pickup\":{\"min_datetime\":\"2022-06-03\",\"max_datetime\":\"2022-06-03\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_6496f7b5dae3494cb134f77fd19a988c\"}}}"
+            "text": "{\"pickup\":{\"min_datetime\":\"2022-08-01\",\"max_datetime\":\"2022-08-01\",\"instructions\":\"Pickup at front door\",\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"shipment\":{\"id\":\"shp_262e5347c98b40d1887a083a74bd4f1a\"}}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/pickups"
         },
         "response": {
-          "bodySize": 728,
+          "bodySize": 732,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 728,
-            "text": "{\"id\":\"pickup_a0d248864bc544feba81ad8ad97e57dd\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:49:57Z\",\"updated_at\":\"2022-06-01T19:49:57Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_03a3f5e6e1e411ecb10bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:57+00:00\",\"updated_at\":\"2022-06-01T19:49:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:49:58Z\",\"updated_at\":\"2022-06-01T19:49:58Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_a0d248864bc544feba81ad8ad97e57dd\",\"id\":\"pickuprate_c59983dece0048feba3469f4c632b44f\",\"object\":\"PickupRate\"}]}"
+            "size": 732,
+            "text": "{\"id\":\"pickup_ba4dfb9027ba4f43b612948615481aef\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:05Z\",\"updated_at\":\"2022-07-29T22:04:05Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_5cecef1d0f8a11edb4fcac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:05+00:00\",\"updated_at\":\"2022-07-29T22:04:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:07Z\",\"updated_at\":\"2022-07-29T22:04:07Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_ba4dfb9027ba4f43b612948615481aef\",\"id\":\"pickuprate_3ffe9add1beb4f699eaa96371576a6ac\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2e5e786c5630009b592"
+              "value": "999d146a62e45955e788dda0000ff54b"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"da638c625004a212a301c81de6249d6e\""
+              "value": "W/\"64850f07e4f667724cbfb9851b6281cc\""
             },
             {
               "name": "x-runtime",
-              "value": "1.122531"
+              "value": "1.619472"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:56.896Z",
-        "time": 1603,
+        "startedDateTime": "2022-07-29T22:04:05.483Z",
+        "time": 1862,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,11 +314,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1603
+          "wait": 1862
         }
       },
       {
-        "_id": "acea6f3d8ce5049cdb6ca584c261476d",
+        "_id": "89ee75588ca699842480a4a9cb93a3ff",
         "_order": 0,
         "cache": {},
         "request": {
@@ -342,19 +342,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 509,
+          "headersSize": 407,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/pickups/pickup_a0d248864bc544feba81ad8ad97e57dd"
+          "url": "https://api.easypost.com/v2/pickups/pickup_ba4dfb9027ba4f43b612948615481aef"
         },
         "response": {
-          "bodySize": 728,
+          "bodySize": 732,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 728,
-            "text": "{\"id\":\"pickup_a0d248864bc544feba81ad8ad97e57dd\",\"object\":\"Pickup\",\"created_at\":\"2022-06-01T19:49:57Z\",\"updated_at\":\"2022-06-01T19:49:57Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-06-03T00:00:00Z\",\"max_datetime\":\"2022-06-03T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_03a3f5e6e1e411ecb10bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:57+00:00\",\"updated_at\":\"2022-06-01T19:49:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-06-01T19:49:58Z\",\"updated_at\":\"2022-06-01T19:49:58Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_a0d248864bc544feba81ad8ad97e57dd\",\"id\":\"pickuprate_c59983dece0048feba3469f4c632b44f\",\"object\":\"PickupRate\"}]}"
+            "size": 732,
+            "text": "{\"id\":\"pickup_ba4dfb9027ba4f43b612948615481aef\",\"object\":\"Pickup\",\"created_at\":\"2022-07-29T22:04:05Z\",\"updated_at\":\"2022-07-29T22:04:05Z\",\"mode\":\"test\",\"status\":\"unknown\",\"reference\":null,\"min_datetime\":\"2022-08-01T00:00:00Z\",\"max_datetime\":\"2022-08-01T00:00:00Z\",\"is_account_address\":false,\"instructions\":\"Pickup at front door\",\"messages\":[],\"confirmation\":null,\"address\":{\"id\":\"adr_5cecef1d0f8a11edb4fcac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:05+00:00\",\"updated_at\":\"2022-07-29T22:04:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"carrier_accounts\":[],\"pickup_rates\":[{\"mode\":\"test\",\"service\":\"NextDay\",\"rate\":\"0.00\",\"currency\":\"USD\",\"created_at\":\"2022-07-29T22:04:07Z\",\"updated_at\":\"2022-07-29T22:04:07Z\",\"carrier\":\"USPS\",\"pickup_id\":\"pickup_ba4dfb9027ba4f43b612948615481aef\",\"id\":\"pickuprate_3ffe9add1beb4f699eaa96371576a6ac\",\"object\":\"PickupRate\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -384,7 +384,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297c2e6e786c5640009b6bb"
+              "value": "999d146e62e45957e788dda1000ff5d1"
             },
             {
               "name": "cache-control",
@@ -404,11 +404,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"da638c625004a212a301c81de6249d6e\""
+              "value": "W/\"64850f07e4f667724cbfb9851b6281cc\""
             },
             {
               "name": "x-runtime",
-              "value": "0.067423"
+              "value": "0.080076"
             },
             {
               "name": "content-encoding",
@@ -420,11 +420,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -432,7 +432,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -449,8 +449,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:58.506Z",
-        "time": 261,
+        "startedDateTime": "2022-07-29T22:04:07.352Z",
+        "time": 503,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -458,7 +458,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 261
+          "wait": 503
         }
       }
     ],

--- a/test/cassettes/Rate-Resource_390152437/retrieves-a-rate_3801249961/recording.har
+++ b/test/cassettes/Rate-Resource_390152437/retrieves-a-rate_3801249961/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1567,
+          "bodySize": 1620,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1567,
-            "text": "{\"created_at\":\"2022-06-01T19:48:46Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:48:46Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_d966c4f0e1e311ecadf0ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:46+00:00\",\"updated_at\":\"2022-06-01T19:48:46+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_cb3af08c7fbb43bf85daa6c59da5aa1c\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_f733825b95b3454eae80805efe06b6b7\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_a579f9aeedf04b5aa49e91467b853af9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_3bc8150d33ad4d5b9dc3286c7c0c3fd5\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_12f6557131114e85a7bd466367f5076f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_d964dc09e1e311ecadeeac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:46+00:00\",\"updated_at\":\"2022-06-01T19:48:46+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_d966c4f0e1e311ecadf0ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:46+00:00\",\"updated_at\":\"2022-06-01T19:48:46+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_d964dc09e1e311ecadeeac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:46+00:00\",\"updated_at\":\"2022-06-01T19:48:46+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"object\":\"Shipment\"}"
+            "size": 1620,
+            "text": "{\"created_at\":\"2022-07-29T22:02:45Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:46Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2d3d20120f8a11eda9f6ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:45+00:00\",\"updated_at\":\"2022-07-29T22:02:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_692efc080fe84ce794b424f92a5f2f20\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:45Z\",\"updated_at\":\"2022-07-29T22:02:45Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_72db0cedd4cc4444818004ffa8541c06\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:46Z\",\"updated_at\":\"2022-07-29T22:02:46Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_c60bb928fe924689961ca113b2106733\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d137bccf670e406f88a71be390195dbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:46Z\",\"updated_at\":\"2022-07-29T22:02:46Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_c60bb928fe924689961ca113b2106733\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_76a68645f21f421f8e3de8e4bd68fed0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:46Z\",\"updated_at\":\"2022-07-29T22:02:46Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_c60bb928fe924689961ca113b2106733\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f48a6d33fb7447558daa22a4786b7391\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:46Z\",\"updated_at\":\"2022-07-29T22:02:46Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_c60bb928fe924689961ca113b2106733\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_2d3b38a60f8a11eda9f5ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:45+00:00\",\"updated_at\":\"2022-07-29T22:02:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2d3d20120f8a11eda9f6ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:45+00:00\",\"updated_at\":\"2022-07-29T22:02:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2d3b38a60f8a11eda9f5ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:45+00:00\",\"updated_at\":\"2022-07-29T22:02:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_c60bb928fe924689961ca113b2106733\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c29ee786c1820009834f"
+              "value": "999d147062e45905e788dcdd000fdddc"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_ab737df1fddc4b6e8ae4591ca483e35c"
+              "value": "/api/v2/shipments/shp_c60bb928fe924689961ca113b2106733"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"cb7b3792b0f3adadad123cc6cc1606b4\""
+              "value": "W/\"096d22131ac08f6157e8709cbfc195b8\""
             },
             {
               "name": "x-runtime",
-              "value": "0.623537"
+              "value": "0.626509"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_ab737df1fddc4b6e8ae4591ca483e35c",
+          "redirectURL": "/api/v2/shipments/shp_c60bb928fe924689961ca113b2106733",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:46.023Z",
-        "time": 815,
+        "startedDateTime": "2022-07-29T22:02:45.472Z",
+        "time": 875,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 815
+          "wait": 875
         }
       },
       {
-        "_id": "f5e30572e3c5f9be6d75c3c83d796a3a",
+        "_id": "d5388e530d1ffb2ae590b4fec68af204",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,11 +189,11 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 505,
+          "headersSize": 403,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/rates/rate_f733825b95b3454eae80805efe06b6b7"
+          "url": "https://api.easypost.com/v2/rates/rate_72db0cedd4cc4444818004ffa8541c06"
         },
         "response": {
           "bodySize": 432,
@@ -201,7 +201,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 432,
-            "text": "{\"id\":\"rate_f733825b95b3454eae80805efe06b6b7\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:46Z\",\"updated_at\":\"2022-06-01T19:48:46Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ab737df1fddc4b6e8ae4591ca483e35c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}"
+            "text": "{\"id\":\"rate_72db0cedd4cc4444818004ffa8541c06\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:46Z\",\"updated_at\":\"2022-07-29T22:02:46Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_c60bb928fe924689961ca113b2106733\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c29fe786c183000983eb"
+              "value": "999d146f62e45907e788dce2000fde4b"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0640664138fa6021048f4c5c4ca0c60c\""
+              "value": "W/\"8d1a03882a290840498d9e2bbaa65564\""
             },
             {
               "name": "x-runtime",
-              "value": "0.157306"
+              "value": "0.188816"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:46.848Z",
-        "time": 342,
+        "startedDateTime": "2022-07-29T22:02:46.351Z",
+        "time": 982,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 342
+          "wait": 982
         }
       }
     ],

--- a/test/cassettes/Refund-Resource_710135213/creates-a-refund_2084766157/recording.har
+++ b/test/cassettes/Refund-Resource_710135213/creates-a-refund_2084766157/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2230,
+          "bodySize": 2240,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2230,
-            "text": "{\"created_at\":\"2022-06-01T19:48:47Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892889\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_da1ba468e1e311ecba5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e71b9ab5a5a441c691acaeafcd1ac4fb\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_40578937ca2341f0afa357324e0d9aaf\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:48Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/7ce1395519204640b68c529500560e02.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a243311090d34da494689d98bfb336e1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e172da0bbc514fbf8eb8d9de3e8f0351\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_69ab7f0439544707bae6f523481362dc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2b8c54c0e3a247bf8da8cc959855eb91\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_2b8c54c0e3a247bf8da8cc959855eb91\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_69a4a896f5e44e6ea9b7fb540657342c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892889\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzY5YTRhODk2ZjVlNDRlNmVhOWI3ZmI1NDA2NTczNDJj\"},\"to_address\":{\"id\":\"adr_da19f8fee1e311eca9c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_da1ba468e1e311ecba5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_da19f8fee1e311eca9c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_640c7c47153d43268830a782c505403c\",\"object\":\"Shipment\"}"
+            "size": 2240,
+            "text": "{\"created_at\":\"2022-07-29T22:02:47Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689364\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2e5aa81c0f8a11eda043ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_5dc817fdfa304c3787818a8363e8b676\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_26ae09fc301d454289657a03c99c03e5\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:48Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/bad02205656a4df281baf7b7ed697d2d.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_16c7627e0bab456b913ae15977758af0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4359caad2ae1444bb18ea497b85f2b86\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1852d8895a41440791b5fd311fe2556e\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0de27a5e1eba41a596fe10eadd45e97d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_1852d8895a41440791b5fd311fe2556e\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_22411da02427401fa7e300befc87de59\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689364\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzIyNDExZGEwMjQyNzQwMWZhN2UzMDBiZWZjODdkZTU5\"},\"to_address\":{\"id\":\"adr_2e589b020f8a11ed988eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2e5aa81c0f8a11eda043ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2e589b020f8a11ed988eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c29fe786c1840009842f"
+              "value": "999d146f62e45907e788dce3000fde6f"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_640c7c47153d43268830a782c505403c"
+              "value": "/api/v2/shipments/shp_396540b5262d4d64be32a6700566a84a"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"03399fc260569dd5afc805aa38e26deb\""
+              "value": "W/\"b71d83f4f166dce032d3f5a0ab1fc852\""
             },
             {
               "name": "x-runtime",
-              "value": "1.176256"
+              "value": "1.199604"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_640c7c47153d43268830a782c505403c",
+          "redirectURL": "/api/v2/shipments/shp_396540b5262d4d64be32a6700566a84a",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:47.200Z",
-        "time": 1463,
+        "startedDateTime": "2022-07-29T22:02:47.343Z",
+        "time": 1392,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1463
+          "wait": 1392
         }
       },
       {
-        "_id": "f091582143e87d173dc986bc12993163",
+        "_id": "586e8728b38314be49313ec191d2de6b",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 508,
+          "headersSize": 406,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_640c7c47153d43268830a782c505403c"
+          "url": "https://api.easypost.com/v2/shipments/shp_396540b5262d4d64be32a6700566a84a"
         },
         "response": {
-          "bodySize": 2622,
+          "bodySize": 2639,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2622,
-            "text": "{\"created_at\":\"2022-06-01T19:48:47Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892889\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_da1ba468e1e311ecba5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e71b9ab5a5a441c691acaeafcd1ac4fb\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_40578937ca2341f0afa357324e0d9aaf\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:48Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/7ce1395519204640b68c529500560e02.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a243311090d34da494689d98bfb336e1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e172da0bbc514fbf8eb8d9de3e8f0351\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_69ab7f0439544707bae6f523481362dc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2b8c54c0e3a247bf8da8cc959855eb91\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:47Z\",\"updated_at\":\"2022-06-01T19:48:47Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_2b8c54c0e3a247bf8da8cc959855eb91\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_69a4a896f5e44e6ea9b7fb540657342c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892889\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T19:48:48Z\",\"updated_at\":\"2022-06-01T19:48:48Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T19:48:48Z\",\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T19:48:48Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T08:25:48Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzY5YTRhODk2ZjVlNDRlNmVhOWI3ZmI1NDA2NTczNDJj\"},\"to_address\":{\"id\":\"adr_da19f8fee1e311eca9c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_da1ba468e1e311ecba5aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_da19f8fee1e311eca9c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:47+00:00\",\"updated_at\":\"2022-06-01T19:48:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_640c7c47153d43268830a782c505403c\",\"object\":\"Shipment\"}"
+            "size": 2639,
+            "text": "{\"created_at\":\"2022-07-29T22:02:47Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689364\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2e5aa81c0f8a11eda043ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_5dc817fdfa304c3787818a8363e8b676\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_26ae09fc301d454289657a03c99c03e5\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:48Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/bad02205656a4df281baf7b7ed697d2d.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_16c7627e0bab456b913ae15977758af0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4359caad2ae1444bb18ea497b85f2b86\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1852d8895a41440791b5fd311fe2556e\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0de27a5e1eba41a596fe10eadd45e97d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:47Z\",\"updated_at\":\"2022-07-29T22:02:47Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_1852d8895a41440791b5fd311fe2556e\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_22411da02427401fa7e300befc87de59\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689364\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:02:48Z\",\"updated_at\":\"2022-07-29T22:02:48Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:02:48Z\",\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:02:48Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:39:48Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzIyNDExZGEwMjQyNzQwMWZhN2UzMDBiZWZjODdkZTU5\"},\"to_address\":{\"id\":\"adr_2e589b020f8a11ed988eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2e5aa81c0f8a11eda043ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2e589b020f8a11ed988eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:47+00:00\",\"updated_at\":\"2022-07-29T22:02:47+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_396540b5262d4d64be32a6700566a84a\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297c2a0e786c18500098521"
+              "value": "999d146e62e45908e788dcfb000fded9"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"9d879ccbfa7f6af1af1d48954b34a7ce\""
+              "value": "W/\"c3a3eb278ca17a84bd3c0d7467383281\""
             },
             {
               "name": "x-runtime",
-              "value": "0.285561"
+              "value": "0.175866"
             },
             {
               "name": "content-encoding",
@@ -267,23 +267,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -294,14 +290,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:48.669Z",
-        "time": 513,
+        "startedDateTime": "2022-07-29T22:02:48.744Z",
+        "time": 373,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -309,11 +305,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 513
+          "wait": 373
         }
       },
       {
-        "_id": "ec8f6a06cde4f2361c2a7fc4e8bd9042",
+        "_id": "7b047125f04e5031d1084d494da19eed",
         "_order": 0,
         "cache": {},
         "request": {
@@ -341,24 +337,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 490,
+          "headersSize": 388,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"refund\":{\"carrier\":\"USPS\",\"tracking_codes\":\"9400100109361121892889\"}}"
+            "text": "{\"refund\":{\"carrier\":\"USPS\",\"tracking_codes\":\"9400100109361130689364\"}}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/refunds"
         },
         "response": {
-          "bodySize": 319,
+          "bodySize": 316,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 319,
-            "text": "[{\"id\":\"rfnd_1562b9e624f04354a6ef5b9a0f3837d2\",\"object\":\"Refund\",\"created_at\":\"2022-06-01T19:48:49Z\",\"updated_at\":\"2022-06-01T19:48:49Z\",\"tracking_code\":\"9400100109361121892889\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_640c7c47153d43268830a782c505403c\"}]"
+            "size": 316,
+            "text": "[{\"id\":\"rfnd_0cab79e89cc94eb7a4c9adddb21daa37\",\"object\":\"Refund\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"tracking_code\":\"9400100109361130689364\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_396540b5262d4d64be32a6700566a84a\"}]"
           },
           "cookies": [],
           "headers": [
@@ -388,7 +384,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297c2a1e786c18600098579"
+              "value": "999d146f62e45909e788dcfc000fdf0c"
             },
             {
               "name": "cache-control",
@@ -408,11 +404,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f762c8bde9ba7d922da99b483fe0058a\""
+              "value": "W/\"a0926d99de4f6e56ea9df53c2bd779bf\""
             },
             {
               "name": "x-runtime",
-              "value": "0.085724"
+              "value": "0.070137"
             },
             {
               "name": "content-encoding",
@@ -424,11 +420,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -436,7 +432,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -453,8 +449,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:49.188Z",
-        "time": 536,
+        "startedDateTime": "2022-07-29T22:02:49.127Z",
+        "time": 262,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -462,7 +458,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 536
+          "wait": 262
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/creates-a-report-by-specifying-columns_1660528128/recording.har
+++ b/test/cassettes/Report-Resource_72515537/creates-a-report-by-specifying-columns_1660528128/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 499,
+          "headersSize": 397,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
-          "bodySize": 272,
+          "bodySize": 268,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 272,
-            "text": "{\"id\":\"shprep_e0c5a1aa560f4f4b8bd25038976a155d\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:50Z\",\"updated_at\":\"2022-06-01T19:48:50Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
+            "size": 268,
+            "text": "{\"id\":\"shprep_424033d6421a454eb33d6ea974c68aeb\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297c2a2e786c18b000986c3"
+              "value": "999d147062e45962e788ddc3000ffa46"
             },
             {
               "name": "cache-control",
@@ -103,11 +103,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"ad89ea205debfdc8dd679f9e0905c224\""
+              "value": "W/\"31e38974ceb132c7044c010420756191\""
             },
             {
               "name": "x-runtime",
-              "value": "0.039341"
+              "value": "0.065939"
             },
             {
               "name": "content-encoding",
@@ -119,23 +119,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +142,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:50.700Z",
-        "time": 232,
+        "startedDateTime": "2022-07-29T22:04:18.203Z",
+        "time": 267,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +157,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 267
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/creates-a-report-with-additional-columns_3168456315/recording.har
+++ b/test/cassettes/Report-Resource_72515537/creates-a-report-with-additional-columns_3168456315/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 500,
+          "headersSize": 398,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
-          "bodySize": 276,
+          "bodySize": 272,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 276,
-            "text": "{\"id\":\"shprep_e828f0f7c0234278903f8f24bce72dde\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:51Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
+            "size": 272,
+            "text": "{\"id\":\"shprep_df37e383e0ce4d1e8be0ce5d2cf2fa75\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2a3e786c49a00098719"
+              "value": "999d146962e45962e788ddc4000ffa5d"
             },
             {
               "name": "cache-control",
@@ -103,11 +103,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"6deabca159aafde057a7913c9231dba6\""
+              "value": "W/\"24336a998145f370c8a8f7a1072d1934\""
             },
             {
               "name": "x-runtime",
-              "value": "0.040882"
+              "value": "0.037065"
             },
             {
               "name": "content-encoding",
@@ -119,11 +119,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -131,7 +131,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,8 +148,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:50.943Z",
-        "time": 228,
+        "startedDateTime": "2022-07-29T22:04:18.475Z",
+        "time": 223,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -157,7 +157,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 228
+          "wait": 223
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/creates-a-report_2930610569/recording.har
+++ b/test/cassettes/Report-Resource_72515537/creates-a-report_2930610569/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 499,
+          "headersSize": 397,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
-          "bodySize": 272,
+          "bodySize": 276,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 272,
-            "text": "{\"id\":\"shprep_b543920fbf3745acbb6c180a9bc299a5\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:50Z\",\"updated_at\":\"2022-06-01T19:48:50Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
+            "size": 276,
+            "text": "{\"id\":\"shprep_d6927e4385ee4f41b6f5ca4cdc41398d\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c2a2e786c18a0009868e"
+              "value": "999d147062e45962e788ddc2000ffa25"
             },
             {
               "name": "cache-control",
@@ -103,11 +103,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"e20a54a322d66c19c2476c5e21540238\""
+              "value": "W/\"0e67da68ebf8811974230bc74841d145\""
             },
             {
               "name": "x-runtime",
-              "value": "0.037441"
+              "value": "0.053352"
             },
             {
               "name": "content-encoding",
@@ -123,7 +123,7 @@
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -131,7 +131,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,8 +148,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:50.461Z",
-        "time": 226,
+        "startedDateTime": "2022-07-29T22:04:17.940Z",
+        "time": 243,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -157,7 +157,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 226
+          "wait": 243
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/retrieves-a-shipment-report_2373872365/recording.har
+++ b/test/cassettes/Report-Resource_72515537/retrieves-a-shipment-report_2373872365/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 499,
+          "headersSize": 397,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/reports/shipment"
         },
         "response": {
-          "bodySize": 276,
+          "bodySize": 272,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 276,
-            "text": "{\"id\":\"shprep_9d519b26d3c849e792188a18c8a741bf\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:51Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
+            "size": 272,
+            "text": "{\"id\":\"shprep_00464c387b794936b04c6963f7888044\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2a3e786c49b00098749"
+              "value": "999d146962e45962e788ddc5000ffa6d"
             },
             {
               "name": "cache-control",
@@ -103,11 +103,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"b53f6577b1920c97b02b86ffc7ab2296\""
+              "value": "W/\"8e57a5ec3c4631199391be759296e9e6\""
             },
             {
               "name": "x-runtime",
-              "value": "0.051513"
+              "value": "0.043082"
             },
             {
               "name": "content-encoding",
@@ -119,11 +119,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -131,7 +131,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,8 +148,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:51.176Z",
-        "time": 237,
+        "startedDateTime": "2022-07-29T22:04:18.703Z",
+        "time": 230,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -157,11 +157,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 237
+          "wait": 230
         }
       },
       {
-        "_id": "f888c3ac641ee9e0ef01a4aefb2bf5d5",
+        "_id": "50f27578f925f78db02f49baae2e2868",
         "_order": 0,
         "cache": {},
         "request": {
@@ -185,11 +185,11 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 509,
+          "headersSize": 407,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/reports/shprep_9d519b26d3c849e792188a18c8a741bf"
+          "url": "https://api.easypost.com/v2/reports/shprep_00464c387b794936b04c6963f7888044"
         },
         "response": {
           "bodySize": 616,
@@ -197,7 +197,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 616,
-            "text": "{\"id\":\"shprep_9d519b26d3c849e792188a18c8a741bf\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:51Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220601/dc0f3fe90eb94fd69c08109972cb0120.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=67d325a6841eaafe249e82cb374d3b3e817f65c23d21eeb7ba1e111356928592\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false}"
+            "text": "{\"id\":\"shprep_00464c387b794936b04c6963f7888044\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:19Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220729/20a8c38a23144e7e9c39231abd5f04ef.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220729%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220729T220419Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=d694c611a898babcf6891f86c474ebbf8190899a016e78bb0e16b901a626e887\",\"url_expires_at\":\"2022-07-29T22:04:49Z\",\"include_children\":false}"
           },
           "cookies": [],
           "headers": [
@@ -227,7 +227,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2a3e786c49c0009876e"
+              "value": "999d146d62e45963e788ddc6000ffa7f"
             },
             {
               "name": "cache-control",
@@ -247,11 +247,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"6101cf63296de43f13d98a920108135a\""
+              "value": "W/\"367a261dff6eb5670c02cf14031904dc\""
             },
             {
               "name": "x-runtime",
-              "value": "0.039659"
+              "value": "0.033792"
             },
             {
               "name": "content-encoding",
@@ -263,11 +263,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -275,7 +275,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -292,8 +292,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:51.419Z",
-        "time": 233,
+        "startedDateTime": "2022-07-29T22:04:18.940Z",
+        "time": 227,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -301,7 +301,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 233
+          "wait": 227
         }
       }
     ],

--- a/test/cassettes/Report-Resource_72515537/retrieves-all-reports_3952278090/recording.har
+++ b/test/cassettes/Report-Resource_72515537/retrieves-all-reports_3952278090/recording.har
@@ -32,7 +32,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 490,
+          "headersSize": 388,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -44,12 +44,12 @@
           "url": "https://api.easypost.com/v2/reports/shipment?page_size=5"
         },
         "response": {
-          "bodySize": 1178,
+          "bodySize": 1122,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1178,
-            "text": "{\"reports\":[{\"id\":\"shprep_9d519b26d3c849e792188a18c8a741bf\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:51Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220601/dc0f3fe90eb94fd69c08109972cb0120.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=67d325a6841eaafe249e82cb374d3b3e817f65c23d21eeb7ba1e111356928592\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false},{\"id\":\"shprep_e828f0f7c0234278903f8f24bce72dde\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:51Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220601/ffc2b2512a524e8bbaba87304404a978.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=89d74e3bf3bec78747ba3fd078ba0c0fd72621fdc67fb45142321923a06032a0\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false},{\"id\":\"shprep_e0c5a1aa560f4f4b8bd25038976a155d\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:50Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220601/37b2cc5290df4391b98028ee52dc7a6a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=23a1fb916a0088c501641e75b5b1d72ae11ca246ec3f5eccb5f96e6387c03669\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false},{\"id\":\"shprep_b543920fbf3745acbb6c180a9bc299a5\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-01T19:48:50Z\",\"updated_at\":\"2022-06-01T19:48:51Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220601/fe8e683ea4a342f589f80eaabde5ad21.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=287e3b8a31c5d40830853cb22cfc49c90b670069e4ab4f9aa0937079d7437954\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false},{\"id\":\"shprep_ff2c795bf5c94fdcbb4b569abb44c07e\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-05-27T17:38:00Z\",\"updated_at\":\"2022-05-27T17:38:01Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220527/44aac226fe1a46ebb4f04a97431e7dbc.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220601%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220601T194851Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=fdb1edccfd4e2499345b67a7939d2213c04a8e266d9db530c52ec8cb44172852\",\"url_expires_at\":\"2022-06-01T19:49:21Z\",\"include_children\":false}],\"has_more\":true}"
+            "size": 1122,
+            "text": "{\"reports\":[{\"id\":\"shprep_00464c387b794936b04c6963f7888044\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:19Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220729/20a8c38a23144e7e9c39231abd5f04ef.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220729%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220729T220419Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=d694c611a898babcf6891f86c474ebbf8190899a016e78bb0e16b901a626e887\",\"url_expires_at\":\"2022-07-29T22:04:49Z\",\"include_children\":false},{\"id\":\"shprep_df37e383e0ce4d1e8be0ce5d2cf2fa75\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false},{\"id\":\"shprep_424033d6421a454eb33d6ea974c68aeb\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220729/a23e3594acf94c3fab392c7de642a3e7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220729%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220729T220419Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=0cc75f80b62f0322d460d45efafbfb87d540acba0766a06491c130ba30d45174\",\"url_expires_at\":\"2022-07-29T22:04:49Z\",\"include_children\":false},{\"id\":\"shprep_d6927e4385ee4f41b6f5ca4cdc41398d\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-07-29T22:04:18Z\",\"updated_at\":\"2022-07-29T22:04:18Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220729/cd21fdb7ef8b4ea694fcf46a07d5c7af.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220729%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220729T220419Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=0ae3b676fa4e4f99968d10de55d33b880e7f46f8451c56c17ddce79c98e44ef1\",\"url_expires_at\":\"2022-07-29T22:04:49Z\",\"include_children\":false},{\"id\":\"shprep_51e7ad6bac164d3199b1c4efafe4ed6b\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-06-30T20:55:53Z\",\"updated_at\":\"2022-06-30T20:55:53Z\",\"start_date\":\"2022-04-11\",\"end_date\":\"2022-04-11\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220630/93b6e83f61244162b620d285c33bae5a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220729%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220729T220419Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=e6011bb39d12827e7afb8edc833dbb2313dab02f5312bfc2bf755afc6a053046\",\"url_expires_at\":\"2022-07-29T22:04:49Z\",\"include_children\":false}],\"has_more\":true}"
           },
           "cookies": [],
           "headers": [
@@ -79,7 +79,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2a3e786c49d0009878e"
+              "value": "999d146b62e45963e788ddc7000ffa8e"
             },
             {
               "name": "cache-control",
@@ -99,11 +99,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"543b3ef77da2533f574bc97854b8f7bb\""
+              "value": "W/\"841d42014a5cf5571941377dea10f608\""
             },
             {
               "name": "x-runtime",
-              "value": "0.041849"
+              "value": "0.054210"
             },
             {
               "name": "content-encoding",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -127,7 +127,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -144,8 +144,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:51.664Z",
-        "time": 232,
+        "startedDateTime": "2022-07-29T22:04:19.180Z",
+        "time": 244,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -153,7 +153,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 232
+          "wait": 244
         }
       }
     ],

--- a/test/cassettes/ScanForm-Resource_3833511234/creates-a-scanform_355573720/recording.har
+++ b/test/cassettes/ScanForm-Resource_3833511234/creates-a-scanform_355573720/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2220,
+          "bodySize": 2231,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2220,
-            "text": "{\"created_at\":\"2022-06-01T19:48:52Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892896\",\"updated_at\":\"2022-06-01T19:48:53Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_dce7e674e1e311eca1acac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:52+00:00\",\"updated_at\":\"2022-06-01T19:48:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_929efbe710934444b77108c31545807f\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_d0e8cb58c4804c7393bcaf8412f13bf6\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:52Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/16d5ef4afef04ff99605816c303964d9.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a83ee4c2b7b54c64b13fc70b32e4724e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_de45babb72fb40b6be7f7efdeb94ef32\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b53aa81825914222911424964ac3d0e5\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5c0a516698d4445e8b6e03b92f1a1761\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_5c0a516698d4445e8b6e03b92f1a1761\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:52Z\",\"updated_at\":\"2022-06-01T19:48:52Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_74402ec48e7c41dd9fd4535e0f6d503a\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892896\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:53Z\",\"updated_at\":\"2022-06-01T19:48:53Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzc0NDAyZWM0OGU3YzQxZGQ5ZmQ0NTM1ZTBmNmQ1MDNh\"},\"to_address\":{\"id\":\"adr_dce67c98e1e311ecaac8ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:52+00:00\",\"updated_at\":\"2022-06-01T19:48:52+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_dce7e674e1e311eca1acac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:52+00:00\",\"updated_at\":\"2022-06-01T19:48:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_dce67c98e1e311ecaac8ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:52+00:00\",\"updated_at\":\"2022-06-01T19:48:52+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\",\"object\":\"Shipment\"}"
+            "size": 2231,
+            "text": "{\"created_at\":\"2022-07-29T22:02:49Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689371\",\"updated_at\":\"2022-07-29T22:02:50Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_2f9a1b360f8a11eda07dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:49+00:00\",\"updated_at\":\"2022-07-29T22:02:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_1938e5fea8234cb1affd3457a1a70a4d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_aee6418e9b70468b8bbad8c1a1bea530\",\"created_at\":\"2022-07-29T22:02:50Z\",\"updated_at\":\"2022-07-29T22:02:50Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:50Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/c465001a554f48f5b23ed1369c36dcff.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_0dc4855bfc554fadb697927ad09f9f36\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_3f8a2e7e50a8450ba6402fff19f99721\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ad096a8ef7e344ea8251f154cf863227\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d369b622d2d744f2a2a91dd84e527900\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:49Z\",\"updated_at\":\"2022-07-29T22:02:49Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_0dc4855bfc554fadb697927ad09f9f36\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:50Z\",\"updated_at\":\"2022-07-29T22:02:50Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_8c7cd2b8d36249bda2ef6188d42c4d16\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689371\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:50Z\",\"updated_at\":\"2022-07-29T22:02:50Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzhjN2NkMmI4ZDM2MjQ5YmRhMmVmNjE4OGQ0MmM0ZDE2\"},\"to_address\":{\"id\":\"adr_2f986fd20f8a11edaa75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:49+00:00\",\"updated_at\":\"2022-07-29T22:02:49+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_2f9a1b360f8a11eda07dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:49+00:00\",\"updated_at\":\"2022-07-29T22:02:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_2f986fd20f8a11edaa75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:49+00:00\",\"updated_at\":\"2022-07-29T22:02:49+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297c2a4e786c49e000987c4"
+              "value": "999d146b62e45909e788dcfd000fdf27"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_f4d9707010f24ee5b7c61879ec5cf471"
+              "value": "/api/v2/shipments/shp_6c8ece25993347578d4021e0ccb2c0c0"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"cdc34146475f37253e4e964726720761\""
+              "value": "W/\"749951b54ff0822f0d3cadc725f1dd85\""
             },
             {
               "name": "x-runtime",
-              "value": "1.022196"
+              "value": "0.981920"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_f4d9707010f24ee5b7c61879ec5cf471",
+          "redirectURL": "/api/v2/shipments/shp_6c8ece25993347578d4021e0ccb2c0c0",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:51.909Z",
-        "time": 1259,
+        "startedDateTime": "2022-07-29T22:02:49.445Z",
+        "time": 1203,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1259
+          "wait": 1203
         }
       },
       {
-        "_id": "ffa06eaf268c22d96b422cd4b49b2e7d",
+        "_id": "14c903ace279bcfef7770633e83b95a2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,13 +193,13 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipments\":[{\"id\":\"shp_f4d9707010f24ee5b7c61879ec5cf471\"}]}"
+            "text": "{\"shipments\":[{\"id\":\"shp_6c8ece25993347578d4021e0ccb2c0c0\"}]}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/scan_forms"
@@ -210,7 +210,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 712,
-            "text": "{\"id\":\"sf_2f07a53fefe54712a44ec8a4407e7e55\",\"object\":\"ScanForm\",\"created_at\":\"2022-06-01T19:48:53Z\",\"updated_at\":\"2022-06-01T19:48:53Z\",\"tracking_codes\":[\"9400100109361121892896\"],\"address\":{\"id\":\"adr_dce7e674e1e311eca1acac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:52+00:00\",\"updated_at\":\"2022-06-01T19:48:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220601/9b4e0fdf9c3d4cd9b70a139b7164306c.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_79aa7d7b79164274865a8a7f458ebb43\",\"confirmation\":null}"
+            "text": "{\"id\":\"sf_68d27a5084614081b2deb12e5f9887fe\",\"object\":\"ScanForm\",\"created_at\":\"2022-07-29T22:02:50Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"tracking_codes\":[\"9400100109361130689371\"],\"address\":{\"id\":\"adr_2f9a1b360f8a11eda07dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:49+00:00\",\"updated_at\":\"2022-07-29T22:02:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220729/3ede11527819405299d15c77a4bcaa86.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_f13b8e64056f43e6b5f1dece43505249\",\"confirmation\":null}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2a5e786c49f00098878"
+              "value": "999d146d62e4590ae788dcfe000fdf7c"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"060c02163329b5e799fc501bab58ab05\""
+              "value": "W/\"6700bfff057049545ee23a16c947d1ef\""
             },
             {
               "name": "x-runtime",
-              "value": "0.210829"
+              "value": "0.216606"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:53.174Z",
-        "time": 504,
+        "startedDateTime": "2022-07-29T22:02:50.657Z",
+        "time": 413,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 504
+          "wait": 413
         }
       }
     ],

--- a/test/cassettes/ScanForm-Resource_3833511234/retrieves-a-scanform_3128791796/recording.har
+++ b/test/cassettes/ScanForm-Resource_3833511234/retrieves-a-scanform_3128791796/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2239,
+          "bodySize": 2224,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2239,
-            "text": "{\"created_at\":\"2022-06-01T19:48:53Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892902\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_ddfa6253e1e311ecab3aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_5a9136754ba64a12beb5d434e65254da\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:53Z\",\"updated_at\":\"2022-06-01T19:48:53Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_0b9b5c318d934034bf0a628ac171d03e\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:48:54Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/fb23b2f83002454aaf922835df51dcdb.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_21f33beffdfd48b193ed38d6c5c2e74b\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0da48bdd53364debb0893cb2663fbd82\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d26886ca3c4c45e8a163ca1a78abfdac\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_04a3828344f84f20a412b90ef9abd4a5\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_04a3828344f84f20a412b90ef9abd4a5\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:54Z\",\"updated_at\":\"2022-06-01T19:48:54Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_9efd144b04f14e6f8d0713ace06251b7\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892902\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:48:55Z\",\"updated_at\":\"2022-06-01T19:48:55Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzllZmQxNDRiMDRmMTRlNmY4ZDA3MTNhY2UwNjI1MWI3\"},\"to_address\":{\"id\":\"adr_ddf8837be1e311ecaf13ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:54+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_ddfa6253e1e311ecab3aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_ddf8837be1e311ecaf13ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:54+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_ff1f021947e0456284c73c023bc4e010\",\"object\":\"Shipment\"}"
+            "size": 2224,
+            "text": "{\"created_at\":\"2022-07-29T22:02:51Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689388\",\"updated_at\":\"2022-07-29T22:02:52Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_309856150f8a11eda0bcac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_d97a0c3460bc4ee4aad9be81935bba91\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_e5cd2e30001d4a31ae25ab4914c8bfef\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:52Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:51Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/92442b4098624ed399ef288d8cbe342c.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_39a2339911ea4b84af21fec623587d9a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_a54632b008024599bc53478695adcd47\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_60d126323ece4382b578aa866193826c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_9a12fef02c074f918df0747e96dd38c8\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_60d126323ece4382b578aa866193826c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:51Z\",\"updated_at\":\"2022-07-29T22:02:51Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_5157a1d8489f43dc8eeb6d297973c440\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689388\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:52Z\",\"updated_at\":\"2022-07-29T22:02:52Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzUxNTdhMWQ4NDg5ZjQzZGM4ZWViNmQyOTc5NzNjNDQw\"},\"to_address\":{\"id\":\"adr_3093db130f8a11edaaadac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_309856150f8a11eda0bcac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3093db130f8a11edaaadac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_99919fffe9c84751b6a865b784c056eb\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2a5e786c4a0000988d5"
+              "value": "999d146d62e4590be788dcff000fdf9c"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_ff1f021947e0456284c73c023bc4e010"
+              "value": "/api/v2/shipments/shp_99919fffe9c84751b6a865b784c056eb"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"fe505bf2b9a6ba71167b52e3336a7149\""
+              "value": "W/\"06283d4bfb357e88ff4bb3effa0b4d95\""
             },
             {
               "name": "x-runtime",
-              "value": "1.185228"
+              "value": "1.003579"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_ff1f021947e0456284c73c023bc4e010",
+          "redirectURL": "/api/v2/shipments/shp_99919fffe9c84751b6a865b784c056eb",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:53.689Z",
-        "time": 1388,
+        "startedDateTime": "2022-07-29T22:02:51.083Z",
+        "time": 1306,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1388
+          "wait": 1306
         }
       },
       {
-        "_id": "3cfb8148884e27a2593e04c3b95d7c86",
+        "_id": "3ee1d5b77084485f7d58e46b784b3a50",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipments\":[{\"id\":\"shp_ff1f021947e0456284c73c023bc4e010\"}]}"
+            "text": "{\"shipments\":[{\"id\":\"shp_99919fffe9c84751b6a865b784c056eb\"}]}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/scan_forms"
         },
         "response": {
-          "bodySize": 712,
+          "bodySize": 708,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 712,
-            "text": "{\"id\":\"sf_024c3dc282314a1386bbd2f05f1827dd\",\"object\":\"ScanForm\",\"created_at\":\"2022-06-01T19:48:55Z\",\"updated_at\":\"2022-06-01T19:48:55Z\",\"tracking_codes\":[\"9400100109361121892902\"],\"address\":{\"id\":\"adr_ddfa6253e1e311ecab3aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220601/0a14ee24738d4238b497ed205a27a22c.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_2630ab47b36844269bc7c2ce073e0009\",\"confirmation\":null}"
+            "size": 708,
+            "text": "{\"id\":\"sf_c32a960d6ebd478aa52ed61e2e116b5c\",\"object\":\"ScanForm\",\"created_at\":\"2022-07-29T22:02:52Z\",\"updated_at\":\"2022-07-29T22:02:52Z\",\"tracking_codes\":[\"9400100109361130689388\"],\"address\":{\"id\":\"adr_309856150f8a11eda0bcac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220729/908b1e22090940eba91fb2c0dffed3d4.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_cae159caed484ffca808096cfff7c5e3\",\"confirmation\":null}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297c2a7e786c4a100098997"
+              "value": "999d146a62e4590ce788dd00000fdffc"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f8e30f47d0affd6ed4b26aa3bc462f30\""
+              "value": "W/\"3c49f28cb84e727bd28435d071c76338\""
             },
             {
               "name": "x-runtime",
-              "value": "0.483995"
+              "value": "0.216140"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:55.084Z",
-        "time": 846,
+        "startedDateTime": "2022-07-29T22:02:52.395Z",
+        "time": 482,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,11 +314,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 846
+          "wait": 482
         }
       },
       {
-        "_id": "5d34b732469ea010e0c4f995b756ec0a",
+        "_id": "5d3353c478e1720eade5a43a096c8e7c",
         "_order": 0,
         "cache": {},
         "request": {
@@ -342,19 +342,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 508,
+          "headersSize": 406,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/scan_forms/sf_024c3dc282314a1386bbd2f05f1827dd"
+          "url": "https://api.easypost.com/v2/scan_forms/sf_c32a960d6ebd478aa52ed61e2e116b5c"
         },
         "response": {
-          "bodySize": 712,
+          "bodySize": 708,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 712,
-            "text": "{\"id\":\"sf_024c3dc282314a1386bbd2f05f1827dd\",\"object\":\"ScanForm\",\"created_at\":\"2022-06-01T19:48:55Z\",\"updated_at\":\"2022-06-01T19:48:55Z\",\"tracking_codes\":[\"9400100109361121892902\"],\"address\":{\"id\":\"adr_ddfa6253e1e311ecab3aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:53+00:00\",\"updated_at\":\"2022-06-01T19:48:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220601/0a14ee24738d4238b497ed205a27a22c.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_2630ab47b36844269bc7c2ce073e0009\",\"confirmation\":null}"
+            "size": 708,
+            "text": "{\"id\":\"sf_c32a960d6ebd478aa52ed61e2e116b5c\",\"object\":\"ScanForm\",\"created_at\":\"2022-07-29T22:02:52Z\",\"updated_at\":\"2022-07-29T22:02:52Z\",\"tracking_codes\":[\"9400100109361130689388\"],\"address\":{\"id\":\"adr_309856150f8a11eda0bcac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:51+00:00\",\"updated_at\":\"2022-07-29T22:02:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"status\":\"created\",\"message\":null,\"form_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/scan_form/20220729/908b1e22090940eba91fb2c0dffed3d4.pdf\",\"form_file_type\":null,\"batch_id\":\"batch_cae159caed484ffca808096cfff7c5e3\",\"confirmation\":null}"
           },
           "cookies": [],
           "headers": [
@@ -384,7 +384,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297c2a8e786c4a200098a1e"
+              "value": "999d146a62e4590de788dd01000fe01d"
             },
             {
               "name": "cache-control",
@@ -404,11 +404,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f8e30f47d0affd6ed4b26aa3bc462f30\""
+              "value": "W/\"3c49f28cb84e727bd28435d071c76338\""
             },
             {
               "name": "x-runtime",
-              "value": "0.036682"
+              "value": "0.025934"
             },
             {
               "name": "content-encoding",
@@ -420,11 +420,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -432,7 +432,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -449,8 +449,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:48:55.938Z",
-        "time": 227,
+        "startedDateTime": "2022-07-29T22:02:52.883Z",
+        "time": 230,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -458,7 +458,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 227
+          "wait": 230
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/buy-a-carbon-offset-shipment_3573650270/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/buy-a-carbon-offset-shipment_3573650270/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "36bcd5b520aedee6860efc729b085ce3",
+        "_id": "06990daeee33724687f695680404db40",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 474,
+          "bodySize": 496,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 474
+              "value": 496
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 390,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1691,
+          "bodySize": 1703,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1691,
-            "text": "{\"created_at\":\"2022-07-28T23:08:16Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:08:17Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_297eb5696d084a70b2eab3cde8e0c21d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:08:16Z\",\"updated_at\":\"2022-07-28T23:08:16Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_2ab2c4b9527e4e359e754387e1fd62c4\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_87062c405f9f449b86a941d2e1dc7a9c\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"object\":\"Shipment\"}"
+            "size": 1703,
+            "text": "{\"created_at\":\"2022-07-29T22:03:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:18Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_40783ebd0f8a11edb582ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_58dcf9d9d7bc42e1871fda4ea7b81316\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:17Z\",\"updated_at\":\"2022-07-29T22:03:17Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_3fe40a1378d24aa0bcdba326c9d144a0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_68e58dc389c24853a48fbaec082eba77\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4958d220808f437f9f5f359a0c88a280\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_407680610f8a11eda458ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_40783ebd0f8a11edb582ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_407680610f8a11eda458ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "b0657e4362e316e0ff24e6c300400ab2"
+              "value": "999d147062e45925e788dd67000fe754"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c"
+              "value": "/api/v2/shipments/shp_23597625ed88422c8fed4d1f8b8b5b0c"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"915a11f48adb9fb7030787ee0fc51f96\""
+              "value": "W/\"ff8e0719d3509da0e676bef7080091ab\""
             },
             {
               "name": "x-runtime",
-              "value": "0.696540"
+              "value": "0.431218"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +146,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 832,
+          "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c",
+          "redirectURL": "/api/v2/shipments/shp_23597625ed88422c8fed4d1f8b8b5b0c",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-28T23:08:16.136Z",
-        "time": 949,
+        "startedDateTime": "2022-07-29T22:03:17.737Z",
+        "time": 625,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 949
+          "wait": 625
         }
       },
       {
-        "_id": "fcab7b197d1ea5f1f127158776df81a1",
+        "_id": "e34a6ead566e4ec93fc33722d910f895",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 430,
+          "headersSize": 431,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\"},\"carbon_offset\":true}"
+            "text": "{\"rate\":{\"id\":\"rate_3fe40a1378d24aa0bcdba326c9d144a0\"},\"carbon_offset\":true}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_23597625ed88422c8fed4d1f8b8b5b0c/buy"
         },
         "response": {
-          "bodySize": 2472,
+          "bodySize": 2491,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2472,
-            "text": "{\"created_at\":\"2022-07-28T23:08:16Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9461200109361130523345\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_297eb5696d084a70b2eab3cde8e0c21d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:08:16Z\",\"updated_at\":\"2022-07-28T23:08:16Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_991e8d6e4c7a4421956148f9deec80a4\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:08:18Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/2e3509a6d6e44797ac59c8b6439754cf.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_2ab2c4b9527e4e359e754387e1fd62c4\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_87062c405f9f449b86a941d2e1dc7a9c\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_037766b2b82a41829054e62a2d1181e5\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9461200109361130523345\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzAzNzc2NmIyYjgyYTQxODI5MDU0ZTYyYTJkMTE4MWU1\"},\"to_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:17+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:17+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"8.91000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"CarbonOffsetFee\",\"amount\":\"0.11000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"object\":\"Shipment\"}"
+            "size": 2491,
+            "text": "{\"created_at\":\"2022-07-29T22:03:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9461200109361130689461\",\"updated_at\":\"2022-07-29T22:03:19Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_40783ebd0f8a11edb582ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_58dcf9d9d7bc42e1871fda4ea7b81316\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:17Z\",\"updated_at\":\"2022-07-29T22:03:17Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_5ecaa9e115c1437b8a262abefa474aa1\",\"created_at\":\"2022-07-29T22:03:19Z\",\"updated_at\":\"2022-07-29T22:03:19Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:19Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/113998cb1da44fa7b442ed6b87ca25ea.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_3fe40a1378d24aa0bcdba326c9d144a0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_68e58dc389c24853a48fbaec082eba77\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4958d220808f437f9f5f359a0c88a280\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:18Z\",\"updated_at\":\"2022-07-29T22:03:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_3fe40a1378d24aa0bcdba326c9d144a0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:19Z\",\"updated_at\":\"2022-07-29T22:03:19Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_9b648a6740a24e7f9ca7d1828f4c3c5a\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9461200109361130689461\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:19Z\",\"updated_at\":\"2022-07-29T22:03:19Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzliNjQ4YTY3NDBhMjRlN2Y5Y2E3ZDE4MjhmNGMzYzVh\"},\"to_address\":{\"id\":\"adr_407680610f8a11eda458ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:18+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_40783ebd0f8a11edb582ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:17+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_407680610f8a11eda458ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:17+00:00\",\"updated_at\":\"2022-07-29T22:03:18+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"8.91000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"CarbonOffsetFee\",\"amount\":\"0.11000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_23597625ed88422c8fed4d1f8b8b5b0c\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "b0657e4262e316e1ff24e6c400400aed"
+              "value": "999d146b62e45926e788dd7f000fe77a"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"88b5eeb7c7189024b664064a6e8b1b45\""
+              "value": "W/\"c1037f821ab6fcf5721e7f758076fa90\""
             },
             {
               "name": "x-runtime",
-              "value": "1.161284"
+              "value": "1.001437"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 403f17ff97, intlb2wdc 403f17ff97, extlb3wdc 403f17ff97"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -299,14 +299,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-28T23:08:17.090Z",
-        "time": 1425,
+        "startedDateTime": "2022-07-29T22:03:18.370Z",
+        "time": 1202,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1425
+          "wait": 1202
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/buy-a-carbon-offset-shipment_3573650270/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/buy-a-carbon-offset-shipment_3573650270/recording.har
@@ -1,0 +1,324 @@
+{
+  "log": {
+    "_recordingName": "Shipment Resource/buy a carbon offset shipment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "36bcd5b520aedee6860efc729b085ce3",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 474,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 474
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 390,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9}}}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 1691,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1691,
+            "text": "{\"created_at\":\"2022-07-28T23:08:16Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:08:17Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_297eb5696d084a70b2eab3cde8e0c21d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:08:16Z\",\"updated_at\":\"2022-07-28T23:08:16Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_2ab2c4b9527e4e359e754387e1fd62c4\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_87062c405f9f449b86a941d2e1dc7a9c\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "b0657e4362e316e0ff24e6c300400ab2"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"915a11f48adb9fb7030787ee0fc51f96\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.696540"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb2nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207282200-10f97b2b99-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 832,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-07-28T23:08:16.136Z",
+        "time": 949,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 949
+        }
+      },
+      {
+        "_id": "fcab7b197d1ea5f1f127158776df81a1",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 76,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 76
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 430,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"rate\":{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\"},\"carbon_offset\":true}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments/shp_b6a095c5cb87423b8c5fcb2f51c7cc4c/buy"
+        },
+        "response": {
+          "bodySize": 2472,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2472,
+            "text": "{\"created_at\":\"2022-07-28T23:08:16Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9461200109361130523345\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_297eb5696d084a70b2eab3cde8e0c21d\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:08:16Z\",\"updated_at\":\"2022-07-28T23:08:16Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_991e8d6e4c7a4421956148f9deec80a4\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:08:18Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/2e3509a6d6e44797ac59c8b6439754cf.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_2ab2c4b9527e4e359e754387e1fd62c4\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_87062c405f9f449b86a941d2e1dc7a9c\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:17Z\",\"updated_at\":\"2022-07-28T23:08:17Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_050f27c844f44bbbb1ff491d63eee9cf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_037766b2b82a41829054e62a2d1181e5\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9461200109361130523345\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:08:18Z\",\"updated_at\":\"2022-07-28T23:08:18Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzAzNzc2NmIyYjgyYTQxODI5MDU0ZTYyYTJkMTE4MWU1\"},\"to_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:17+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_29c572820eca11eda560ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:16+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_29c380a50eca11eda55eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:08:16+00:00\",\"updated_at\":\"2022-07-28T23:08:17+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"8.91000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"CarbonOffsetFee\",\"amount\":\"0.11000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_b6a095c5cb87423b8c5fcb2f51c7cc4c\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "b0657e4262e316e1ff24e6c400400aed"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"88b5eeb7c7189024b664064a6e8b1b45\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "1.161284"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb1nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207282200-10f97b2b99-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 403f17ff97, intlb2wdc 403f17ff97, extlb3wdc 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-07-28T23:08:17.090Z",
+        "time": 1425,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1425
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Shipment-Resource_2534528937/buys-a-shipment_3413405727/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/buys-a-shipment_3413405727/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 390,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2072,
+          "bodySize": 2064,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2072,
-            "text": "{\"created_at\":\"2022-07-28T23:00:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:00:58Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4a40d6ced5124b65be89cf45d1925a69\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a0fce06eb70d4074a45e6c4970b42c9d\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_fbe3a1f5b6df453cab4433731bc6ac20\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_b552961b13df4f3f808c8a323ff63738\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_384c2359784c4d98981f4db141f89513\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ba09ca69094041a0bc6815fd80c68222\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"object\":\"Shipment\"}"
+            "size": 2064,
+            "text": "{\"created_at\":\"2022-07-29T22:02:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:58Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_e272f0bfb0de4f1b8187a965e1a60147\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_860871aacee64626a20540944cb429a8\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3468edcb0f8a11ed99eaac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_630743fb1dbb4795956e2273fed9f72c\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_04bd77bd02b9488bbf0c9ee6dc8ef70f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_95cfd13edc1a47ca914e9a16415702a4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0d7d7fbd1d684899b9940425289694e5\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_989bcdea109147f9a3cbe01c0b1bf807\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_34672f7a0f8a11edaba0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3468edcb0f8a11ed99eaac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_34672f7a0f8a11edaba0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_240b920638344688a3532e9b866c2362\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "a41775b262e31529ff24e616000b42e0"
+              "value": "999d146d62e45911e788dd1f000fe17c"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa"
+              "value": "/api/v2/shipments/shp_240b920638344688a3532e9b866c2362"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"80a95d56ba8434a01083295001c6807f\""
+              "value": "W/\"37a8f46a96d2d16eacd5c490462a49dd\""
             },
             {
               "name": "x-runtime",
-              "value": "0.805716"
+              "value": "0.503825"
             },
             {
               "name": "content-encoding",
@@ -123,15 +123,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
+            },
+            {
+              "name": "x-canary",
+              "value": "direct"
             },
             {
               "name": "x-proxied",
@@ -146,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 828,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa",
+          "redirectURL": "/api/v2/shipments/shp_240b920638344688a3532e9b866c2362",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-28T23:00:57.091Z",
-        "time": 1103,
+        "startedDateTime": "2022-07-29T22:02:57.507Z",
+        "time": 692,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +165,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1103
+          "wait": 692
         }
       },
       {
-        "_id": "ed732ff34705ccf3e1f2c29a79cc0efd",
+        "_id": "207abc57358eee28c768aa232eb7a1dd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,24 +197,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 430,
+          "headersSize": 431,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\"},\"carbon_offset\":false}"
+            "text": "{\"rate\":{\"id\":\"rate_989bcdea109147f9a3cbe01c0b1bf807\"},\"carbon_offset\":false}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_240b920638344688a3532e9b866c2362/buy"
         },
         "response": {
-          "bodySize": 2910,
+          "bodySize": 2895,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2910,
-            "text": "{\"created_at\":\"2022-07-28T23:00:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522883\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4a40d6ced5124b65be89cf45d1925a69\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a0fce06eb70d4074a45e6c4970b42c9d\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_fbe3a1f5b6df453cab4433731bc6ac20\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_95442ddb6f12441991378461bf46514c\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:00:58Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/66ba301cabb64287836196b63801e992.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_b552961b13df4f3f808c8a323ff63738\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_384c2359784c4d98981f4db141f89513\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ba09ca69094041a0bc6815fd80c68222\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_cb05ba4bc8e8464d9feda41372827d3f\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522883\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:01:00Z\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2NiMDViYTRiYzhlODQ2NGQ5ZmVkYTQxMzcyODI3ZDNm\"},\"to_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"object\":\"Shipment\"}"
+            "size": 2895,
+            "text": "{\"created_at\":\"2022-07-29T22:02:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689418\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_e272f0bfb0de4f1b8187a965e1a60147\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_860871aacee64626a20540944cb429a8\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3468edcb0f8a11ed99eaac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_630743fb1dbb4795956e2273fed9f72c\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_14fe59ffdb94426ca02963f14e704ed2\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:02:58Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/222c10140d544882b0a1eefbd2e8ac2d.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_04bd77bd02b9488bbf0c9ee6dc8ef70f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_95cfd13edc1a47ca914e9a16415702a4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0d7d7fbd1d684899b9940425289694e5\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_989bcdea109147f9a3cbe01c0b1bf807\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_989bcdea109147f9a3cbe01c0b1bf807\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:58Z\",\"updated_at\":\"2022-07-29T22:02:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_1c03c118fccf46e7988ea40234e396c8\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689418\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:02:59Z\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_240b920638344688a3532e9b866c2362\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzFjMDNjMTE4ZmNjZjQ2ZTc5ODhlYTQwMjM0ZTM5NmM4\"},\"to_address\":{\"id\":\"adr_34672f7a0f8a11edaba0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3468edcb0f8a11ed99eaac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_34672f7a0f8a11edaba0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:57+00:00\",\"updated_at\":\"2022-07-29T22:02:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_240b920638344688a3532e9b866c2362\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +244,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "efdf9e0162e3152aff24e617000ade91"
+              "value": "999d146f62e45912e788dd20000fe1aa"
             },
             {
               "name": "cache-control",
@@ -260,11 +264,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"4d8ec5f67378d953be6cc33699b16102\""
+              "value": "W/\"7b7744e95b25b071b5aa6828eec9b8c9\""
             },
             {
               "name": "x-runtime",
-              "value": "2.040165"
+              "value": "0.930407"
             },
             {
               "name": "content-encoding",
@@ -276,11 +280,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +292,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb4wdc 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -299,14 +303,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-28T23:00:58.199Z",
-        "time": 2419,
+        "startedDateTime": "2022-07-29T22:02:58.205Z",
+        "time": 1299,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2419
+          "wait": 1299
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/buys-a-shipment_3413405727/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/buys-a-shipment_3413405727/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 390,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1980,
+          "bodySize": 2072,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1980,
-            "text": "{\"created_at\":\"2022-06-01T19:49:03Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:03Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_477af9355ae841f39dd52f4bb1994eac\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_e1e5944b438a44b498c51c425accf743\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e38d8bbee1e311eca485ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_e6488aed60ce42b08e18bb067e943919\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_f165b9a3055d4c4d8c53e00622f3ae9c\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_248363e32ced4b49b50b00d2d03db810\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_783b5eb34b464b32a3ce95cfdc84bc2e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_908f9877ad964a7f9cbcb37fd416fe36\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e38c393ce1e311ecbe2fac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e38d8bbee1e311eca485ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e38c393ce1e311ecbe2fac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"object\":\"Shipment\"}"
+            "size": 2072,
+            "text": "{\"created_at\":\"2022-07-28T23:00:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:00:58Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4a40d6ced5124b65be89cf45d1925a69\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a0fce06eb70d4074a45e6c4970b42c9d\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_fbe3a1f5b6df453cab4433731bc6ac20\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_b552961b13df4f3f808c8a323ff63738\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_384c2359784c4d98981f4db141f89513\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ba09ca69094041a0bc6815fd80c68222\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2afe786c4dc00098f20"
+              "value": "a41775b262e31529ff24e616000b42e0"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_f383d616dfd044a2865e51afe9843dbe"
+              "value": "/api/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"42f30aeec941e077eae608b10721b9e4\""
+              "value": "W/\"80a95d56ba8434a01083295001c6807f\""
             },
             {
               "name": "x-runtime",
-              "value": "0.578236"
+              "value": "0.805716"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_f383d616dfd044a2865e51afe9843dbe",
+          "redirectURL": "/api/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:03.059Z",
-        "time": 858,
+        "startedDateTime": "2022-07-28T23:00:57.091Z",
+        "time": 1103,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,15 +161,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 858
+          "wait": 1103
         }
       },
       {
-        "_id": "211b5bbc2b1f9783d1fd80feee7da905",
+        "_id": "ed732ff34705ccf3e1f2c29a79cc0efd",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 55,
+          "bodySize": 77,
           "cookies": [],
           "headers": [
             {
@@ -186,31 +186,31 @@
             },
             {
               "name": "content-length",
-              "value": 55
+              "value": 77
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 533,
+          "headersSize": 430,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_908f9877ad964a7f9cbcb37fd416fe36\"}}"
+            "text": "{\"rate\":{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\"},\"carbon_offset\":false}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_f383d616dfd044a2865e51afe9843dbe/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_8dd17fb0d4f14ac692d5058cfe9f8dfa/buy"
         },
         "response": {
-          "bodySize": 2830,
+          "bodySize": 2910,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2830,
-            "text": "{\"created_at\":\"2022-06-01T19:49:03Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892933\",\"updated_at\":\"2022-06-01T19:49:04Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_477af9355ae841f39dd52f4bb1994eac\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_e1e5944b438a44b498c51c425accf743\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e38d8bbee1e311eca485ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e6488aed60ce42b08e18bb067e943919\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_3646cdfd689f4276bb1ca57a5ec7f1b8\",\"created_at\":\"2022-06-01T19:49:04Z\",\"updated_at\":\"2022-06-01T19:49:04Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:04Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/79ee0659a21f4fb18f36d4b2eae728fe.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_f165b9a3055d4c4d8c53e00622f3ae9c\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_248363e32ced4b49b50b00d2d03db810\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_783b5eb34b464b32a3ce95cfdc84bc2e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_908f9877ad964a7f9cbcb37fd416fe36\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:03Z\",\"updated_at\":\"2022-06-01T19:49:03Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_908f9877ad964a7f9cbcb37fd416fe36\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:04Z\",\"updated_at\":\"2022-06-01T19:49:04Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_c2c4011b2c0e44689a0ba58d28ee5ac5\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892933\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:49:04Z\",\"updated_at\":\"2022-06-01T19:49:04Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2MyYzQwMTFiMmMwZTQ0Njg5YTBiYTU4ZDI4ZWU1YWM1\"},\"to_address\":{\"id\":\"adr_e38c393ce1e311ecbe2fac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:04+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e38d8bbee1e311eca485ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:03+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e38c393ce1e311ecbe2fac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:03+00:00\",\"updated_at\":\"2022-06-01T19:49:04+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_f383d616dfd044a2865e51afe9843dbe\",\"object\":\"Shipment\"}"
+            "size": 2910,
+            "text": "{\"created_at\":\"2022-07-28T23:00:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522883\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4a40d6ced5124b65be89cf45d1925a69\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a0fce06eb70d4074a45e6c4970b42c9d\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_fbe3a1f5b6df453cab4433731bc6ac20\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:00:57Z\",\"updated_at\":\"2022-07-28T23:00:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_95442ddb6f12441991378461bf46514c\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:00:58Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/66ba301cabb64287836196b63801e992.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_b552961b13df4f3f808c8a323ff63738\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_384c2359784c4d98981f4db141f89513\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ba09ca69094041a0bc6815fd80c68222\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_d5fb56b6031f4ee1b7dac402ecb39dd8\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:00:58Z\",\"updated_at\":\"2022-07-28T23:00:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_cb05ba4bc8e8464d9feda41372827d3f\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522883\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:01:00Z\",\"updated_at\":\"2022-07-28T23:01:00Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2NiMDViYTRiYzhlODQ2NGQ5ZmVkYTQxMzcyODI3ZDNm\"},\"to_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_241d95f50ec911ed8e5bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_241b52a90ec911ed9cfcac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:00:57+00:00\",\"updated_at\":\"2022-07-28T23:00:58+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_8dd17fb0d4f14ac692d5058cfe9f8dfa\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c2b0e786c4dd00098fc6"
+              "value": "efdf9e0162e3152aff24e617000ade91"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"92a76056952e8a3f903dab00773bbee0\""
+              "value": "W/\"4d8ec5f67378d953be6cc33699b16102\""
             },
             {
               "name": "x-runtime",
-              "value": "0.880006"
+              "value": "2.040165"
             },
             {
               "name": "content-encoding",
@@ -276,23 +276,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb4wdc 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -303,14 +299,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:03.924Z",
-        "time": 1124,
+        "startedDateTime": "2022-07-28T23:00:58.199Z",
+        "time": 2419,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1124
+          "wait": 2419
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/converts-the-label-format-of-a-shipment_4034441427/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/converts-the-label-format-of-a-shipment_4034441427/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 390,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2071,
+          "bodySize": 2056,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2071,
-            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:01:18Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
+            "size": 2056,
+            "text": "{\"created_at\":\"2022-07-29T22:03:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:01Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_c3939399f0c9455bbcc271840ebd867b\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_82ff7554f62747a29dd15c62933feb6f\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_c67048cc4478484dbaee0a877c1f6ca5\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_42f4a2a67bcf4089a9a5b53bf88b1b8d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ca531ff2b6b541009ca97b20023bc04a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1b8c9da1885145d99d07872192e2b102\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "a41775b562e3153eff24e61b000b4a1e"
+              "value": "999d146d62e45915e788dd23000fe293"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4"
+              "value": "/api/v2/shipments/shp_ed2035f1a49f45228f04cdcb5ca229bd"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"7930227bdd5fd616f20abf07b84c7d12\""
+              "value": "W/\"8a4229b3507a1fec54b344cb13432499\""
             },
             {
               "name": "x-runtime",
-              "value": "0.666455"
+              "value": "0.556721"
             },
             {
               "name": "content-encoding",
@@ -123,23 +123,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -150,14 +146,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 828,
+          "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4",
+          "redirectURL": "/api/v2/shipments/shp_ed2035f1a49f45228f04cdcb5ca229bd",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-28T23:01:17.809Z",
-        "time": 1051,
+        "startedDateTime": "2022-07-29T22:03:01.208Z",
+        "time": 743,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -165,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1051
+          "wait": 743
         }
       },
       {
-        "_id": "eb71e81b72288a9b9378c3ddd5ce3ff8",
+        "_id": "2b7ea62b31c2ef9342eb2d9e3786aefd",
         "_order": 0,
         "cache": {},
         "request": {
@@ -197,24 +193,24 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 430,
+          "headersSize": 431,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\"},\"carbon_offset\":false}"
+            "text": "{\"rate\":{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\"},\"carbon_offset\":false}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_ed2035f1a49f45228f04cdcb5ca229bd/buy"
         },
         "response": {
-          "bodySize": 2908,
+          "bodySize": 2900,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2908,
-            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522913\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_53626df89ea64d1e83eb0f7b668d420a\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:01:19Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/06da2024d94546c8b142b47db2648e3b.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_7450330d3152418381cf6b6a0808a0ec\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522913\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:01:20Z\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzc0NTAzMzBkMzE1MjQxODM4MWNmNmI2YTA4MDhhMGVj\"},\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
+            "size": 2900,
+            "text": "{\"created_at\":\"2022-07-29T22:03:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689425\",\"updated_at\":\"2022-07-29T22:03:03Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_c3939399f0c9455bbcc271840ebd867b\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_82ff7554f62747a29dd15c62933feb6f\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_c67048cc4478484dbaee0a877c1f6ca5\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_32fad24e6be3401ea9ad9306f8fdbcca\",\"created_at\":\"2022-07-29T22:03:02Z\",\"updated_at\":\"2022-07-29T22:03:03Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:02Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/79693a73a2314814809d871a688a90ed.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_42f4a2a67bcf4089a9a5b53bf88b1b8d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ca531ff2b6b541009ca97b20023bc04a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1b8c9da1885145d99d07872192e2b102\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:02Z\",\"updated_at\":\"2022-07-29T22:03:02Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_cb6a65c609b544d4aa128bb2dd99e1d1\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689425\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:03Z\",\"updated_at\":\"2022-07-29T22:03:03Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2NiNmE2NWM2MDliNTQ0ZDRhYTEyOGJiMmRkOTllMWQx\"},\"to_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:02+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:02+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -244,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "efdf9dfe62e3153fff24e61c000ae498"
+              "value": "999d147062e45916e788dd24000fe2c4"
             },
             {
               "name": "cache-control",
@@ -264,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"82d26e6eb70e5da017dc1f48061dff6b\""
+              "value": "W/\"0906678037031d25c5c6843e69e850ae\""
             },
             {
               "name": "x-runtime",
-              "value": "0.979527"
+              "value": "1.080075"
             },
             {
               "name": "content-encoding",
@@ -280,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -292,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb4wdc 403f17ff97"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -303,14 +299,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-28T23:01:18.865Z",
-        "time": 1242,
+        "startedDateTime": "2022-07-29T22:03:01.954Z",
+        "time": 1288,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,11 +314,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1242
+          "wait": 1288
         }
       },
       {
-        "_id": "b63294eba67e045a10dc077f0de88379",
+        "_id": "353f8e5d10cb5b2891bef2ef8df449ec",
         "_order": 0,
         "cache": {},
         "request": {
@@ -346,7 +342,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 427,
+          "headersSize": 428,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -355,15 +351,15 @@
               "value": "ZPL"
             }
           ],
-          "url": "https://api.easypost.com/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4/label?file_format=ZPL"
+          "url": "https://api.easypost.com/v2/shipments/shp_ed2035f1a49f45228f04cdcb5ca229bd/label?file_format=ZPL"
         },
         "response": {
-          "bodySize": 3328,
+          "bodySize": 3319,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 3328,
-            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522913\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_53626df89ea64d1e83eb0f7b668d420a\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:22Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:01:19Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/06da2024d94546c8b142b47db2648e3b.png\",\"label_pdf_url\":null,\"label_zpl_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220728/eedd6a1e31c748908d6dc6bf153811c9.zpl\",\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_7450330d3152418381cf6b6a0808a0ec\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522913\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-28T23:01:20Z\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-28T23:01:20Z\",\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-28T23:01:20Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T11:38:20Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzc0NTAzMzBkMzE1MjQxODM4MWNmNmI2YTA4MDhhMGVj\"},\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
+            "size": 3319,
+            "text": "{\"created_at\":\"2022-07-29T22:03:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689425\",\"updated_at\":\"2022-07-29T22:03:03Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_c3939399f0c9455bbcc271840ebd867b\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_82ff7554f62747a29dd15c62933feb6f\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_c67048cc4478484dbaee0a877c1f6ca5\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_32fad24e6be3401ea9ad9306f8fdbcca\",\"created_at\":\"2022-07-29T22:03:02Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:02Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/79693a73a2314814809d871a688a90ed.png\",\"label_pdf_url\":null,\"label_zpl_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220729/30a6a65aa20542258fa9cd8cb16694c8.zpl\",\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_42f4a2a67bcf4089a9a5b53bf88b1b8d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ca531ff2b6b541009ca97b20023bc04a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1b8c9da1885145d99d07872192e2b102\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_645f93b882b84f48ad5c880a8c6c1f00\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:02Z\",\"updated_at\":\"2022-07-29T22:03:02Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_cb6a65c609b544d4aa128bb2dd99e1d1\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689425\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:03:03Z\",\"updated_at\":\"2022-07-29T22:03:03Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:03:03Z\",\"shipment_id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:03:03Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:40:03Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrX2NiNmE2NWM2MDliNTQ0ZDRhYTEyOGJiMmRkOTllMWQx\"},\"to_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:02+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_369dae9e0f8a11edac17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_369bc6c70f8a11edac16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:01+00:00\",\"updated_at\":\"2022-07-29T22:03:02+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_ed2035f1a49f45228f04cdcb5ca229bd\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -393,7 +389,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "b0657e4162e31540ff24e61d003fa5d9"
+              "value": "999d146c62e45917e788dd25000fe31c"
             },
             {
               "name": "cache-control",
@@ -413,11 +409,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"52711b6d32653226f346ddabbf2cd6a6\""
+              "value": "W/\"a40db231f05bf77c08fefc66d37d923d\""
             },
             {
               "name": "x-runtime",
-              "value": "1.814962"
+              "value": "1.708342"
             },
             {
               "name": "content-encoding",
@@ -429,11 +425,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -441,7 +437,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 403f17ff97, intlb2wdc 403f17ff97, extlb3wdc 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -452,14 +448,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-28T23:01:20.113Z",
-        "time": 2016,
+        "startedDateTime": "2022-07-29T22:03:03.248Z",
+        "time": 2037,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -467,7 +463,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 2016
+          "wait": 2037
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/converts-the-label-format-of-a-shipment_4034441427/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/converts-the-label-format-of-a-shipment_4034441427/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 390,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2006,
+          "bodySize": 2071,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2006,
-            "text": "{\"created_at\":\"2022-06-01T19:49:07Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:07Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_fbea57ae9b854348af939aad020261bb\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_fd08bc04ac47484fbe885f19d106429c\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_49e78c77ef8c4f208efe70cbcfd20f41\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_04d8760bd8794f9c982c307f0acf6f2f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ce3edbc639a246a68d1d0b0637799c51\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2ad34e7a4e9d47d4bb0a84664c250cbf\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"object\":\"Shipment\"}"
+            "size": 2071,
+            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-28T23:01:18Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2b3e786c4e0000991ba"
+              "value": "a41775b562e3153eff24e61b000b4a1e"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_dc1654abc3364d4f9cdedaed995d6a49"
+              "value": "/api/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0d014a121a050935512392c8e8c466a7\""
+              "value": "W/\"7930227bdd5fd616f20abf07b84c7d12\""
             },
             {
               "name": "x-runtime",
-              "value": "0.476998"
+              "value": "0.666455"
             },
             {
               "name": "content-encoding",
@@ -123,19 +123,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 828,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_dc1654abc3364d4f9cdedaed995d6a49",
+          "redirectURL": "/api/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:06.790Z",
-        "time": 668,
+        "startedDateTime": "2022-07-28T23:01:17.809Z",
+        "time": 1051,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,15 +165,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 668
+          "wait": 1051
         }
       },
       {
-        "_id": "bdc0a31c4e8af3cc61b8065186abd88a",
+        "_id": "eb71e81b72288a9b9378c3ddd5ce3ff8",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 55,
+          "bodySize": 77,
           "cookies": [],
           "headers": [
             {
@@ -186,31 +190,31 @@
             },
             {
               "name": "content-length",
-              "value": 55
+              "value": 77
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 533,
+          "headersSize": 430,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\"}}"
+            "text": "{\"rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\"},\"carbon_offset\":false}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_dc1654abc3364d4f9cdedaed995d6a49/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4/buy"
         },
         "response": {
-          "bodySize": 2824,
+          "bodySize": 2908,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2824,
-            "text": "{\"created_at\":\"2022-06-01T19:49:07Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892940\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_fbea57ae9b854348af939aad020261bb\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_fd08bc04ac47484fbe885f19d106429c\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_49e78c77ef8c4f208efe70cbcfd20f41\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_e0e7d58f397e4f4193fdefff422c8e8e\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:08Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/ad8177ca5fa84327a1fd652943684a1e.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_04d8760bd8794f9c982c307f0acf6f2f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ce3edbc639a246a68d1d0b0637799c51\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2ad34e7a4e9d47d4bb0a84664c250cbf\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_ea579b34302e45d49ae76343d143694e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892940\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2VhNTc5YjM0MzAyZTQ1ZDQ5YWU3NjM0M2QxNDM2OTRl\"},\"to_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"object\":\"Shipment\"}"
+            "size": 2908,
+            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522913\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_53626df89ea64d1e83eb0f7b668d420a\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:01:19Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/06da2024d94546c8b142b47db2648e3b.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_7450330d3152418381cf6b6a0808a0ec\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522913\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:01:20Z\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzc0NTAzMzBkMzE1MjQxODM4MWNmNmI2YTA4MDhhMGVj\"},\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +244,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2b3e786c4e10009922e"
+              "value": "efdf9dfe62e3153fff24e61c000ae498"
             },
             {
               "name": "cache-control",
@@ -260,11 +264,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"18bb16f4cd579e08e8a8917be05f6f99\""
+              "value": "W/\"82d26e6eb70e5da017dc1f48061dff6b\""
             },
             {
               "name": "x-runtime",
-              "value": "0.970323"
+              "value": "0.979527"
             },
             {
               "name": "content-encoding",
@@ -276,11 +280,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +292,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb4wdc 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -299,14 +303,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:07.464Z",
-        "time": 1218,
+        "startedDateTime": "2022-07-28T23:01:18.865Z",
+        "time": 1242,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,11 +318,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1218
+          "wait": 1242
         }
       },
       {
-        "_id": "bce5adbfe35379f040af83dd635b7340",
+        "_id": "b63294eba67e045a10dc077f0de88379",
         "_order": 0,
         "cache": {},
         "request": {
@@ -342,7 +346,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 530,
+          "headersSize": 427,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
@@ -351,15 +355,15 @@
               "value": "ZPL"
             }
           ],
-          "url": "https://api.easypost.com/v2/shipments/shp_dc1654abc3364d4f9cdedaed995d6a49/label?file_format=ZPL"
+          "url": "https://api.easypost.com/v2/shipments/shp_42382225eb594633bf82f6bb16a16df4/label?file_format=ZPL"
         },
         "response": {
-          "bodySize": 3246,
+          "bodySize": 3328,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 3246,
-            "text": "{\"created_at\":\"2022-06-01T19:49:07Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361121892940\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_fbea57ae9b854348af939aad020261bb\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_fd08bc04ac47484fbe885f19d106429c\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_49e78c77ef8c4f208efe70cbcfd20f41\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_e0e7d58f397e4f4193fdefff422c8e8e\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:10Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T19:49:08Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/ad8177ca5fa84327a1fd652943684a1e.png\",\"label_pdf_url\":null,\"label_zpl_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220601/0a6738351aa64537a95fb6f2a4fe03bf.zpl\",\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_04d8760bd8794f9c982c307f0acf6f2f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ce3edbc639a246a68d1d0b0637799c51\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2ad34e7a4e9d47d4bb0a84664c250cbf\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:07Z\",\"updated_at\":\"2022-06-01T19:49:07Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_37f94141dea247189df7f8dcbf4058c9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_ea579b34302e45d49ae76343d143694e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121892940\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T19:49:08Z\",\"updated_at\":\"2022-06-01T19:49:08Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T19:49:08Z\",\"shipment_id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T19:49:08Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T08:26:08Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrX2VhNTc5YjM0MzAyZTQ1ZDQ5YWU3NjM0M2QxNDM2OTRl\"},\"to_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e5c85d91e1e311ecae7eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e5c66bc8e1e311ecb123ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:07+00:00\",\"updated_at\":\"2022-06-01T19:49:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_dc1654abc3364d4f9cdedaed995d6a49\",\"object\":\"Shipment\"}"
+            "size": 3328,
+            "text": "{\"created_at\":\"2022-07-28T23:01:18Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100109361130522913\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ec6e7fb41b664a48ae2a4e423b135c4c\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d9927f03bdc44e06837babea99154360\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_69de3742d68240928984ed66662d845f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_53626df89ea64d1e83eb0f7b668d420a\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:22Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:01:19Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/06da2024d94546c8b142b47db2648e3b.png\",\"label_pdf_url\":null,\"label_zpl_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/postage_label/20220728/eedd6a1e31c748908d6dc6bf153811c9.zpl\",\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a7aff8002ad64acc9703670508ccae37\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1520eb7f83994379a3903b5a6494c074\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_13471d9bf6da43f9b72d57b1f9cb4bbe\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:18Z\",\"updated_at\":\"2022-07-28T23:01:18Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_7485ade6c1084c6da6224f9694070dcf\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:19Z\",\"updated_at\":\"2022-07-28T23:01:19Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_7450330d3152418381cf6b6a0808a0ec\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130522913\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-28T23:01:20Z\",\"updated_at\":\"2022-07-28T23:01:20Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-28T23:01:20Z\",\"shipment_id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-28T23:01:20Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T11:38:20Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzc0NTAzMzBkMzE1MjQxODM4MWNmNmI2YTA4MDhhMGVj\"},\"to_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3073d7a50ec911ed94a5ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:18+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_30720d3e0ec911ed8dc6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:01:18+00:00\",\"updated_at\":\"2022-07-28T23:01:19+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_42382225eb594633bf82f6bb16a16df4\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -389,7 +393,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2b4e786c4e2000992f2"
+              "value": "b0657e4162e31540ff24e61d003fa5d9"
             },
             {
               "name": "cache-control",
@@ -409,11 +413,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"77baf1d119e1399076f89ca5f8671782\""
+              "value": "W/\"52711b6d32653226f346ddabbf2cd6a6\""
             },
             {
               "name": "x-runtime",
-              "value": "1.493202"
+              "value": "1.814962"
             },
             {
               "name": "content-encoding",
@@ -425,11 +429,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
@@ -437,7 +441,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, intlb2wdc 403f17ff97, extlb3wdc 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -448,14 +452,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 766,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:08.687Z",
-        "time": 1685,
+        "startedDateTime": "2022-07-28T23:01:20.113Z",
+        "time": 2016,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -463,7 +467,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1685
+          "wait": 2016
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/create-a-carbon-offset-shipment_3278956520/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/create-a-carbon-offset-shipment_3278956520/recording.har
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "_recordingName": "Shipment Resource/create a carbon offset shipment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "7ecaca9e12fdd1caa7501ba338c5174b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 495,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 495
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 390,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9}},\"carbon_offset\":true}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 1766,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 1766,
+            "text": "{\"created_at\":\"2022-07-21T21:38:08Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-21T21:38:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_69380a86093d11edb353ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-21T21:38:08+00:00\",\"updated_at\":\"2022-07-21T21:38:08+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_0f33ddcd0f6447589815e6b913ee49cb\",\"object\":\"Parcel\",\"created_at\":\"2022-07-21T21:38:08Z\",\"updated_at\":\"2022-07-21T21:38:08Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_cf43d21751c041279ebe233e5dc0759a\",\"object\":\"Rate\",\"created_at\":\"2022-07-21T21:38:08Z\",\"updated_at\":\"2022-07-21T21:38:08Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_444f56a7b4d64336a9a237b742e9ee8b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_3c81348a9e604bac86fdd054948d2a84\",\"object\":\"Rate\",\"created_at\":\"2022-07-21T21:38:08Z\",\"updated_at\":\"2022-07-21T21:38:08Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_444f56a7b4d64336a9a237b742e9ee8b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_a194f347a017419da58c678db42a6b08\",\"object\":\"Rate\",\"created_at\":\"2022-07-21T21:38:08Z\",\"updated_at\":\"2022-07-21T21:38:08Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_444f56a7b4d64336a9a237b742e9ee8b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_6936307a093d11ed9a64ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-21T21:38:08+00:00\",\"updated_at\":\"2022-07-21T21:38:08+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_69380a86093d11edb353ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-21T21:38:08+00:00\",\"updated_at\":\"2022-07-21T21:38:08+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_6936307a093d11ed9a64ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-21T21:38:08+00:00\",\"updated_at\":\"2022-07-21T21:38:08+00:00\",\"name\":\"Dr. Steve Brule\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_444f56a7b4d64336a9a237b742e9ee8b\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "61ae037562d9c740e798d10300105f49"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_444f56a7b4d64336a9a237b742e9ee8b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"5f91096624a59e51fa0fcddedbc37699\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.605859"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb5nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207211838-2796cdef6c-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 403f17ff97, extlb1nuq 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 810,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_444f56a7b4d64336a9a237b742e9ee8b",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-07-21T21:38:07.528Z",
+        "time": 971,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 971
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-when-only-IDs-are-used_3469201880/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-when-only-IDs-are-used_3469201880/recording.har
@@ -479,11 +479,11 @@
         }
       },
       {
-        "_id": "54badac7d998b22ccb908aeea4a211c5",
+        "_id": "e74200d9294805e51ccd1bec3a9a9fc0",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 190,
+          "bodySize": 212,
           "cookies": [],
           "headers": [
             {
@@ -500,31 +500,31 @@
             },
             {
               "name": "content-length",
-              "value": 190
+              "value": 212
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\"},\"from_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\"},\"parcel\":{\"id\":\"prcl_2893bb2990f14bcf9c9304b43d801e67\"}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\"},\"from_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\"},\"parcel\":{\"id\":\"prcl_2893bb2990f14bcf9c9304b43d801e67\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1578,
+          "bodySize": 1658,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1578,
-            "text": "{\"created_at\":\"2022-06-01T19:49:00Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:01Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_2893bb2990f14bcf9c9304b43d801e67\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:00Z\",\"updated_at\":\"2022-06-01T19:49:00Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_ea8838bcf0df427db46c44d96cb6ba56\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_106dca5bc57a46989c352af8e82bf327\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4495cae5bd1e4901a2d36ec8cfc2eefe\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_106dca5bc57a46989c352af8e82bf327\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_3cb4cd214d6245d5bfc0959694027c17\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_106dca5bc57a46989c352af8e82bf327\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_cb7946285dff4e28a5e780b99ccff57d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_106dca5bc57a46989c352af8e82bf327\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_106dca5bc57a46989c352af8e82bf327\",\"object\":\"Shipment\"}"
+            "size": 1658,
+            "text": "{\"created_at\":\"2022-07-29T22:02:55Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:56Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_2893bb2990f14bcf9c9304b43d801e67\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:00Z\",\"updated_at\":\"2022-06-01T19:49:00Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_72b80fbc489d4a2da0d519e9a2b8dc97\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e49fb642dc414830b119d93484f64ce8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_a8c6ab90dd3341d6a12135beebb80c47\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e49fb642dc414830b119d93484f64ce8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_14f79480adf04d1f898e8118bf0dfc97\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_e49fb642dc414830b119d93484f64ce8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6bdbb2c93e6049cf88de156ad403e523\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_e49fb642dc414830b119d93484f64ce8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e1b0b698e1e311ecacd3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e1d3d28fe1e311ecbd7bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:00+00:00\",\"updated_at\":\"2022-06-01T19:49:00+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_e49fb642dc414830b119d93484f64ce8\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -554,7 +554,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2ace786c4c100098d6a"
+              "value": "999d146a62e4590fe788dd1c000fe0e8"
             },
             {
               "name": "cache-control",
@@ -570,7 +570,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_106dca5bc57a46989c352af8e82bf327"
+              "value": "/api/v2/shipments/shp_e49fb642dc414830b119d93484f64ce8"
             },
             {
               "name": "content-type",
@@ -578,11 +578,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"3f7e8225b42f9f0aed582003c386484f\""
+              "value": "W/\"0e1618611c919082be5cdc014ba1a17d\""
             },
             {
               "name": "x-runtime",
-              "value": "0.552129"
+              "value": "0.503129"
             },
             {
               "name": "content-encoding",
@@ -594,11 +594,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -606,7 +606,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -619,12 +619,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_106dca5bc57a46989c352af8e82bf327",
+          "redirectURL": "/api/v2/shipments/shp_e49fb642dc414830b119d93484f64ce8",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:00.620Z",
-        "time": 772,
+        "startedDateTime": "2022-07-29T22:02:55.690Z",
+        "time": 742,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -632,7 +632,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 772
+          "wait": 742
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-with-empty-or-null-objects-and-arrays_3556538065/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-with-empty-or-null-objects-and-arrays_3556538065/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1574,
+          "bodySize": 1607,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1574,
-            "text": "{\"created_at\":\"2022-06-01T19:48:57Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:48:58Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_e03e270ae1e311ecbcbdac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:57+00:00\",\"updated_at\":\"2022-06-01T19:48:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_04a04f63999d4a199d884c5599ab7710\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:57Z\",\"updated_at\":\"2022-06-01T19:48:57Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_e83964bd6ee1425e9b3cf77bf77ff7b1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:58Z\",\"updated_at\":\"2022-06-01T19:48:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_199910e68e4e4b39a298f074734d4396\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_44ac58bf13054b2dafd174a6e7527ed3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:58Z\",\"updated_at\":\"2022-06-01T19:48:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_199910e68e4e4b39a298f074734d4396\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4d220f099da1465c9a45cd89aa33d3b9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:58Z\",\"updated_at\":\"2022-06-01T19:48:58Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_199910e68e4e4b39a298f074734d4396\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ca8e3c99aec741399251b773bf969850\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:58Z\",\"updated_at\":\"2022-06-01T19:48:58Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_199910e68e4e4b39a298f074734d4396\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e03af4d0e1e311ecac37ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:57+00:00\",\"updated_at\":\"2022-06-01T19:48:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e03e270ae1e311ecbcbdac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:57+00:00\",\"updated_at\":\"2022-06-01T19:48:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e03af4d0e1e311ecac37ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:57+00:00\",\"updated_at\":\"2022-06-01T19:48:57+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_199910e68e4e4b39a298f074734d4396\",\"object\":\"Shipment\"}"
+            "size": 1607,
+            "text": "{\"created_at\":\"2022-07-29T22:02:54Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:54Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3243d6130f8a11ed9964ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_fe998bd5da1a4a2ebdc6f21c28fcd7c8\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_4db40e44a60d4731a0dde4ac7f7ef6d4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_efefb8014487438d8a390e5b6f09def6\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d6a90db033e04a289882d656aca308d2\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_efefb8014487438d8a390e5b6f09def6\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_74ca3e34a22c46a7b5ea22367a35d6c2\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_efefb8014487438d8a390e5b6f09def6\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7143f3a58dd449a39e93ec986df88a45\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_efefb8014487438d8a390e5b6f09def6\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_3241f4d10f8a11ed9963ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3243d6130f8a11ed9964ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3241f4d10f8a11ed9963ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_efefb8014487438d8a390e5b6f09def6\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297c2a9e786c4bc00098b1a"
+              "value": "999d147062e4590ee788dd03000fe061"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_199910e68e4e4b39a298f074734d4396"
+              "value": "/api/v2/shipments/shp_efefb8014487438d8a390e5b6f09def6"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"ff3056783595a123f57d85db869b6a31\""
+              "value": "W/\"adcb5f05b5c3391a872158e145cfb1a0\""
             },
             {
               "name": "x-runtime",
-              "value": "1.007933"
+              "value": "0.454819"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_199910e68e4e4b39a298f074734d4396",
+          "redirectURL": "/api/v2/shipments/shp_efefb8014487438d8a390e5b6f09def6",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:57.480Z",
-        "time": 1324,
+        "startedDateTime": "2022-07-29T22:02:53.908Z",
+        "time": 642,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +161,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1324
+          "wait": 642
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-with-tax_identifiers_2190110005/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment-with-tax_identifiers_2190110005/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "e7e909f356e1f2b40dc11382f9d63270",
+        "_id": "a1fccdf35e278afa1706a61a71e5ff00",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 527,
+          "bodySize": 549,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 527
+              "value": 549
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"tax_identifiers\":[{\"entity\":\"SENDER\",\"tax_id_type\":\"IOSS\",\"tax_id\":\"12345\",\"issuing_country\":\"GB\"}]}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"tax_identifiers\":[{\"entity\":\"SENDER\",\"tax_id_type\":\"IOSS\",\"tax_id\":\"12345\",\"issuing_country\":\"GB\"}]},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1626,
+          "bodySize": 1714,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1626,
-            "text": "{\"created_at\":\"2022-06-01T19:48:59Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:48:59Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_e106686be1e311ecac83ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:59+00:00\",\"updated_at\":\"2022-06-01T19:48:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_2c5a1634e0ca4ad6b420810632819c38\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:59Z\",\"updated_at\":\"2022-06-01T19:48:59Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_bfa864ba02a04046af1ffe5054f00e87\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:59Z\",\"updated_at\":\"2022-06-01T19:48:59Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_226e5a1a1776445aad0dd01168af0632\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f8a707cc020240b29f3f4916ad2bbe99\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:59Z\",\"updated_at\":\"2022-06-01T19:48:59Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_226e5a1a1776445aad0dd01168af0632\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c84ff4bb421245c18c0150a644cfa5d6\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:59Z\",\"updated_at\":\"2022-06-01T19:48:59Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_226e5a1a1776445aad0dd01168af0632\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4144ad519f50432e9ca09fcba11ce21d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:59Z\",\"updated_at\":\"2022-06-01T19:48:59Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_226e5a1a1776445aad0dd01168af0632\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e1049cfbe1e311ecac82ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:59+00:00\",\"updated_at\":\"2022-06-01T19:48:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e106686be1e311ecac83ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:59+00:00\",\"updated_at\":\"2022-06-01T19:48:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e1049cfbe1e311ecac82ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:59+00:00\",\"updated_at\":\"2022-06-01T19:48:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_226e5a1a1776445aad0dd01168af0632\",\"object\":\"Shipment\",\"tax_identifiers\":[{\"entity\":\"SENDER\",\"tax_id\":\"HIDDEN\",\"tax_id_type\":\"IOSS\",\"issuing_country\":\"GB\"}]}"
+            "size": 1714,
+            "text": "{\"created_at\":\"2022-07-29T22:02:54Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:55Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_32a7f8e20f8a11eda12aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_140b188702e7446caa433995444e4815\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:54Z\",\"updated_at\":\"2022-07-29T22:02:54Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_5a4c7da3c02548828727746bc313e30d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:55Z\",\"updated_at\":\"2022-07-29T22:02:55Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fa0e0db132934e64a5de435de4479eee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e27a13ad578e4737a66e565a41b77c93\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:55Z\",\"updated_at\":\"2022-07-29T22:02:55Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_fa0e0db132934e64a5de435de4479eee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_83a84f25692643b98385c096bc0db710\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:55Z\",\"updated_at\":\"2022-07-29T22:02:55Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fa0e0db132934e64a5de435de4479eee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f043f828f62742f4b3ee6af01d02e460\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:55Z\",\"updated_at\":\"2022-07-29T22:02:55Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_fa0e0db132934e64a5de435de4479eee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_32a661b60f8a11edab32ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_32a7f8e20f8a11eda12aac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_32a661b60f8a11edab32ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:54+00:00\",\"updated_at\":\"2022-07-29T22:02:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_fa0e0db132934e64a5de435de4479eee\",\"object\":\"Shipment\",\"tax_identifiers\":[{\"entity\":\"SENDER\",\"tax_id\":\"HIDDEN\",\"tax_id_type\":\"IOSS\",\"issuing_country\":\"GB\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c2abe786c4bd00098c19"
+              "value": "999d146962e4590ee788dd04000fe090"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_226e5a1a1776445aad0dd01168af0632"
+              "value": "/api/v2/shipments/shp_fa0e0db132934e64a5de435de4479eee"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"14f96977f72939a1df1229d4acb8f56b\""
+              "value": "W/\"cc209d9a85e08406c43551ca11a5328c\""
             },
             {
               "name": "x-runtime",
-              "value": "0.776353"
+              "value": "0.541425"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_226e5a1a1776445aad0dd01168af0632",
+          "redirectURL": "/api/v2/shipments/shp_fa0e0db132934e64a5de435de4479eee",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:58.814Z",
-        "time": 1114,
+        "startedDateTime": "2022-07-29T22:02:54.559Z",
+        "time": 1104,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +161,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1114
+          "wait": 1104
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment_2399399653/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/creates-a-shipment_2399399653/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2018,
+          "bodySize": 2051,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2018,
-            "text": "{\"created_at\":\"2022-06-01T19:48:56Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:48:57Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_f26965931f224caa95655237124efeb9\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:48:56Z\",\"updated_at\":\"2022-06-01T19:48:56Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_b8de75a8c8014bad9771361f8aeea39c\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:48:56Z\",\"updated_at\":\"2022-06-01T19:48:56Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_dfb0b488e1e311ecbc94ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:56+00:00\",\"updated_at\":\"2022-06-01T19:48:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_dfe73407d16a40788e3688e053acc0ce\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:48:56Z\",\"updated_at\":\"2022-06-01T19:48:56Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_73db36ff3f06452c9a65cd648c7b63fe\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:57Z\",\"updated_at\":\"2022-06-01T19:48:57Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e728f995df8f422193cc948d5538d737\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_254867322d2946ef85951fff86b25519\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:57Z\",\"updated_at\":\"2022-06-01T19:48:57Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e728f995df8f422193cc948d5538d737\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4e3ecf2e5fb34136b8d6f91698aa48e6\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:57Z\",\"updated_at\":\"2022-06-01T19:48:57Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_e728f995df8f422193cc948d5538d737\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5b753a6201ba4455a5269a10f09ca326\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:48:57Z\",\"updated_at\":\"2022-06-01T19:48:57Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_e728f995df8f422193cc948d5538d737\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_dfaed26be1e311eca2d8ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:56+00:00\",\"updated_at\":\"2022-06-01T19:48:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_dfb0b488e1e311ecbc94ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:56+00:00\",\"updated_at\":\"2022-06-01T19:48:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_dfaed26be1e311eca2d8ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:48:56+00:00\",\"updated_at\":\"2022-06-01T19:48:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_e728f995df8f422193cc948d5538d737\",\"object\":\"Shipment\"}"
+            "size": 2051,
+            "text": "{\"created_at\":\"2022-07-29T22:02:53Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:53Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_ff8ab520f6c94547aa0c23343763dbf0\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_2ae347aef2444e3a8fcdbe7b0696dad1\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_31d09c430f8a11edb373ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:53+00:00\",\"updated_at\":\"2022-07-29T22:02:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_1ecd9be7c9bf4e5c9d39b0bcaa017aeb\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_82cc29ea19a040e1b13cbbaa646b739d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_d4c691aeab624bbeb6f45f4b3e98798d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_724325e1de394d96948ae2ad9bd7696c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_d4c691aeab624bbeb6f45f4b3e98798d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0ac14a513f5f4b15be707bb6d7741c1b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d4c691aeab624bbeb6f45f4b3e98798d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f1125831727048eb96dcab20b9802c23\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:53Z\",\"updated_at\":\"2022-07-29T22:02:53Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d4c691aeab624bbeb6f45f4b3e98798d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_31ce68c60f8a11edaaf7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:53+00:00\",\"updated_at\":\"2022-07-29T22:02:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_31d09c430f8a11edb373ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:53+00:00\",\"updated_at\":\"2022-07-29T22:02:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_31ce68c60f8a11edaaf7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:53+00:00\",\"updated_at\":\"2022-07-29T22:02:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_d4c691aeab624bbeb6f45f4b3e98798d\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297c2a8e786c4bb00098a7d"
+              "value": "999d146962e4590de788dd02000fe027"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_e728f995df8f422193cc948d5538d737"
+              "value": "/api/v2/shipments/shp_d4c691aeab624bbeb6f45f4b3e98798d"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"250aa16f64fc3f49ed8c68e2d28ceb7d\""
+              "value": "W/\"4ea77322c5d6ba99d1fc4b464cfb1e7a\""
             },
             {
               "name": "x-runtime",
-              "value": "0.777909"
+              "value": "0.510404"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_e728f995df8f422193cc948d5538d737",
+          "redirectURL": "/api/v2/shipments/shp_d4c691aeab624bbeb6f45f4b3e98798d",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:48:56.497Z",
-        "time": 972,
+        "startedDateTime": "2022-07-29T22:02:53.136Z",
+        "time": 758,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +161,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 972
+          "wait": 758
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/generates-a-form-for-a-shipment_1612844164/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/generates-a-form-for-a-shipment_1612844164/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 389,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2239,
+          "bodySize": 2238,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2239,
-            "text": "{\"created_at\":\"2022-07-13T16:37:31Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361127999346\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_174d8cc802ca11eda97eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_6713021402a148f9a0e2c90e56a17f96\",\"object\":\"Parcel\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_332c003d3e304146b7e25c46326a6b5c\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-13T16:37:32Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220713/3ea0f8e7e7af450498b37244c7709b8c.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_5c2a897a2f944095873ded7e24456067\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ef51006932eb4c1d8e1fb9a4d103aae2\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_dcc65a23a1b443df825e758a7cdb5f82\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ddaa8673586447dcae0c9ff5122f6af9\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_dcc65a23a1b443df825e758a7cdb5f82\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_97950b0cf6da41f2941ffd6ca9d6fb3d\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361127999346\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzk3OTUwYjBjZjZkYTQxZjI5NDFmZmQ2Y2E5ZDZmYjNk\"},\"to_address\":{\"id\":\"adr_174b4aab02ca11ed8358ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_174d8cc802ca11eda97eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_174b4aab02ca11ed8358ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"object\":\"Shipment\"}"
+            "size": 2238,
+            "text": "{\"created_at\":\"2022-07-29T22:03:15Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689456\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3f41ea430f8a11edae17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_5ff3e0b30b1c40b7b3b681dd807f3a2b\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_2012b941159842e395e320e020931558\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:16Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/2d01a1490b9b4a70b8dd50b29ccdda95.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_bd168d154b8844f5892061da566707eb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d63fea06176b4a84a43c3e9d34a682cb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b40d1309e7654519858ea1c5105102c3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b525ac5e8d674e89944c1e23bf8e037f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_b40d1309e7654519858ea1c5105102c3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_81d9c110ead24bd0a6cb7269f5f1da35\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689456\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzgxZDljMTEwZWFkMjRiZDBhNmNiNzI2OWY1ZjFkYTM1\"},\"to_address\":{\"id\":\"adr_3f3ef8ef0f8a11ed9c71ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3f41ea430f8a11edae17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3f3ef8ef0f8a11ed9c71ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "6b116ea462cef4cbec737ff800297413"
+              "value": "999d147062e45923e788dd65000fe6c7"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_cdf414468cbf490c9182d545b2153d97"
+              "value": "/api/v2/shipments/shp_a918dcdf6afc4647a769198f0a5c212d"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"8447008aecbc0939d5434d9785f8c8f7\""
+              "value": "W/\"f0d4a0f31b7989284a48976a4969625c\""
             },
             {
               "name": "x-runtime",
-              "value": "0.970607"
+              "value": "1.065623"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207122341-012813a625-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_cdf414468cbf490c9182d545b2153d97",
+          "redirectURL": "/api/v2/shipments/shp_a918dcdf6afc4647a769198f0a5c212d",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-13T16:37:31.382Z",
-        "time": 1108,
+        "startedDateTime": "2022-07-29T22:03:15.697Z",
+        "time": 1256,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1108
+          "wait": 1256
         }
       },
       {
-        "_id": "b7df98840e061e993fe173564ea57f5c",
+        "_id": "771981d192819767509201cfc6b42446",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,7 +193,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 432,
+          "headersSize": 434,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -202,15 +202,15 @@
             "text": "{\"form\":{\"barcode\":\"RMA12345678900\",\"line_items\":[{\"product\":{\"title\":\"Square Reader\",\"barcode\":\"855658003251\"},\"units\":8}],\"type\":\"return_packing_slip\"}}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_cdf414468cbf490c9182d545b2153d97/forms"
+          "url": "https://api.easypost.com/v2/shipments/shp_a918dcdf6afc4647a769198f0a5c212d/forms"
         },
         "response": {
-          "bodySize": 2768,
+          "bodySize": 2772,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2768,
-            "text": "{\"created_at\":\"2022-07-13T16:37:31Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361127999346\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_174d8cc802ca11eda97eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_6713021402a148f9a0e2c90e56a17f96\",\"object\":\"Parcel\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_332c003d3e304146b7e25c46326a6b5c\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-13T16:37:32Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220713/3ea0f8e7e7af450498b37244c7709b8c.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_5c2a897a2f944095873ded7e24456067\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ef51006932eb4c1d8e1fb9a4d103aae2\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_dcc65a23a1b443df825e758a7cdb5f82\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ddaa8673586447dcae0c9ff5122f6af9\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:31Z\",\"updated_at\":\"2022-07-13T16:37:31Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_dcc65a23a1b443df825e758a7cdb5f82\",\"object\":\"Rate\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_97950b0cf6da41f2941ffd6ca9d6fb3d\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361127999346\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:32Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-13T16:37:32Z\",\"shipment_id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-13T16:37:32Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-14T05:14:32Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzk3OTUwYjBjZjZkYTQxZjI5NDFmZmQ2Y2E5ZDZmYjNk\"},\"to_address\":{\"id\":\"adr_174b4aab02ca11ed8358ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_174d8cc802ca11eda97eac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_174b4aab02ca11ed8358ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-13T16:37:31+00:00\",\"updated_at\":\"2022-07-13T16:37:31+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[{\"object\":\"Form\",\"id\":\"form_35312757a1864eabb78e39a905a0fdf3\",\"created_at\":\"2022-07-13T16:37:32Z\",\"updated_at\":\"2022-07-13T16:37:33Z\",\"mode\":\"test\",\"form_type\":\"return_packing_slip\",\"form_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/form/20220713/4195f982744041cba0dad18940be4223.pdf\",\"submitted_electronically\":null}],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_cdf414468cbf490c9182d545b2153d97\",\"object\":\"Shipment\"}"
+            "size": 2772,
+            "text": "{\"created_at\":\"2022-07-29T22:03:15Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689456\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3f41ea430f8a11edae17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_5ff3e0b30b1c40b7b3b681dd807f3a2b\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_2012b941159842e395e320e020931558\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:16Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/2d01a1490b9b4a70b8dd50b29ccdda95.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_bd168d154b8844f5892061da566707eb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d63fea06176b4a84a43c3e9d34a682cb\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b40d1309e7654519858ea1c5105102c3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b525ac5e8d674e89944c1e23bf8e037f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_b40d1309e7654519858ea1c5105102c3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:16Z\",\"updated_at\":\"2022-07-29T22:03:16Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_81d9c110ead24bd0a6cb7269f5f1da35\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689456\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:03:17Z\",\"updated_at\":\"2022-07-29T22:03:17Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:03:17Z\",\"shipment_id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:03:17Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:40:17Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzgxZDljMTEwZWFkMjRiZDBhNmNiNzI2OWY1ZjFkYTM1\"},\"to_address\":{\"id\":\"adr_3f3ef8ef0f8a11ed9c71ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3f41ea430f8a11edae17ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3f3ef8ef0f8a11ed9c71ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:16+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[{\"object\":\"Form\",\"id\":\"form_b8fdbe39e57b4e8ca222b44ff99b1f5a\",\"created_at\":\"2022-07-29T22:03:17Z\",\"updated_at\":\"2022-07-29T22:03:17Z\",\"mode\":\"test\",\"form_type\":\"return_packing_slip\",\"form_url\":\"https://easypost-files.s3-us-west-2.amazonaws.com/files/form/20220729/4a9bd16a470547a68c2474c7c69a8346.pdf\",\"submitted_electronically\":null}],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_a918dcdf6afc4647a769198f0a5c212d\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "6b116ea662cef4ccec5fc2d80029747e"
+              "value": "999d146d62e45925e788dd66000fe721"
             },
             {
               "name": "cache-control",
@@ -256,7 +256,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_cdf414468cbf490c9182d545b2153d97/forms/return_packing_slip"
+              "value": "/api/v2/shipments/shp_a918dcdf6afc4647a769198f0a5c212d/forms/return_packing_slip"
             },
             {
               "name": "content-type",
@@ -264,11 +264,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"eac7730723f921b5935a2a7019dd45fc\""
+              "value": "W/\"3bdccd85bd9b2bf93fc7c2993319c47d\""
             },
             {
               "name": "x-runtime",
-              "value": "0.546552"
+              "value": "0.565943"
             },
             {
               "name": "content-encoding",
@@ -280,19 +280,15 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207122341-012813a625-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
-            },
-            {
-              "name": "x-canary",
-              "value": "direct"
             },
             {
               "name": "x-proxied",
@@ -307,14 +303,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 854,
+          "headersSize": 836,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_cdf414468cbf490c9182d545b2153d97/forms/return_packing_slip",
+          "redirectURL": "/api/v2/shipments/shp_a918dcdf6afc4647a769198f0a5c212d/forms/return_packing_slip",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-13T16:37:32.504Z",
-        "time": 649,
+        "startedDateTime": "2022-07-29T22:03:16.960Z",
+        "time": 760,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -322,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 649
+          "wait": 760
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-rate_906620131/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-rate_906620131/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2072,
+          "bodySize": 2086,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2072,
-            "text": "{\"created_at\":\"2022-06-01T21:06:47Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_29df72e491334a109de21bfec07ee526\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T21:06:47Z\",\"updated_at\":\"2022-06-01T21:06:47Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_52cff7ec65c44192b909707561e41f1c\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T21:06:47Z\",\"updated_at\":\"2022-06-01T21:06:47Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_bf9c3545e1ee11ecb3b7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:47+00:00\",\"updated_at\":\"2022-06-01T21:06:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_cc8815a9f3c448a1ba5dcc720771c601\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:47Z\",\"updated_at\":\"2022-06-01T21:06:47Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_d0ab66578aa847e1b529f03be73d2479\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5e5ce53afc3147eb83e89625925ae500\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7ac285ab1e1041799a52dd6ea9be01dc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_5e5ce53afc3147eb83e89625925ae500\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5f8e75cfd63449959aee818deba1a099\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5e5ce53afc3147eb83e89625925ae500\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_aac78fa07f834b0bb8c198a2a58cfff3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_5e5ce53afc3147eb83e89625925ae500\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_bf9a95d4e1ee11ec88a6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:47+00:00\",\"updated_at\":\"2022-06-01T21:06:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_bf9c3545e1ee11ecb3b7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:47+00:00\",\"updated_at\":\"2022-06-01T21:06:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_bf9a95d4e1ee11ec88a6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:47+00:00\",\"updated_at\":\"2022-06-01T21:06:47+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_5e5ce53afc3147eb83e89625925ae500\",\"object\":\"Shipment\"}"
+            "size": 2086,
+            "text": "{\"created_at\":\"2022-07-29T22:04:48Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:04:49Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_18ca2e4cac60471195db8e2e24f58557\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:04:48Z\",\"updated_at\":\"2022-07-29T22:04:48Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_de80c952131c42a294f5b41d8528ccb9\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:04:48Z\",\"updated_at\":\"2022-07-29T22:04:48Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_76a8578d0f8a11eda955ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:48+00:00\",\"updated_at\":\"2022-07-29T22:04:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_8016cd82e14e48108a8da5c550dcf416\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:48Z\",\"updated_at\":\"2022-07-29T22:04:48Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_3368282ec8524576ba9b6265aa3781cd\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:49Z\",\"updated_at\":\"2022-07-29T22:04:49Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7d01ec632d36480ba0b404c1e4b7d4d5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_08b48d339d8a4192b5de858687379781\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:49Z\",\"updated_at\":\"2022-07-29T22:04:49Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7d01ec632d36480ba0b404c1e4b7d4d5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6254e93b73bf4e71bd72864a66e2b071\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:49Z\",\"updated_at\":\"2022-07-29T22:04:49Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7d01ec632d36480ba0b404c1e4b7d4d5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6de44ec7888a49a992ecb788e7aed192\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:49Z\",\"updated_at\":\"2022-07-29T22:04:49Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_7d01ec632d36480ba0b404c1e4b7d4d5\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_76a68d670f8a11edb0beac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:48+00:00\",\"updated_at\":\"2022-07-29T22:04:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_76a8578d0f8a11eda955ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:48+00:00\",\"updated_at\":\"2022-07-29T22:04:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_76a68d670f8a11edb0beac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:48+00:00\",\"updated_at\":\"2022-07-29T22:04:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_7d01ec632d36480ba0b404c1e4b7d4d5\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297d4e7e787449c00112d41"
+              "value": "999d146a62e45980e788e0d90010032f"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_5e5ce53afc3147eb83e89625925ae500"
+              "value": "/api/v2/shipments/shp_7d01ec632d36480ba0b404c1e4b7d4d5"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"3930de188ac24d96c62dc3d9c8541054\""
+              "value": "W/\"70a3add5dcb0e62d2860debe11eb42be\""
             },
             {
               "name": "x-runtime",
-              "value": "0.644310"
+              "value": "0.768921"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_5e5ce53afc3147eb83e89625925ae500",
+          "redirectURL": "/api/v2/shipments/shp_7d01ec632d36480ba0b404c1e4b7d4d5",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:47.186Z",
-        "time": 919,
+        "startedDateTime": "2022-07-29T22:04:48.638Z",
+        "time": 1140,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +161,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 919
+          "wait": 1140
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-smartrate-from-a-list-of-smartrates_2148185914/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-smartrate-from-a-list-of-smartrates_2148185914/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1634,
+          "bodySize": 1616,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1634,
-            "text": "{\"created_at\":\"2022-06-01T21:06:52Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:52Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c26785a1e1ee11ecb8c3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:52+00:00\",\"updated_at\":\"2022-06-01T21:06:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_c57f5ab99ab74c91b3b59e4393fb1270\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:52Z\",\"updated_at\":\"2022-06-01T21:06:52Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_f84c7ecfd0e84c8b85a14a47fd027846\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:52Z\",\"updated_at\":\"2022-06-01T21:06:52Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_bc973d6a17fa4f2d819ebf35fdc9a95e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:52Z\",\"updated_at\":\"2022-06-01T21:06:52Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5b5339c616574945bbb5a0fd99b24f1d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:52Z\",\"updated_at\":\"2022-06-01T21:06:52Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_afdbb51a2eb943d6baf5d0ee80175970\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:52Z\",\"updated_at\":\"2022-06-01T21:06:52Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c265cfc7e1ee11ecb8c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:52+00:00\",\"updated_at\":\"2022-06-01T21:06:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c26785a1e1ee11ecb8c3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:52+00:00\",\"updated_at\":\"2022-06-01T21:06:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c265cfc7e1ee11ecb8c1ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:52+00:00\",\"updated_at\":\"2022-06-01T21:06:52+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"object\":\"Shipment\"}"
+            "size": 1616,
+            "text": "{\"created_at\":\"2022-07-29T22:04:51Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:04:51Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_780ef3f00f8a11edbb7dac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:51+00:00\",\"updated_at\":\"2022-07-29T22:04:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_b9de6f5785584faa85f13e53bb738d73\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:51Z\",\"updated_at\":\"2022-07-29T22:04:51Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_75f6ebb81d8c49a4991a434567f8f410\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:51Z\",\"updated_at\":\"2022-07-29T22:04:51Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c67e180757f448e094f51cd8d85ee747\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:51Z\",\"updated_at\":\"2022-07-29T22:04:51Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8dff87ef786c427a840d0a421469ad28\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:51Z\",\"updated_at\":\"2022-07-29T22:04:51Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_eccc0b2af2834ca7bdc428b3b49a0710\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:51Z\",\"updated_at\":\"2022-07-29T22:04:51Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_780d35d30f8a11edbb7cac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:51+00:00\",\"updated_at\":\"2022-07-29T22:04:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_780ef3f00f8a11edbb7dac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:51+00:00\",\"updated_at\":\"2022-07-29T22:04:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_780d35d30f8a11edbb7cac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:51+00:00\",\"updated_at\":\"2022-07-29T22:04:51+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297d4ece78744a30011302f"
+              "value": "999d146c62e45983e788e0dc001003cf"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_7443d33a2ce84f2b80c6f916d7b1c6da"
+              "value": "/api/v2/shipments/shp_4112031ca7c74575bda9e72cbf4d2280"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"42f5de1fbdcc45f05d9ab4f5b8417294\""
+              "value": "W/\"e1ddace538ff61e0f086f6d889625e32\""
             },
             {
               "name": "x-runtime",
-              "value": "0.647506"
+              "value": "0.574626"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_7443d33a2ce84f2b80c6f916d7b1c6da",
+          "redirectURL": "/api/v2/shipments/shp_4112031ca7c74575bda9e72cbf4d2280",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:51.877Z",
-        "time": 900,
+        "startedDateTime": "2022-07-29T22:04:51.001Z",
+        "time": 785,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 900
+          "wait": 785
         }
       },
       {
-        "_id": "8bcc78eb1a17d93e50bef73bf9e6734b",
+        "_id": "44ccb74b549d5e95108146e4c48f34f8",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_7443d33a2ce84f2b80c6f916d7b1c6da/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_4112031ca7c74575bda9e72cbf4d2280/smartrate"
         },
         "response": {
-          "bodySize": 760,
+          "bodySize": 756,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 760,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:52Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_f84c7ecfd0e84c8b85a14a47fd027846\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:52Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:52Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_bc973d6a17fa4f2d819ebf35fdc9a95e\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:52Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:52Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_5b5339c616574945bbb5a0fd99b24f1d\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:52Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:52Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_afdbb51a2eb943d6baf5d0ee80175970\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_7443d33a2ce84f2b80c6f916d7b1c6da\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:52Z\"}]}"
+            "size": 756,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_75f6ebb81d8c49a4991a434567f8f410\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:04:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_c67e180757f448e094f51cd8d85ee747\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:04:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_8dff87ef786c427a840d0a421469ad28\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:04:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_eccc0b2af2834ca7bdc428b3b49a0710\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_4112031ca7c74575bda9e72cbf4d2280\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:04:51Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297d4ede78744a4001130c5"
+              "value": "999d146d62e45983e788e0dd00100406"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"b32aeab4840496cd621ad3f70253c6a4\""
+              "value": "W/\"2e27c8828aeb11d589ffde7666bd47ab\""
             },
             {
               "name": "x-runtime",
-              "value": "0.088810"
+              "value": "0.087796"
             },
             {
               "name": "content-encoding",
@@ -267,23 +267,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -294,14 +290,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 762,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:52.783Z",
-        "time": 291,
+        "startedDateTime": "2022-07-29T22:04:51.791Z",
+        "time": 281,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -309,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 291
+          "wait": 281
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-smartrate_175702804/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/gets-the-lowest-smartrate_175702804/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1619,
+          "bodySize": 1631,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1619,
-            "text": "{\"created_at\":\"2022-06-01T21:06:48Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:48Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c02a1d31e1ee11ecb3e9ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:48+00:00\",\"updated_at\":\"2022-06-01T21:06:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_cbb39777a89a45a7a74a179ada2fa9da\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_b2f032395a574b89b1dd0700f8fcf5cc\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_294a299752e844868d58c7c75cf4abd1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ed3b090f2aab4f078e674e30ebecf4f1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b5b2eab78bcd4bb89ed56064cffc774d\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:48Z\",\"updated_at\":\"2022-06-01T21:06:48Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c0286213e1ee11ecb3e7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:48+00:00\",\"updated_at\":\"2022-06-01T21:06:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c02a1d31e1ee11ecb3e9ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:48+00:00\",\"updated_at\":\"2022-06-01T21:06:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c0286213e1ee11ecb3e7ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:48+00:00\",\"updated_at\":\"2022-06-01T21:06:48+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"object\":\"Shipment\"}"
+            "size": 1631,
+            "text": "{\"created_at\":\"2022-07-29T22:04:50Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:04:50Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_775754640f8a11edbd22ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:50+00:00\",\"updated_at\":\"2022-07-29T22:04:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_527d4a45691f490ebc80b2669d634eac\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:04:50Z\",\"updated_at\":\"2022-07-29T22:04:50Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_0a277a84c6164ce1855f3d16e8066bd5\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:50Z\",\"updated_at\":\"2022-07-29T22:04:50Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_16774866c3d94af5b7b04fe2ef3c0246\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:50Z\",\"updated_at\":\"2022-07-29T22:04:50Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_568d7880dc4f4db68fb0df65eedc08b1\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:50Z\",\"updated_at\":\"2022-07-29T22:04:50Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d230166b52924f4997470a55d4a787ef\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:04:50Z\",\"updated_at\":\"2022-07-29T22:04:50Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_7755a4e50f8a11edbd20ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:50+00:00\",\"updated_at\":\"2022-07-29T22:04:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_775754640f8a11edbd22ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:50+00:00\",\"updated_at\":\"2022-07-29T22:04:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_7755a4e50f8a11edbd20ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:04:50+00:00\",\"updated_at\":\"2022-07-29T22:04:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297d4e8e787449d00112de7"
+              "value": "999d146a62e45982e788e0da0010037c"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_4ecfde150a9c4589aa2709f0ed75497e"
+              "value": "/api/v2/shipments/shp_1b98c9292ca34a1f9a915db3c828b7bd"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"babd20d0f0d77bdb4c2d5b3a15986174\""
+              "value": "W/\"6408a56270fefa80a3d7718a3d04573f\""
             },
             {
               "name": "x-runtime",
-              "value": "0.605547"
+              "value": "0.496298"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_4ecfde150a9c4589aa2709f0ed75497e",
+          "redirectURL": "/api/v2/shipments/shp_1b98c9292ca34a1f9a915db3c828b7bd",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:48.117Z",
-        "time": 807,
+        "startedDateTime": "2022-07-29T22:04:49.792Z",
+        "time": 848,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 807
+          "wait": 848
         }
       },
       {
-        "_id": "8c63efc8555abdcf10397ccae3c024ce",
+        "_id": "4fe4c1352a268d92756a2d0679f6cbcc",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_4ecfde150a9c4589aa2709f0ed75497e/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_1b98c9292ca34a1f9a915db3c828b7bd/smartrate"
         },
         "response": {
-          "bodySize": 748,
+          "bodySize": 764,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 748,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:48Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_b2f032395a574b89b1dd0700f8fcf5cc\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:48Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:48Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_294a299752e844868d58c7c75cf4abd1\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:48Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:48Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_ed3b090f2aab4f078e674e30ebecf4f1\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:48Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:48Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_b5b2eab78bcd4bb89ed56064cffc774d\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_4ecfde150a9c4589aa2709f0ed75497e\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:48Z\"}]}"
+            "size": 764,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_0a277a84c6164ce1855f3d16e8066bd5\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:04:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_16774866c3d94af5b7b04fe2ef3c0246\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:04:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_568d7880dc4f4db68fb0df65eedc08b1\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:04:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:04:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_d230166b52924f4997470a55d4a787ef\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_1b98c9292ca34a1f9a915db3c828b7bd\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:04:50Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297d4e9e787449e00112e5c"
+              "value": "999d146a62e45982e788e0db001003b0"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"dd323c8b32d0d152fc12efd58b0ef4f4\""
+              "value": "W/\"14b1da5e051f7406ca6c5334591b748f\""
             },
             {
               "name": "x-runtime",
-              "value": "0.092590"
+              "value": "0.130146"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:48.928Z",
-        "time": 516,
+        "startedDateTime": "2022-07-29T22:04:50.644Z",
+        "time": 321,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 516
+          "wait": 321
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/one-call-buy-a-carbon-offset-shipment_3908635436/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/one-call-buy-a-carbon-offset-shipment_3908635436/recording.har
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "_recordingName": "Shipment Resource/one call buy a carbon offset shipment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "cc19e4472a8c202af853929b97ee6c3b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 592,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 592
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 390,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"Priority\"},\"carbon_offset\":true}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 2298,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2298,
+            "text": "{\"created_at\":\"2022-07-28T23:27:40Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9405500109361130524675\",\"updated_at\":\"2022-07-28T23:27:41Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_df6851970ecc11ed83bcac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:27:40+00:00\",\"updated_at\":\"2022-07-28T23:27:40+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_330bf9f0a50e4bbc91f8c9d55a42540e\",\"object\":\"Parcel\",\"created_at\":\"2022-07-28T23:27:40Z\",\"updated_at\":\"2022-07-28T23:27:40Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_89f73259bef5434fa60ab296ff53acbe\",\"created_at\":\"2022-07-28T23:27:41Z\",\"updated_at\":\"2022-07-28T23:27:41Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-28T23:27:41Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220728/664926995d314bbc9d327d5d5e32c81f.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_184e8e5ac9e34921acaa89d2931b2907\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:27:40Z\",\"updated_at\":\"2022-07-28T23:27:40Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_db18775d019e4efb9e745d3fd80a7e17\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:27:40Z\",\"updated_at\":\"2022-07-28T23:27:40Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_b4aa0b50b56f455682319410699cb89c\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:27:40Z\",\"updated_at\":\"2022-07-28T23:27:40Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_db18775d019e4efb9e745d3fd80a7e17\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:27:41Z\",\"updated_at\":\"2022-07-28T23:27:41Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_48d84686cebd49f9891da5ada3809660\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9405500109361130524675\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-28T23:27:41Z\",\"updated_at\":\"2022-07-28T23:27:41Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzQ4ZDg0Njg2Y2ViZDQ5Zjk4OTFkYTVhZGEzODA5NjYw\"},\"to_address\":{\"id\":\"adr_df665c7e0ecc11ed81e0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:27:40+00:00\",\"updated_at\":\"2022-07-28T23:27:40+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_df6851970ecc11ed83bcac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:27:40+00:00\",\"updated_at\":\"2022-07-28T23:27:40+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_df665c7e0ecc11ed81e0ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-28T23:27:40+00:00\",\"updated_at\":\"2022-07-28T23:27:40+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"9.82000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"CarbonOffsetFee\",\"amount\":\"0.11000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_4506b31111754024be5e6c35bca2fba3\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "efdf9e0262e31b6cff24eb40000c718a"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_4506b31111754024be5e6c35bca2fba3"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"38e9a490717908baa017239d7f25dc98\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "1.320288"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb1nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207282200-10f97b2b99-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 403f17ff97, intlb2wdc 403f17ff97, extlb4wdc 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 832,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_4506b31111754024be5e6c35bca2fba3",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-07-28T23:27:40.013Z",
+        "time": 1616,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1616
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-getLowestSmartrate-when-no-rates-are-found-due-to-deliveryAccuracy_3282317757/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-getLowestSmartrate-when-no-rates-are-found-due-to-deliveryAccuracy_3282317757/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1644,
+          "bodySize": 1642,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1644,
-            "text": "{\"created_at\":\"2022-06-01T21:06:54Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:55Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c3ebc9f8e1ee11ecb93fac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:54+00:00\",\"updated_at\":\"2022-06-01T21:06:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_97003d12b3ea44f887e6198998422eca\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:54Z\",\"updated_at\":\"2022-06-01T21:06:54Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_922bb98910eb4b8782a50a63aa2d0ace\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:55Z\",\"updated_at\":\"2022-06-01T21:06:55Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ebfec47e7078447bbbc83dc43f9f936e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:55Z\",\"updated_at\":\"2022-06-01T21:06:55Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f1257f0d37ef42dba4309fb4507212b3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:55Z\",\"updated_at\":\"2022-06-01T21:06:55Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_41c292e7de944f8595acf9bbfb4ac69e\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:55Z\",\"updated_at\":\"2022-06-01T21:06:55Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c3ea50c2e1ee11ec8a06ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:54+00:00\",\"updated_at\":\"2022-06-01T21:06:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c3ebc9f8e1ee11ecb93fac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:54+00:00\",\"updated_at\":\"2022-06-01T21:06:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c3ea50c2e1ee11ec8a06ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:54+00:00\",\"updated_at\":\"2022-06-01T21:06:54+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"object\":\"Shipment\"}"
+            "size": 1642,
+            "text": "{\"created_at\":\"2022-07-29T22:03:15Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:15Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3eb5bbb50f8a11eda3daac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_12cfe8005f73432bb995881291471c40\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_1ce9a875c23c415ca4cee9041d3b2fc9\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_04c198df79b3470480b2d67107a9bc9d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_3210bb9e1fca496a8fe2ed8a10cc2a16\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_84bd302e68ef4b2e8beffc0552c87c52\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:15Z\",\"updated_at\":\"2022-07-29T22:03:15Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_3eb3c10d0f8a11ed9c49ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3eb5bbb50f8a11eda3daac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3eb3c10d0f8a11ed9c49ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:15+00:00\",\"updated_at\":\"2022-07-29T22:03:15+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297d4eee78744be001131c2"
+              "value": "999d146e62e45922e788dd63000fe687"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_f6932590489a49f492ff1bedd4ff7c80"
+              "value": "/api/v2/shipments/shp_84c3709d0f794626bfc47580b85833fa"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"bd7a30a5c6cfd8184bae3c4d342aad71\""
+              "value": "W/\"c3e8bc34c409277234a909094e4acbee\""
             },
             {
               "name": "x-runtime",
-              "value": "0.664812"
+              "value": "0.428118"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_f6932590489a49f492ff1bedd4ff7c80",
+          "redirectURL": "/api/v2/shipments/shp_84c3709d0f794626bfc47580b85833fa",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:54.420Z",
-        "time": 953,
+        "startedDateTime": "2022-07-29T22:03:14.781Z",
+        "time": 620,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 953
+          "wait": 620
         }
       },
       {
-        "_id": "92bef1fb660b2ed4383d0b7e7e2af7eb",
+        "_id": "c84b0a6e965b2504231cce92cf12f877",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_f6932590489a49f492ff1bedd4ff7c80/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_84c3709d0f794626bfc47580b85833fa/smartrate"
         },
         "response": {
-          "bodySize": 756,
+          "bodySize": 764,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 756,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:55Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_922bb98910eb4b8782a50a63aa2d0ace\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:55Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:55Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_ebfec47e7078447bbbc83dc43f9f936e\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:55Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:55Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_f1257f0d37ef42dba4309fb4507212b3\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:55Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:55Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_41c292e7de944f8595acf9bbfb4ac69e\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_f6932590489a49f492ff1bedd4ff7c80\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:55Z\"}]}"
+            "size": 764,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:15Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_1ce9a875c23c415ca4cee9041d3b2fc9\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:03:15Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:15Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_04c198df79b3470480b2d67107a9bc9d\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:03:15Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:15Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_3210bb9e1fca496a8fe2ed8a10cc2a16\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:03:15Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:15Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_84bd302e68ef4b2e8beffc0552c87c52\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_84c3709d0f794626bfc47580b85833fa\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:03:15Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297d4efe78744bf00113255"
+              "value": "999d147062e45923e788dd64000fe6b9"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"8e9083ecc6a8482971763a302c749139\""
+              "value": "W/\"bc1b1aece31d50c732db97251e648f91\""
             },
             {
               "name": "x-runtime",
-              "value": "0.130092"
+              "value": "0.084577"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb9nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:55.380Z",
-        "time": 329,
+        "startedDateTime": "2022-07-29T22:03:15.406Z",
+        "time": 283,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 329
+          "wait": 283
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-getLowestSmartrate-when-no-rates-are-found-due-to-deliveryDays_4238247347/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-getLowestSmartrate-when-no-rates-are-found-due-to-deliveryDays_4238247347/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1642,
+          "bodySize": 1620,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1642,
-            "text": "{\"created_at\":\"2022-06-01T21:06:53Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:54Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c3203cf2e1ee11ecb900ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:53+00:00\",\"updated_at\":\"2022-06-01T21:06:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_791854d5550a4cb387747a2fa9777256\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:53Z\",\"updated_at\":\"2022-06-01T21:06:53Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_ef3e9147a0f74586b6fd08273e7a8fcd\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:54Z\",\"updated_at\":\"2022-06-01T21:06:54Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c4a548575b8c4c458ca557edb558cbfe\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:54Z\",\"updated_at\":\"2022-06-01T21:06:54Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_4bd569ffd168411cbb1050aafd22a910\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:54Z\",\"updated_at\":\"2022-06-01T21:06:54Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c8a66135037c43f0b810832c2ec81485\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:54Z\",\"updated_at\":\"2022-06-01T21:06:54Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c31ea4bce1ee11ec89c3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:53+00:00\",\"updated_at\":\"2022-06-01T21:06:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c3203cf2e1ee11ecb900ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:53+00:00\",\"updated_at\":\"2022-06-01T21:06:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c31ea4bce1ee11ec89c3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:53+00:00\",\"updated_at\":\"2022-06-01T21:06:53+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"object\":\"Shipment\"}"
+            "size": 1620,
+            "text": "{\"created_at\":\"2022-07-29T22:03:14Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:14Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3e2a08bb0f8a11edb530ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:14+00:00\",\"updated_at\":\"2022-07-29T22:03:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_1a9b0ab4b4fb45b58efab88eb3ca9b6f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:14Z\",\"updated_at\":\"2022-07-29T22:03:14Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_494221b8ce7d4d4ab642449298b01225\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:14Z\",\"updated_at\":\"2022-07-29T22:03:14Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6cc21ddc30d143afb66b2a9deb047050\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:14Z\",\"updated_at\":\"2022-07-29T22:03:14Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0fe76212898f4c00b62cdecf7c1cf3e3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:14Z\",\"updated_at\":\"2022-07-29T22:03:14Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_205498173e174c7285f9f51255653a0c\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:14Z\",\"updated_at\":\"2022-07-29T22:03:14Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_3e28763e0f8a11edb52fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:14+00:00\",\"updated_at\":\"2022-07-29T22:03:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3e2a08bb0f8a11edb530ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:14+00:00\",\"updated_at\":\"2022-07-29T22:03:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3e28763e0f8a11edb52fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:14+00:00\",\"updated_at\":\"2022-07-29T22:03:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297d4ede78744bc001130f4"
+              "value": "999d146a62e45922e788dd61000fe645"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_6957ad4fdfc14085bcdceef7c2c17037"
+              "value": "/api/v2/shipments/shp_494c5fabc016446a8a2016c2ace6567d"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"631a1e52b26f791d90735ff9a6aa2746\""
+              "value": "W/\"60cdffc46492d3552da35f11c3732811\""
             },
             {
               "name": "x-runtime",
-              "value": "0.830295"
+              "value": "0.404590"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb6nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_6957ad4fdfc14085bcdceef7c2c17037",
+          "redirectURL": "/api/v2/shipments/shp_494c5fabc016446a8a2016c2ace6567d",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:53.086Z",
-        "time": 1029,
+        "startedDateTime": "2022-07-29T22:03:13.874Z",
+        "time": 634,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1029
+          "wait": 634
         }
       },
       {
-        "_id": "5114d18c3c6c89839cc2038ba52fb313",
+        "_id": "f2b8c24498859bdeebe593910190d8d3",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_6957ad4fdfc14085bcdceef7c2c17037/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_494c5fabc016446a8a2016c2ace6567d/smartrate"
         },
         "response": {
-          "bodySize": 752,
+          "bodySize": 760,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 752,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:54Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_ef3e9147a0f74586b6fd08273e7a8fcd\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:54Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:54Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_c4a548575b8c4c458ca557edb558cbfe\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:54Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:54Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_4bd569ffd168411cbb1050aafd22a910\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:54Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:54Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_c8a66135037c43f0b810832c2ec81485\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_6957ad4fdfc14085bcdceef7c2c17037\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:54Z\"}]}"
+            "size": 760,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:14Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_494221b8ce7d4d4ab642449298b01225\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:03:14Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:14Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_6cc21ddc30d143afb66b2a9deb047050\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:03:14Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:14Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_0fe76212898f4c00b62cdecf7c1cf3e3\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:03:14Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:14Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_205498173e174c7285f9f51255653a0c\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_494c5fabc016446a8a2016c2ace6567d\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:03:14Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297d4eee78744bd0011318e"
+              "value": "999d146e62e45922e788dd62000fe673"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"6e15e67c2f3cd4c36e200135b3b1bab6\""
+              "value": "W/\"1e788ce6e69cf72d9dd1c25cc75d1903\""
             },
             {
               "name": "x-runtime",
-              "value": "0.075244"
+              "value": "0.077186"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb4nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:54.121Z",
-        "time": 285,
+        "startedDateTime": "2022-07-29T22:03:14.510Z",
+        "time": 263,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 285
+          "wait": 263
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-lowestSmartrate-when-no-rates-are-found-due-to-deliveryAccuracy_4259296465/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-lowestSmartrate-when-no-rates-are-found-due-to-deliveryAccuracy_4259296465/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1630,
+          "bodySize": 1628,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1630,
-            "text": "{\"created_at\":\"2022-06-01T21:06:50Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:51Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c1a05dc4e1ee11ec9338ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:50+00:00\",\"updated_at\":\"2022-06-01T21:06:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_aaa3a9d926a64bda871d7c409036293d\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:50Z\",\"updated_at\":\"2022-06-01T21:06:50Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_be480978416d4857915d21ecced80914\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:51Z\",\"updated_at\":\"2022-06-01T21:06:51Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b17bee05115b47a0b32c1b28fc16ddbe\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:51Z\",\"updated_at\":\"2022-06-01T21:06:51Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c511fbb9c01a46a1818aceca0bb81d7a\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:51Z\",\"updated_at\":\"2022-06-01T21:06:51Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e4c988e9b10a4c72a44532aaac23a83f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:51Z\",\"updated_at\":\"2022-06-01T21:06:51Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c19e6fe9e1ee11ec9337ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:50+00:00\",\"updated_at\":\"2022-06-01T21:06:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c1a05dc4e1ee11ec9338ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:50+00:00\",\"updated_at\":\"2022-06-01T21:06:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c19e6fe9e1ee11ec9337ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:50+00:00\",\"updated_at\":\"2022-06-01T21:06:50+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"object\":\"Shipment\"}"
+            "size": 1628,
+            "text": "{\"created_at\":\"2022-07-29T22:03:12Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:12Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3cf8938f0f8a11eda37dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:12+00:00\",\"updated_at\":\"2022-07-29T22:03:12+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_596a3078ae954a569c025ba703fc096c\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:12Z\",\"updated_at\":\"2022-07-29T22:03:12Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_73e2ec575e5648da995df05f0327571f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:12Z\",\"updated_at\":\"2022-07-29T22:03:12Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1311c3aadf1741969130796110c88d4b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:12Z\",\"updated_at\":\"2022-07-29T22:03:12Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_0d8ba78d668f46caaa1f7cd3bf969822\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:12Z\",\"updated_at\":\"2022-07-29T22:03:12Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_01ccdd2389c84026a287476a84a6104d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:12Z\",\"updated_at\":\"2022-07-29T22:03:12Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_3cf6bd300f8a11edb4feac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:12+00:00\",\"updated_at\":\"2022-07-29T22:03:12+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3cf8938f0f8a11eda37dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:12+00:00\",\"updated_at\":\"2022-07-29T22:03:12+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3cf6bd300f8a11edb4feac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:12+00:00\",\"updated_at\":\"2022-07-29T22:03:12+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297d4eae78744a100112f5b"
+              "value": "999d146c62e45920e788dd46000fe5b1"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_87aa3ef808494208a9965c3cc4477a75"
+              "value": "/api/v2/shipments/shp_f6e0ca6306ba421e87c6f9b7e467e705"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"04b98454f1c6120eb5446325217bc19c\""
+              "value": "W/\"44a239f7ec9da309104bfc6bf18f68e0\""
             },
             {
               "name": "x-runtime",
-              "value": "0.633650"
+              "value": "0.441617"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_87aa3ef808494208a9965c3cc4477a75",
+          "redirectURL": "/api/v2/shipments/shp_f6e0ca6306ba421e87c6f9b7e467e705",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:50.563Z",
-        "time": 1025,
+        "startedDateTime": "2022-07-29T22:03:11.862Z",
+        "time": 632,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1025
+          "wait": 632
         }
       },
       {
-        "_id": "61d617a66fec63ac735c3552ea8d2922",
+        "_id": "4eddbf1f6b9b33b0d8ce3a1531ab48f3",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_87aa3ef808494208a9965c3cc4477a75/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_f6e0ca6306ba421e87c6f9b7e467e705/smartrate"
         },
         "response": {
-          "bodySize": 748,
+          "bodySize": 768,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 748,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_be480978416d4857915d21ecced80914\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_b17bee05115b47a0b32c1b28fc16ddbe\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_c511fbb9c01a46a1818aceca0bb81d7a\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:51Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:51Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_e4c988e9b10a4c72a44532aaac23a83f\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_87aa3ef808494208a9965c3cc4477a75\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:51Z\"}]}"
+            "size": 768,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:12Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_73e2ec575e5648da995df05f0327571f\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:03:12Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:12Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_1311c3aadf1741969130796110c88d4b\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:03:12Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:12Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_0d8ba78d668f46caaa1f7cd3bf969822\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:03:12Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:12Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_01ccdd2389c84026a287476a84a6104d\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_f6e0ca6306ba421e87c6f9b7e467e705\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:03:12Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0436297d4ebe78744a200112ffe"
+              "value": "999d147062e45920e788dd5e000fe5e4"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"0f6a503e803540b868c9de7e66bb12a6\""
+              "value": "W/\"8e95a06a6f07831e1ef809eaadb397ca\""
             },
             {
               "name": "x-runtime",
-              "value": "0.074263"
+              "value": "0.086933"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:51.594Z",
-        "time": 274,
+        "startedDateTime": "2022-07-29T22:03:12.499Z",
+        "time": 276,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 274
+          "wait": 276
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-lowestSmartrate-when-no-rates-are-found-due-to-deliveryDays_4095457255/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/raises-an-error-for-lowestSmartrate-when-no-rates-are-found-due-to-deliveryDays_4095457255/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d48a9fb2c58340aff367cfd2ef47a35a",
+        "_id": "10d6695c35de770059030222303ff1a6",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 426,
+          "bodySize": 448,
           "cookies": [],
           "headers": [
             {
@@ -29,20 +29,20 @@
             },
             {
               "name": "content-length",
-              "value": 426
+              "value": 448
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
@@ -53,7 +53,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 1636,
-            "text": "{\"created_at\":\"2022-06-01T21:06:49Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T21:06:50Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_c0f532bce1ee11ec8918ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:49+00:00\",\"updated_at\":\"2022-06-01T21:06:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_ffe93523d3664884a1667bc3c21e0e74\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:49Z\",\"updated_at\":\"2022-06-01T21:06:49Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_d132236ceebf45cb8cc1c9694997f89a\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:50Z\",\"updated_at\":\"2022-06-01T21:06:50Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5f594ba2bfbe43569fb1c5e0a9c67da8\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:50Z\",\"updated_at\":\"2022-06-01T21:06:50Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_683b58781f9c4c96952ebe74585dbe2c\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:50Z\",\"updated_at\":\"2022-06-01T21:06:50Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f6df10016cc24556881faec96badc86a\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:50Z\",\"updated_at\":\"2022-06-01T21:06:50Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_c0f2ef67e1ee11ecb85dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:49+00:00\",\"updated_at\":\"2022-06-01T21:06:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_c0f532bce1ee11ec8918ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:49+00:00\",\"updated_at\":\"2022-06-01T21:06:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_c0f2ef67e1ee11ecb85dac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:49+00:00\",\"updated_at\":\"2022-06-01T21:06:49+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"object\":\"Shipment\"}"
+            "text": "{\"created_at\":\"2022-07-29T22:03:10Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:11Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3c4a83090f8a11edb4dfac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:10+00:00\",\"updated_at\":\"2022-07-29T22:03:10+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_db251678cf5e4234b007afa6b052050c\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:10Z\",\"updated_at\":\"2022-07-29T22:03:10Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_0c4d5bd47c6a4c99915a01e67b53415f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:11Z\",\"updated_at\":\"2022-07-29T22:03:11Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ccf38d5f388548f99357f9235edd2b1b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:11Z\",\"updated_at\":\"2022-07-29T22:03:11Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_104f0bbf7b3f4131b1bbf792ca43af8a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:11Z\",\"updated_at\":\"2022-07-29T22:03:11Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_98ecab00c0d64654a76b8879cf44d632\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:11Z\",\"updated_at\":\"2022-07-29T22:03:11Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_3c489a950f8a11ed9bcbac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:10+00:00\",\"updated_at\":\"2022-07-29T22:03:10+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3c4a83090f8a11edb4dfac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:10+00:00\",\"updated_at\":\"2022-07-29T22:03:10+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3c489a950f8a11ed9bcbac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:10+00:00\",\"updated_at\":\"2022-07-29T22:03:10+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297d4e9e787449f00112eb8"
+              "value": "999d146f62e4591ee788dd44000fe557"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_94c1238f5dbe490ca0420b75b9755ad3"
+              "value": "/api/v2/shipments/shp_919be5282e4546a49e65b16ddba63d84"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"691bddc82e9a16376fe9e235986facce\""
+              "value": "W/\"7bd33815dcc6717e4940ff91f9982b27\""
             },
             {
               "name": "x-runtime",
-              "value": "0.498136"
+              "value": "0.649329"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb5nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_94c1238f5dbe490ca0420b75b9755ad3",
+          "redirectURL": "/api/v2/shipments/shp_919be5282e4546a49e65b16ddba63d84",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:49.454Z",
-        "time": 799,
+        "startedDateTime": "2022-07-29T22:03:10.724Z",
+        "time": 838,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 799
+          "wait": 838
         }
       },
       {
-        "_id": "c9f8bd8e70130ef447eb7c245afbe283",
+        "_id": "643b40cecaa946f9758b8a959cdd46d1",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_94c1238f5dbe490ca0420b75b9755ad3/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_919be5282e4546a49e65b16ddba63d84/smartrate"
         },
         "response": {
-          "bodySize": 760,
+          "bodySize": 756,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 760,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_d132236ceebf45cb8cc1c9694997f89a\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_5f594ba2bfbe43569fb1c5e0a9c67da8\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_683b58781f9c4c96952ebe74585dbe2c\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:50Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:50Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_f6df10016cc24556881faec96badc86a\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_94c1238f5dbe490ca0420b75b9755ad3\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:50Z\"}]}"
+            "size": 756,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:11Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_0c4d5bd47c6a4c99915a01e67b53415f\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:03:11Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:11Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_ccf38d5f388548f99357f9235edd2b1b\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:03:11Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:11Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_104f0bbf7b3f4131b1bbf792ca43af8a\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:03:11Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:11Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_98ecab00c0d64654a76b8879cf44d632\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_919be5282e4546a49e65b16ddba63d84\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:03:11Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297d4eae78744a000112f2c"
+              "value": "999d146962e4591fe788dd45000fe59a"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"7ec745b0e03e7e48e04bbc31930dae8e\""
+              "value": "W/\"e477202af7ab5e8aff38e575c47f5af9\""
             },
             {
               "name": "x-runtime",
-              "value": "0.108467"
+              "value": "0.082285"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:50.257Z",
-        "time": 296,
+        "startedDateTime": "2022-07-29T22:03:11.566Z",
+        "time": 285,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 296
+          "wait": 285
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/refunds-a-shipment_2011747091/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/refunds-a-shipment_2011747091/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2222,
+          "bodySize": 2232,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2222,
-            "text": "{\"created_at\":\"2022-06-01T21:06:44Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121901482\",\"updated_at\":\"2022-06-01T21:06:45Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_bd9a0311e1ee11ec880aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_02d500dc55ec428d91a1c994dd0196e0\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_dceac2c137c44929b76bfa042e5bb093\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T21:06:44Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/7dadbf948b5d4301985fd7ddf9c45ad5.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_38254a44f6004c3d9f03661b2209a278\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2429011122c2489e91588d3ce173402f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_83e461ed32fb40f588a783f8c579096f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f90cd98a71784d40be019aace2589164\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_f90cd98a71784d40be019aace2589164\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_924b6ceda718429b994b68adcd4844f6\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121901482\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T21:06:45Z\",\"updated_at\":\"2022-06-01T21:06:45Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzkyNGI2Y2VkYTcxODQyOWI5OTRiNjhhZGNkNDg0NGY2\"},\"to_address\":{\"id\":\"adr_bd97ba32e1ee11ecb755ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_bd9a0311e1ee11ec880aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_bd97ba32e1ee11ecb755ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"object\":\"Shipment\"}"
+            "size": 2232,
+            "text": "{\"created_at\":\"2022-07-29T22:03:05Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689432\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_390d4fc20f8a11eda291ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_56a8d0ec4d5348d08ca6f6bce94aa3f2\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_520a1101ddfb4aa986db90a3a872f5ad\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:06Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/6d5273dca53c4ae1ac17dfe41cadf5c4.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_82a2536b7a9a4556a66a35f98942c362\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_9145ff734e9244838523825fde414855\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_29078bebd1604371a63e8779b6906a3b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_452f6241e27a49a1a8c7a279497d07f9\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_452f6241e27a49a1a8c7a279497d07f9\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_4e6bb1a692f5491dac5c30e0a42a98ce\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689432\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzRlNmJiMWE2OTJmNTQ5MWRhYzVjMzBlMGE0MmE5OGNl\"},\"to_address\":{\"id\":\"adr_390be1d10f8a11edac99ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_390d4fc20f8a11eda291ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_390be1d10f8a11edac99ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0486297d4e4e787447f00112b2e"
+              "value": "999d147062e45919e788dd3d000fe3b1"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_d842222e5e0c460c8f6aad91d348cfba"
+              "value": "/api/v2/shipments/shp_841f6ba6056e478585327e537976eb1f"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"d4aef9b7b7336fcc2675e2728fae727d\""
+              "value": "W/\"fb10ab4da129fe9a78dd9d533ffc490e\""
             },
             {
               "name": "x-runtime",
-              "value": "1.058401"
+              "value": "1.092429"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_d842222e5e0c460c8f6aad91d348cfba",
+          "redirectURL": "/api/v2/shipments/shp_841f6ba6056e478585327e537976eb1f",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:43.817Z",
-        "time": 1317,
+        "startedDateTime": "2022-07-29T22:03:05.297Z",
+        "time": 1298,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1317
+          "wait": 1298
         }
       },
       {
-        "_id": "d9db0da895dba33c076c16351142d3a1",
+        "_id": "5c7ce2fb3576e1969a33d74324310425",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,7 +193,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 535,
+          "headersSize": 433,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -202,15 +202,15 @@
             "text": "{}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_d842222e5e0c460c8f6aad91d348cfba/refund"
+          "url": "https://api.easypost.com/v2/shipments/shp_841f6ba6056e478585327e537976eb1f/refund"
         },
         "response": {
-          "bodySize": 2623,
+          "bodySize": 2636,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2623,
-            "text": "{\"created_at\":\"2022-06-01T21:06:44Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121901482\",\"updated_at\":\"2022-06-01T21:06:45Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_bd9a0311e1ee11ec880aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_02d500dc55ec428d91a1c994dd0196e0\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_dceac2c137c44929b76bfa042e5bb093\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T21:06:44Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/7dadbf948b5d4301985fd7ddf9c45ad5.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_38254a44f6004c3d9f03661b2209a278\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2429011122c2489e91588d3ce173402f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_83e461ed32fb40f588a783f8c579096f\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f90cd98a71784d40be019aace2589164\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":\"submitted\",\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_f90cd98a71784d40be019aace2589164\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:44Z\",\"updated_at\":\"2022-06-01T21:06:44Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_924b6ceda718429b994b68adcd4844f6\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121901482\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-06-01T21:06:45Z\",\"updated_at\":\"2022-06-01T21:06:45Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-06-01T21:06:45Z\",\"shipment_id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-01T21:06:45Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-05-02T09:43:45Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzkyNGI2Y2VkYTcxODQyOWI5OTRiNjhhZGNkNDg0NGY2\"},\"to_address\":{\"id\":\"adr_bd97ba32e1ee11ecb755ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_bd9a0311e1ee11ec880aac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_bd97ba32e1ee11ecb755ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:44+00:00\",\"updated_at\":\"2022-06-01T21:06:44+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_d842222e5e0c460c8f6aad91d348cfba\",\"object\":\"Shipment\"}"
+            "size": 2636,
+            "text": "{\"created_at\":\"2022-07-29T22:03:05Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689432\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_390d4fc20f8a11eda291ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_56a8d0ec4d5348d08ca6f6bce94aa3f2\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_520a1101ddfb4aa986db90a3a872f5ad\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:06Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/6d5273dca53c4ae1ac17dfe41cadf5c4.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_82a2536b7a9a4556a66a35f98942c362\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_9145ff734e9244838523825fde414855\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_29078bebd1604371a63e8779b6906a3b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_452f6241e27a49a1a8c7a279497d07f9\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:05Z\",\"updated_at\":\"2022-07-29T22:03:05Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":\"submitted\",\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_452f6241e27a49a1a8c7a279497d07f9\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_4e6bb1a692f5491dac5c30e0a42a98ce\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689432\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-07-29T22:03:06Z\",\"updated_at\":\"2022-07-29T22:03:06Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-07-29T22:03:06Z\",\"shipment_id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-29T22:03:06Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-06-30T10:40:06Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzRlNmJiMWE2OTJmNTQ5MWRhYzVjMzBlMGE0MmE5OGNl\"},\"to_address\":{\"id\":\"adr_390be1d10f8a11edac99ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_390d4fc20f8a11eda291ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_390be1d10f8a11edac99ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:05+00:00\",\"updated_at\":\"2022-07-29T22:03:05+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_841f6ba6056e478585327e537976eb1f\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f04a6297d4e5e787448000112bff"
+              "value": "999d146d62e4591ae788dd3e000fe40b"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"a13aba9aff3491a409d26c1d81b1dfd5\""
+              "value": "W/\"bcb2be2e39a90264df1327976e5c9722\""
             },
             {
               "name": "x-runtime",
-              "value": "0.189648"
+              "value": "0.208678"
             },
             {
               "name": "content-encoding",
@@ -280,7 +280,7 @@
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -305,8 +305,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:45.138Z",
-        "time": 385,
+        "startedDateTime": "2022-07-29T22:03:06.601Z",
+        "time": 429,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 385
+          "wait": 429
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1972,
+          "bodySize": 2080,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1972,
-            "text": "{\"created_at\":\"2022-06-01T19:49:05Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:05Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_3701297cd40c4919b66f7ffe9d2671a6\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_f6f6f59655ec4b7f95be89b1f31e3469\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e4c3f4b0e1e311ecae21ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:05+00:00\",\"updated_at\":\"2022-06-01T19:49:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_b27df9ee052c425c9afb248e8576caa6\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_ad4904b8135f4554ad8db0c0b1c61790\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_bb3867f20e9848cca264d573d28ebca9\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_9fdd4f22eb9c4469a5c4ec8b594ee952\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_1dad08c7f3d94fe1bd2bc653a873f444\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:05Z\",\"updated_at\":\"2022-06-01T19:49:05Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e4c22c78e1e311ecae20ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:05+00:00\",\"updated_at\":\"2022-06-01T19:49:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e4c3f4b0e1e311ecae21ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:05+00:00\",\"updated_at\":\"2022-06-01T19:49:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e4c22c78e1e311ecae20ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:05+00:00\",\"updated_at\":\"2022-06-01T19:49:05+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"object\":\"Shipment\"}"
+            "size": 2080,
+            "text": "{\"created_at\":\"2022-07-29T22:02:59Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:03:00Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_36259b70be77446cbd9bcd7aed3d7358\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:59Z\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_aa76d0dae3934cea9c1f5974887b9502\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:59Z\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_359c1a150f8a11ed9a2bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:59+00:00\",\"updated_at\":\"2022-07-29T22:02:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_c9d2969e1df7416cbb57cb1ee709b03a\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:59Z\",\"updated_at\":\"2022-07-29T22:02:59Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_0ac5200e60e34975bd0e7aa091d6e02b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:00Z\",\"updated_at\":\"2022-07-29T22:03:00Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7e0daa93c6f547f28a2c9bd369181166\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:00Z\",\"updated_at\":\"2022-07-29T22:03:00Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b9663cd21d51415280af74909b10cc63\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:00Z\",\"updated_at\":\"2022-07-29T22:03:00Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f505ffc6e7084c3aa841fc2bddc2b520\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:00Z\",\"updated_at\":\"2022-07-29T22:03:00Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_359a434b0f8a11edabe1ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:59+00:00\",\"updated_at\":\"2022-07-29T22:02:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_359c1a150f8a11ed9a2bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:59+00:00\",\"updated_at\":\"2022-07-29T22:02:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_359a434b0f8a11edabe1ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:59+00:00\",\"updated_at\":\"2022-07-29T22:02:59+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2b1e786c4de00099095"
+              "value": "999d146b62e45913e788dd21000fe201"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_fc4faf298625475a983efd69e463c77e"
+              "value": "/api/v2/shipments/shp_7457d63515664f00b588037e82a3e9f2"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"f0ce6e38e978f83e616c898551f4409c\""
+              "value": "W/\"617aa568bdf2bb59156d0983e3eb340d\""
             },
             {
               "name": "x-runtime",
-              "value": "0.706227"
+              "value": "0.526142"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_fc4faf298625475a983efd69e463c77e",
+          "redirectURL": "/api/v2/shipments/shp_7457d63515664f00b588037e82a3e9f2",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:05.061Z",
-        "time": 1010,
+        "startedDateTime": "2022-07-29T22:02:59.515Z",
+        "time": 760,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1010
+          "wait": 760
         }
       },
       {
-        "_id": "aa49b582932dbc87ca4a1a6deb04dae4",
+        "_id": "47045184d874464eb10746cd21943679",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,7 +193,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 433,
+          "headersSize": 434,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -202,15 +202,15 @@
             "text": "{\"carbon_offset\":false}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_fc4faf298625475a983efd69e463c77e/rerate"
+          "url": "https://api.easypost.com/v2/shipments/shp_7457d63515664f00b588037e82a3e9f2/rerate"
         },
         "response": {
-          "bodySize": 660,
+          "bodySize": 668,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 660,
-            "text": "{\"rates\":[{\"id\":\"rate_71da9664affc4c7aaaeed22596aadeef\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8ab2afab46f445d696e874c69f559e01\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_095108eaf00f438fadd09eefdf2f1f69\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2a976af77fd64f0eaf3517e2ac7b7907\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}]}"
+            "size": 668,
+            "text": "{\"rates\":[{\"id\":\"rate_609e23869c98457e95cdb94849556e9a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_43731b6578eb449ba4596c2b059957da\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_797c1cd90f954acba61ba43deec4301d\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d8fdf86508be4ab782b6a335a2629037\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:01Z\",\"updated_at\":\"2022-07-29T22:03:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_7457d63515664f00b588037e82a3e9f2\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "b0657e4362e3152cff24e618003fa052"
+              "value": "999d146d62e45914e788dd22000fe231"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"b4c511520721707eb50e2d1f18c4cf16\""
+              "value": "W/\"d6391876a72e483c02f7bf626efeb543\""
             },
             {
               "name": "x-runtime",
-              "value": "0.566455"
+              "value": "0.615806"
             },
             {
               "name": "content-encoding",
@@ -276,23 +276,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb7nuq"
+              "value": "bigweb9nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282200-10f97b2b99-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -303,14 +299,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 784,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-28T23:01:00.636Z",
-        "time": 834,
+        "startedDateTime": "2022-07-29T22:03:00.282Z",
+        "time": 914,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -318,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 834
+          "wait": 914
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/regenerates-rates-for-a-shipment_3874762135/recording.har
@@ -165,11 +165,11 @@
         }
       },
       {
-        "_id": "ce38d09018b77337ce90e8afacbb68aa",
+        "_id": "aa49b582932dbc87ca4a1a6deb04dae4",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 2,
+          "bodySize": 23,
           "cookies": [],
           "headers": [
             {
@@ -186,31 +186,31 @@
             },
             {
               "name": "content-length",
-              "value": 2
+              "value": 23
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 535,
+          "headersSize": 433,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{}"
+            "text": "{\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments/shp_fc4faf298625475a983efd69e463c77e/rerate"
         },
         "response": {
-          "bodySize": 656,
+          "bodySize": 660,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 656,
-            "text": "{\"rates\":[{\"id\":\"rate_01bc153975f74e1c9eda8d9b4ccebf24\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:06Z\",\"updated_at\":\"2022-06-01T19:49:06Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c61f47676b8f48a7840289a5936d2f14\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:06Z\",\"updated_at\":\"2022-06-01T19:49:06Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_29384bea4ec549feaaf3694650515917\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:06Z\",\"updated_at\":\"2022-06-01T19:49:06Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_b0a41333c33c41b3aec7c5caa1bd46b1\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:06Z\",\"updated_at\":\"2022-06-01T19:49:06Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}]}"
+            "size": 660,
+            "text": "{\"rates\":[{\"id\":\"rate_71da9664affc4c7aaaeed22596aadeef\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8ab2afab46f445d696e874c69f559e01\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_095108eaf00f438fadd09eefdf2f1f69\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2a976af77fd64f0eaf3517e2ac7b7907\",\"object\":\"Rate\",\"created_at\":\"2022-07-28T23:01:01Z\",\"updated_at\":\"2022-07-28T23:01:01Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_fc4faf298625475a983efd69e463c77e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0466297c2b2e786c4df00099149"
+              "value": "b0657e4362e3152cff24e618003fa052"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"59573732919de78e0ee43b5460efe060\""
+              "value": "W/\"b4c511520721707eb50e2d1f18c4cf16\""
             },
             {
               "name": "x-runtime",
-              "value": "0.483425"
+              "value": "0.566455"
             },
             {
               "name": "content-encoding",
@@ -276,19 +276,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207282200-10f97b2b99-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -299,14 +303,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 744,
+          "headersSize": 784,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:06.079Z",
-        "time": 698,
+        "startedDateTime": "2022-07-28T23:01:00.636Z",
+        "time": 834,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +318,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 698
+          "wait": 834
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/rerate-a-shipment-with-carbon-offset_4123560847/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/rerate-a-shipment-with-carbon-offset_4123560847/recording.har
@@ -1,0 +1,324 @@
+{
+  "log": {
+    "_recordingName": "Shipment Resource/rerate a shipment with carbon offset",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "d7021f7d50c54f169bd56e0f5da37f2f",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 571,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 571
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 390,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"Priority\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 2231,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 2231,
+            "text": "{\"created_at\":\"2022-07-29T15:29:48Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9405500109361130633339\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_48444e370f5311edb525ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e0dcc84a1876412f8e45531e2b848b36\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_90214bee93a6494b972c70c7608f6c1a\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T15:29:49Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/eee1d596edcf4bf98bcb3464ef7019b7.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_56054905b1c542b682470efc1f3ad135\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7573ae96b6de4477a6b2dc1ec87e5d6b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_449b1f92effa417289190b7d3c76e3b3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_449b1f92effa417289190b7d3c76e3b3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_8074b34c3201415cabe247225c7e2183\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9405500109361130633339\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzgwNzRiMzRjMzIwMTQxNWNhYmUyNDcyMjVjN2UyMTgz\"},\"to_address\":{\"id\":\"adr_4842ae3c0f5311edbbccac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_48444e370f5311edb525ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_4842ae3c0f5311edbbccac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"9.82000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"object\":\"Shipment\"}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "676acead62e3fcecff02eafd000dd079"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "location",
+              "value": "/api/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"2397c0d01280713e47b9a109742e8c89\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "1.031749"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb3nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207282305-ef64fb0c25-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 810,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "/api/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b",
+          "status": 201,
+          "statusText": "Created"
+        },
+        "startedDateTime": "2022-07-29T15:29:48.413Z",
+        "time": 1537,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1537
+        }
+      },
+      {
+        "_id": "9012cc518068c72d15aaebc29d3297a6",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 22,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 22
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 433,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"carbon_offset\":true}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b/rerate"
+        },
+        "response": {
+          "bodySize": 660,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 660,
+            "text": "{\"rates\":[{\"id\":\"rate_3c96b26f5a4849da97c88a0f75ef4274\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_20634ae794ca4f57ae8030c5ce4272d7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_e951738baeb046b885306406ba2b0c52\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "d1b7fc8e62e3fceeff02eafe000dadf4"
+            },
+            {
+              "name": "cache-control",
+              "value": "no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"97a6e72e66ce83319486e2eaf9e186f6\""
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.440458"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb8nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202207282305-ef64fb0c25-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 766,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-07-29T15:29:49.954Z",
+        "time": 636,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 636
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Shipment-Resource_2534528937/rerate-a-shipment-with-carbon-offset_4123560847/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/rerate-a-shipment-with-carbon-offset_4123560847/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d7021f7d50c54f169bd56e0f5da37f2f",
+        "_id": "46dc5bd29fdb500741346f21a911240a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 571,
+          "bodySize": 593,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 571
+              "value": 593
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 390,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"Priority\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Dr. Steve Brule\",\"street1\":\"179 N Harbor Dr\",\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"dr_steve_brule@gmail.com\"},\"from_address\":{\"name\":\"EasyPost\",\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\"},\"parcel\":{\"length\":20.2,\"width\":10.9,\"height\":5,\"weight\":65.9},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"Priority\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2231,
+          "bodySize": 2235,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2231,
-            "text": "{\"created_at\":\"2022-07-29T15:29:48Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9405500109361130633339\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_48444e370f5311edb525ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_e0dcc84a1876412f8e45531e2b848b36\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_90214bee93a6494b972c70c7608f6c1a\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T15:29:49Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/eee1d596edcf4bf98bcb3464ef7019b7.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_56054905b1c542b682470efc1f3ad135\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7573ae96b6de4477a6b2dc1ec87e5d6b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_449b1f92effa417289190b7d3c76e3b3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:48Z\",\"updated_at\":\"2022-07-29T15:29:48Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_449b1f92effa417289190b7d3c76e3b3\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_8074b34c3201415cabe247225c7e2183\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9405500109361130633339\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T15:29:49Z\",\"updated_at\":\"2022-07-29T15:29:49Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzgwNzRiMzRjMzIwMTQxNWNhYmUyNDcyMjVjN2UyMTgz\"},\"to_address\":{\"id\":\"adr_4842ae3c0f5311edbbccac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_48444e370f5311edb525ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_4842ae3c0f5311edbbccac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-07-29T15:29:48+00:00\",\"updated_at\":\"2022-07-29T15:29:48+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"9.82000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"object\":\"Shipment\"}"
+            "size": 2235,
+            "text": "{\"created_at\":\"2022-07-29T22:03:19Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9405500109361130689473\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_4192db470f8a11ed9d07ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:19+00:00\",\"updated_at\":\"2022-07-29T22:03:19+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_9e1a94f5640e4c8da7eb5ac2defa4c82\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:19Z\",\"updated_at\":\"2022-07-29T22:03:19Z\",\"length\":20.2,\"width\":10.9,\"height\":5,\"predefined_package\":null,\"weight\":65.9,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_a7a3ad66125049fa984dd8e67af3932d\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:20Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/0241de79491e404288bf28eb22f7d5ca.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_8be360763db841b58d5f3f5359f319f0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_52d1fd8cd10144e0afac5cd845a853a2\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ab91d434a44b4818918dfd0fc42600e6\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_8be360763db841b58d5f3f5359f319f0\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_fe690671a418461485fcd8b100f1ca31\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9405500109361130689473\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:20Z\",\"updated_at\":\"2022-07-29T22:03:20Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2ZlNjkwNjcxYTQxODQ2MTQ4NWZjZDhiMTAwZjFjYTMx\"},\"to_address\":{\"id\":\"adr_41911bb30f8a11eda494ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:19+00:00\",\"updated_at\":\"2022-07-29T22:03:20+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_4192db470f8a11ed9d07ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:19+00:00\",\"updated_at\":\"2022-07-29T22:03:19+00:00\",\"name\":\"EasyPost\",\"company\":null,\"street1\":\"417 Montgomery Street\",\"street2\":\"5th Floor\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"4153334445\",\"email\":\"support@easypost.com\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_41911bb30f8a11eda494ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:19+00:00\",\"updated_at\":\"2022-07-29T22:03:20+00:00\",\"name\":\"DR. STEVE BRULE\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":null,\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"8573875756\",\"email\":\"DR_STEVE_BRULE@GMAIL.COM\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"9.82000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "676acead62e3fcecff02eafd000dd079"
+              "value": "999d146c62e45927e788dd80000fe7be"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b"
+              "value": "/api/v2/shipments/shp_631ec50708b344e691aa471c77839ba4"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"2397c0d01280713e47b9a109742e8c89\""
+              "value": "W/\"2d0aa23c72989a64de24052426bafd9e\""
             },
             {
               "name": "x-runtime",
-              "value": "1.031749"
+              "value": "1.220807"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb3nuq"
+              "value": "bigweb2nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282305-ef64fb0c25-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b",
+          "redirectURL": "/api/v2/shipments/shp_631ec50708b344e691aa471c77839ba4",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-29T15:29:48.413Z",
-        "time": 1537,
+        "startedDateTime": "2022-07-29T22:03:19.589Z",
+        "time": 1602,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1537
+          "wait": 1602
         }
       },
       {
-        "_id": "9012cc518068c72d15aaebc29d3297a6",
+        "_id": "6ee76257a47d2848c5a22d7f07acc3a5",
         "_order": 0,
         "cache": {},
         "request": {
@@ -193,7 +193,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 433,
+          "headersSize": 434,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -202,15 +202,15 @@
             "text": "{\"carbon_offset\":true}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_f149d025b36d4eb4bd17977543a07a1b/rerate"
+          "url": "https://api.easypost.com/v2/shipments/shp_631ec50708b344e691aa471c77839ba4/rerate"
         },
         "response": {
-          "bodySize": 660,
+          "bodySize": 668,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 660,
-            "text": "{\"rates\":[{\"id\":\"rate_3c96b26f5a4849da97c88a0f75ef4274\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_20634ae794ca4f57ae8030c5ce4272d7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_e951738baeb046b885306406ba2b0c52\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T15:29:50Z\",\"updated_at\":\"2022-07-29T15:29:50Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_f149d025b36d4eb4bd17977543a07a1b\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}}]}"
+            "size": 668,
+            "text": "{\"rates\":[{\"id\":\"rate_b1527a9569854ca783c93421950b470f\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:21Z\",\"updated_at\":\"2022-07-29T22:03:21Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.82\",\"currency\":\"USD\",\"retail_rate\":\"13.15\",\"retail_currency\":\"USD\",\"list_rate\":\"9.82\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_eb70c3b800cb475d817164acd5bc6478\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:21Z\",\"updated_at\":\"2022-07-29T22:03:21Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"8.91\",\"currency\":\"USD\",\"retail_rate\":\"8.91\",\"retail_currency\":\"USD\",\"list_rate\":\"8.91\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":5,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":5,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}},{\"id\":\"rate_9dd67c289cdc444fae66c2d48222f100\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:21Z\",\"updated_at\":\"2022-07-29T22:03:21Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"44.30\",\"currency\":\"USD\",\"retail_rate\":\"51.00\",\"retail_currency\":\"USD\",\"list_rate\":\"44.30\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_631ec50708b344e691aa471c77839ba4\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"carbon_offset\":{\"object\":\"CarbonOffset\",\"grams\":154,\"price\":\"0.11\",\"currency\":\"USD\"}}]}"
           },
           "cookies": [],
           "headers": [
@@ -240,7 +240,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "d1b7fc8e62e3fceeff02eafe000dadf4"
+              "value": "999d146b62e45929e788dd81000fe823"
             },
             {
               "name": "cache-control",
@@ -260,11 +260,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"97a6e72e66ce83319486e2eaf9e186f6\""
+              "value": "W/\"eb258c35cb0349f715fa9dd690b8d24f\""
             },
             {
               "name": "x-runtime",
-              "value": "0.440458"
+              "value": "0.304212"
             },
             {
               "name": "content-encoding",
@@ -276,11 +276,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb8nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202207282305-ef64fb0c25-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -288,7 +288,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, intlb1wdc 403f17ff97, extlb3wdc 403f17ff97"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -299,14 +299,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 766,
+          "headersSize": 744,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-07-29T15:29:49.954Z",
-        "time": 636,
+        "startedDateTime": "2022-07-29T22:03:21.197Z",
+        "time": 496,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -314,7 +314,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 636
+          "wait": 496
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/retrieves-a-shipment_1463360065/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/retrieves-a-shipment_1463360065/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "00ddd49ff1d7991bb7f88949b203d681",
+        "_id": "607bdd63b1d3890e9b634a326cdb11ce",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 849,
+          "bodySize": 871,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 849
+              "value": 871
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}}}"
+            "text": "{\"shipment\":{\"reference\":\"123\",\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"customs_info\":{\"eel_pfc\":\"NOEEI 30.37(a)\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"contents_type\":\"merchandise\",\"contents_explanation\":\"\",\"restriction_type\":\"none\",\"non_delivery_option\":\"return\",\"customs_items\":[{\"description\":\"Sweet shirts\",\"quantity\":2,\"weight\":11,\"value\":23.25,\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\"}]},\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\"}},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2006,
+          "bodySize": 2060,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2006,
-            "text": "{\"created_at\":\"2022-06-01T19:49:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:02Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_a296a8c61ee84362b04743e5e9273e08\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_83769a8c957847128809db4b4903d1e3\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e2930eb9e1e311ecbdc5ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_d08f58cb4a3f4029927e8b320b433e8c\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_a89dbf113780406e8eddc826d0d43255\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6b3cdd13416742729c6e3555c49242f3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ede6491bdf174aacac38fb38838fd165\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_40aa85cbcef64693a2b6c86aee9753cf\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e291718ce1e311ecb03fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e2930eb9e1e311ecbdc5ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e291718ce1e311ecb03fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"object\":\"Shipment\"}"
+            "size": 2060,
+            "text": "{\"created_at\":\"2022-07-29T22:02:56Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:57Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_363bb14b458849bbaf3ef85721690716\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_56ed2b54fb4f4b1cb99aec4b38131842\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_33c8047f0f8a11edab75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_af8140614ca44e97b24d08079164f03f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_9fcbcb19e1264c95af11877f47b6f096\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c1838f4c45144ddc903fa733f7df03db\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c03c8dbdc5f1491db355fe459bf99650\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8e263162bf314f028d7f2cd3c369ff0a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_33c5b36e0f8a11ed99b3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_33c8047f0f8a11edab75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_33c5b36e0f8a11ed99b3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297c2ade786c4c200098df8"
+              "value": "999d146962e45910e788dd1d000fe11f"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_940b14bfdf4c4a9aa9c201766962431e"
+              "value": "/api/v2/shipments/shp_5978389d5b46498f9d1cd92fd8eb6c8e"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"e6ccb8d8fd6bcb18651c1ae94f6639b2\""
+              "value": "W/\"252ea531d1ee6ff1c9ec003037f6f653\""
             },
             {
               "name": "x-runtime",
-              "value": "0.511351"
+              "value": "0.488106"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb1nuq"
+              "value": "bigweb8nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_940b14bfdf4c4a9aa9c201766962431e",
+          "redirectURL": "/api/v2/shipments/shp_5978389d5b46498f9d1cd92fd8eb6c8e",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:49:01.407Z",
-        "time": 709,
+        "startedDateTime": "2022-07-29T22:02:56.439Z",
+        "time": 764,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 709
+          "wait": 764
         }
       },
       {
-        "_id": "8ef3a66c3810030d1c74f22b1241923e",
+        "_id": "6ec3cbb7e64a1e06cf14a12e5ea37e60",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 508,
+          "headersSize": 406,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_940b14bfdf4c4a9aa9c201766962431e"
+          "url": "https://api.easypost.com/v2/shipments/shp_5978389d5b46498f9d1cd92fd8eb6c8e"
         },
         "response": {
-          "bodySize": 2003,
+          "bodySize": 2060,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2003,
-            "text": "{\"created_at\":\"2022-06-01T19:49:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-06-01T19:49:02Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_a296a8c61ee84362b04743e5e9273e08\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_83769a8c957847128809db4b4903d1e3\",\"object\":\"CustomsItem\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_e2930eb9e1e311ecbdc5ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_d08f58cb4a3f4029927e8b320b433e8c\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T19:49:01Z\",\"updated_at\":\"2022-06-01T19:49:01Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_a89dbf113780406e8eddc826d0d43255\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6b3cdd13416742729c6e3555c49242f3\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_ede6491bdf174aacac38fb38838fd165\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_40aa85cbcef64693a2b6c86aee9753cf\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T19:49:02Z\",\"updated_at\":\"2022-06-01T19:49:02Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_e291718ce1e311ecb03fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_e2930eb9e1e311ecbdc5ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_e291718ce1e311ecb03fac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:49:01+00:00\",\"updated_at\":\"2022-06-01T19:49:01+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_940b14bfdf4c4a9aa9c201766962431e\",\"object\":\"Shipment\"}"
+            "size": 2060,
+            "text": "{\"created_at\":\"2022-07-29T22:02:56Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_40a4125ae168494f98c4ab6913740713\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_52401f808d204a939b7273d0ff2a86d0\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_785407083c0c43b2b74270c7962be6c7\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_37788b00b3df4564a501d743b81236d5\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"},{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_84eb72b6170b4b9db15419601139c436\",\"type\":\"rate_error\",\"message\":\"Invalid Access License number\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2022-07-29T22:02:57Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_363bb14b458849bbaf3ef85721690716\",\"object\":\"CustomsInfo\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_56ed2b54fb4f4b1cb99aec4b38131842\",\"object\":\"CustomsItem\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null}]},\"from_address\":{\"id\":\"adr_33c8047f0f8a11edab75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_af8140614ca44e97b24d08079164f03f\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:02:56Z\",\"updated_at\":\"2022-07-29T22:02:56Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_9fcbcb19e1264c95af11877f47b6f096\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c1838f4c45144ddc903fa733f7df03db\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c03c8dbdc5f1491db355fe459bf99650\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8e263162bf314f028d7f2cd3c369ff0a\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:02:57Z\",\"updated_at\":\"2022-07-29T22:02:57Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_33c5b36e0f8a11ed99b3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_33c8047f0f8a11edab75ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_33c5b36e0f8a11ed99b3ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:02:56+00:00\",\"updated_at\":\"2022-07-29T22:02:56+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_5978389d5b46498f9d1cd92fd8eb6c8e\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0456297c2aee786c4c300098e75"
+              "value": "999d147062e45911e788dd1e000fe164"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"e6ccb8d8fd6bcb18651c1ae94f6639b2\""
+              "value": "W/\"252ea531d1ee6ff1c9ec003037f6f653\""
             },
             {
               "name": "x-runtime",
-              "value": "0.063527"
+              "value": "0.081094"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T19:49:02.120Z",
-        "time": 250,
+        "startedDateTime": "2022-07-29T22:02:57.209Z",
+        "time": 277,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 250
+          "wait": 277
         }
       }
     ],

--- a/test/cassettes/Shipment-Resource_2534528937/retrieves-smartrates-of-a-shipment_91343870/recording.har
+++ b/test/cassettes/Shipment-Resource_2534528937/retrieves-smartrates-of-a-shipment_91343870/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "ec961bf7d0168eed4f04e92f06ae1666",
+        "_id": "c5bbd28969df44166b9debfe978b501a",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 520,
+          "bodySize": 542,
           "cookies": [],
           "headers": [
             {
@@ -29,31 +29,31 @@
             },
             {
               "name": "content-length",
-              "value": 520
+              "value": 542
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"}}"
+            "text": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":10,\"width\":8,\"height\":4,\"weight\":15.4},\"carrier_accounts\":[\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"],\"carrier\":\"USPS\",\"service\":\"First\"},\"carbon_offset\":false}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 2226,
+          "bodySize": 2238,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2226,
-            "text": "{\"created_at\":\"2022-06-01T21:06:45Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361121901499\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_beabec59e1ee11ecb7a4ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:45+00:00\",\"updated_at\":\"2022-06-01T21:06:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_18e930fe5a394faea2eb6a42bb2e2c2a\",\"object\":\"Parcel\",\"created_at\":\"2022-06-01T21:06:45Z\",\"updated_at\":\"2022-06-01T21:06:45Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_92cdb2ce5f79447a908d96bda6500dee\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-06-01T21:06:46Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220601/428d808dd532435e927a56e32d723e88.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_7b51137cb3f34aaea55a47662c498bcd\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d1468fd4d34642b88dc7819dd8c9a7c6\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_57fd0f1e7889498a92c9a37dff3c5d27\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_efa1b89f1f464f8c912e8a8ec9c3f9c2\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_57fd0f1e7889498a92c9a37dff3c5d27\",\"object\":\"Rate\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_6906491675354592a148d90a8c5a4fbe\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361121901499\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-06-01T21:06:46Z\",\"updated_at\":\"2022-06-01T21:06:46Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzY5MDY0OTE2NzUzNTQ1OTJhMTQ4ZDkwYThjNWE0ZmJl\"},\"to_address\":{\"id\":\"adr_beaa308fe1ee11ecb7a3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:45+00:00\",\"updated_at\":\"2022-06-01T21:06:46+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_beabec59e1ee11ecb7a4ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:45+00:00\",\"updated_at\":\"2022-06-01T21:06:45+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_beaa308fe1ee11ecb7a3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-06-01T21:06:45+00:00\",\"updated_at\":\"2022-06-01T21:06:46+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"object\":\"Shipment\"}"
+            "size": 2238,
+            "text": "{\"created_at\":\"2022-07-29T22:03:07Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361130689449\",\"updated_at\":\"2022-07-29T22:03:08Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3a195ee00f8a11edacd9ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:07+00:00\",\"updated_at\":\"2022-07-29T22:03:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_4b04b5875306462a99acf834d44c534a\",\"object\":\"Parcel\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_05a7cf5fa1ec4e94803bb09318332a38\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:08Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-07-29T22:03:07Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220729/b8638ed39e6a4ac5ae69c9ab99f492fe.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_1a0a4f0207ea40ecb3d5cf109c95cb2b\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_aeb3f677601b4d6d9e1ed1ce9b38b3d4\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_e12a2ad303c24b98b345b387a0c3d279\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_7293f0fb1b384ca182df248a4586d7c7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_7293f0fb1b384ca182df248a4586d7c7\",\"object\":\"Rate\",\"created_at\":\"2022-07-29T22:03:07Z\",\"updated_at\":\"2022-07-29T22:03:07Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_ed8a616404344257a6d38564c062898e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361130689449\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-07-29T22:03:08Z\",\"updated_at\":\"2022-07-29T22:03:08Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2VkOGE2MTY0MDQzNDQyNTdhNmQzODU2NGMwNjI4OThl\"},\"to_address\":{\"id\":\"adr_3a16f23d0f8a11eda2d7ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:07+00:00\",\"updated_at\":\"2022-07-29T22:03:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3a195ee00f8a11edacd9ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:07+00:00\",\"updated_at\":\"2022-07-29T22:03:07+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3a16f23d0f8a11eda2d7ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T22:03:07+00:00\",\"updated_at\":\"2022-07-29T22:03:07+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.25000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0446297d4e5e787448100112c3f"
+              "value": "999d147062e4591be788dd3f000fe435"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_894150b8fc934a6ea1338d745683cd5d"
+              "value": "/api/v2/shipments/shp_75dc9e2d62c142b884462cd549af24ee"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"882df7e052e844c3ccb55540581230c7\""
+              "value": "W/\"ea9bf46ffda72c51c46915bb6e82653f\""
             },
             {
               "name": "x-runtime",
-              "value": "1.099542"
+              "value": "1.147876"
             },
             {
               "name": "content-encoding",
@@ -123,11 +123,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb1nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_894150b8fc934a6ea1338d745683cd5d",
+          "redirectURL": "/api/v2/shipments/shp_75dc9e2d62c142b884462cd549af24ee",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T21:06:45.533Z",
-        "time": 1344,
+        "startedDateTime": "2022-07-29T22:03:07.036Z",
+        "time": 1429,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,11 +161,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1344
+          "wait": 1429
         }
       },
       {
-        "_id": "be3361a8e95d1ba451dcce8913f8095d",
+        "_id": "deb7a146cf68970bcb87f64458c13837",
         "_order": 0,
         "cache": {},
         "request": {
@@ -189,19 +189,19 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 518,
+          "headersSize": 416,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_894150b8fc934a6ea1338d745683cd5d/smartrate"
+          "url": "https://api.easypost.com/v2/shipments/shp_75dc9e2d62c142b884462cd549af24ee/smartrate"
         },
         "response": {
-          "bodySize": 760,
+          "bodySize": 768,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 760,
-            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:46Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_7b51137cb3f34aaea55a47662c498bcd\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":2,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":4,\"percentile_97\":5,\"percentile_99\":7},\"updated_at\":\"2022-06-01T21:06:46Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:46Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_d1468fd4d34642b88dc7819dd8c9a7c6\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-06-01T21:06:46Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:46Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_57fd0f1e7889498a92c9a37dff3c5d27\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":2},\"updated_at\":\"2022-06-01T21:06:46Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-06-01T21:06:46Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_efa1b89f1f464f8c912e8a8ec9c3f9c2\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_894150b8fc934a6ea1338d745683cd5d\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":1,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-06-01T21:06:46Z\"}]}"
+            "size": 768,
+            "text": "{\"result\":[{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:07Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":1,\"est_delivery_days\":1,\"id\":\"rate_1a0a4f0207ea40ecb3d5cf109c95cb2b\",\"list_currency\":\"USD\",\"list_rate\":7.37,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.37,\"retail_currency\":\"USD\",\"retail_rate\":8.7,\"service\":\"Priority\",\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":3,\"percentile_99\":6},\"updated_at\":\"2022-07-29T22:03:07Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:07Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":null,\"est_delivery_days\":null,\"id\":\"rate_aeb3f677601b4d6d9e1ed1ce9b38b3d4\",\"list_currency\":\"USD\",\"list_rate\":23.75,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":23.75,\"retail_currency\":\"USD\",\"retail_rate\":27.4,\"service\":\"Express\",\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":1,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":4},\"updated_at\":\"2022-07-29T22:03:07Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:07Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_e12a2ad303c24b98b345b387a0c3d279\",\"list_currency\":\"USD\",\"list_rate\":7.22,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":7.22,\"retail_currency\":\"USD\",\"retail_rate\":7.22,\"service\":\"ParcelSelect\",\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"time_in_transit\":{\"percentile_50\":2,\"percentile_75\":3,\"percentile_85\":3,\"percentile_90\":4,\"percentile_95\":5,\"percentile_97\":5,\"percentile_99\":8},\"updated_at\":\"2022-07-29T22:03:07Z\"},{\"carrier\":\"USPS\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\",\"created_at\":\"2022-07-29T22:03:07Z\",\"currency\":\"USD\",\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"delivery_days\":2,\"est_delivery_days\":2,\"id\":\"rate_7293f0fb1b384ca182df248a4586d7c7\",\"list_currency\":\"USD\",\"list_rate\":5.49,\"mode\":\"test\",\"object\":\"Rate\",\"rate\":5.49,\"retail_currency\":\"USD\",\"retail_rate\":5.49,\"service\":\"First\",\"shipment_id\":\"shp_75dc9e2d62c142b884462cd549af24ee\",\"time_in_transit\":{\"percentile_50\":1,\"percentile_75\":1,\"percentile_85\":2,\"percentile_90\":2,\"percentile_95\":2,\"percentile_97\":2,\"percentile_99\":3},\"updated_at\":\"2022-07-29T22:03:07Z\"}]}"
           },
           "cookies": [],
           "headers": [
@@ -231,7 +231,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0496297d4e7e787449b00112d12"
+              "value": "999d146a62e4591ce788dd40000fe4a9"
             },
             {
               "name": "cache-control",
@@ -251,11 +251,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"acc6b8c22c695485302465c59b6ac52a\""
+              "value": "W/\"a408e20f6dcd129c9e3317b3cf072020\""
             },
             {
               "name": "x-runtime",
-              "value": "0.089210"
+              "value": "0.088550"
             },
             {
               "name": "content-encoding",
@@ -267,11 +267,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb2nuq"
+              "value": "bigweb3nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
@@ -279,7 +279,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -296,8 +296,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2022-06-01T21:06:46.883Z",
-        "time": 293,
+        "startedDateTime": "2022-07-29T22:03:08.473Z",
+        "time": 280,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -305,7 +305,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 293
+          "wait": 280
         }
       }
     ],

--- a/test/helpers/fixture.js
+++ b/test/helpers/fixture.js
@@ -270,4 +270,46 @@ export default class Fixture {
 
     return Buffer.from(JSON.stringify(data), 'utf8');
   }
+
+  static carbonOffsetShipment() {
+    return {
+      to_address: {
+        name: 'Dr. Steve Brule',
+        street1: '179 N Harbor Dr',
+        city: 'Redondo Beach',
+        state: 'CA',
+        zip: '90277',
+        country: 'US',
+        phone: '8573875756',
+        email: 'dr_steve_brule@gmail.com',
+      },
+      from_address: {
+        name: 'EasyPost',
+        street1: '417 Montgomery Street',
+        street2: '5th Floor',
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94104',
+        country: 'US',
+        phone: '4153334445',
+        email: 'support@easypost.com',
+      },
+      parcel: {
+        length: 20.2,
+        width: 10.9,
+        height: 5,
+        weight: 65.9,
+      },
+    };
+  }
+
+  static oneCallBuyCarbonOffset() {
+    const shipment = this.carbonOffsetShipment();
+
+    shipment.service = 'Priority';
+    shipment.carrier_accounts = [this.uspsCarrierAccountId()];
+    shipment.carrier = this.usps();
+
+    return shipment;
+  }
 }

--- a/test/helpers/fixture.js
+++ b/test/helpers/fixture.js
@@ -153,7 +153,7 @@ export default class Fixture {
   // If you need to re-record cassettes, increment the date below and ensure it is one day in the future,
   // USPS only does "next-day" pickups including Saturday but not Sunday or Holidays.
   static basicPickup() {
-    const pickupDate = '2022-06-03';
+    const pickupDate = '2022-08-01';
 
     return {
       address: this.basicAddress(),

--- a/test/resources/shipment.test.js
+++ b/test/resources/shipment.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Shipment Resource', function () {
   setupPolly.startPolly();
@@ -206,7 +207,7 @@ describe('Shipment Resource', function () {
     const shipment = await new this.easypost.Shipment(Fixture.basicShipment()).save();
 
     // Test lowest smartrate with valid filters
-    const lowestSmartrate = await shipment.lowestSmartrate(1, 'percentile_90');
+    const lowestSmartrate = await shipment.lowestSmartrate(2, 'percentile_90');
     expect(lowestSmartrate.service).to.equal('First');
     expect(lowestSmartrate.rate).to.equal(5.49);
     expect(lowestSmartrate.carrier).to.equal('USPS');
@@ -239,7 +240,7 @@ describe('Shipment Resource', function () {
     // Test lowest smartrate with valid filters
     const lowestSmartrate = this.easypost.Shipment.getLowestSmartrate(
       smartrates,
-      1,
+      2,
       'percentile_90',
     );
     expect(lowestSmartrate.service).to.equal('First');

--- a/test/resources/shipment.test.js
+++ b/test/resources/shipment.test.js
@@ -281,4 +281,50 @@ describe('Shipment Resource', function () {
     expect(form.form_type).to.equal(formType);
     expect(form.form_url).to.not.be.null;
   });
+
+  it('create a carbon offset shipment', async function () {
+    const shipment = await new this.easypost.Shipment(Fixture.carbonOffsetShipment()).save(true);
+
+    expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
+
+    shipment.rates.forEach((rate) => {
+      expect(rate.carbon_offset).not.to.be.null;
+    });
+  });
+
+  it('buy a carbon offset shipment', async function () {
+    const shipment = await new this.easypost.Shipment(Fixture.carbonOffsetShipment()).save();
+    await shipment.buy(shipment.lowestRate(), null, true);
+
+    expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
+
+    let foundCarbonOffset = false;
+
+    shipment.fees.forEach((fee) => {
+      if (fee.type === 'CarbonOffsetFee') {
+        foundCarbonOffset = true;
+      }
+    });
+
+    expect(foundCarbonOffset).to.be.true;
+  });
+
+  it('one call buy a carbon offset shipment', async function () {
+    const shipment = await new this.easypost.Shipment(Fixture.oneCallBuyCarbonOffset()).save(true);
+
+    expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
+    shipment.rates.forEach((rate) => {
+      expect(rate.carbon_offset).not.to.be.null;
+    });
+  });
+
+  it('rerate a shipment with carbon offset', async function () {
+    const shipment = await new this.easypost.Shipment(Fixture.oneCallBuyCarbonOffset()).save();
+
+    const newCarbonOffsetRates = await shipment.regenerateRates(true);
+
+    newCarbonOffsetRates.rates.forEach((rate) => {
+      expect(rate.carbon_offset).not.to.be.null;
+    });
+  });
 });

--- a/types/Shipment/Rate.d.ts
+++ b/types/Shipment/Rate.d.ts
@@ -74,4 +74,9 @@ export declare interface IRate extends IObjectWithId<'Rate'>, IDatedObject {
    * indicates if delivery window is guaranteed (true) or not (false)
    */
   delivery_date_guaranteed: boolean;
+
+  /**
+   * indicate if a rate has carbon offset
+   */
+  carbon_offset: object;
 }

--- a/types/Shipment/Rate.d.ts
+++ b/types/Shipment/Rate.d.ts
@@ -76,7 +76,7 @@ export declare interface IRate extends IObjectWithId<'Rate'>, IDatedObject {
   delivery_date_guaranteed: boolean;
 
   /**
-   * indicate if a rate has carbon offset
+   * Indicate if a rate includes a carbon offset fee
    */
   carbon_offset: object;
 }

--- a/types/Shipment/Shipment.d.ts
+++ b/types/Shipment/Shipment.d.ts
@@ -148,6 +148,11 @@ export declare interface IShipment extends IObjectWithId<'Shipment'>, IDatedObje
    * The current message of the associated BatchShipment
    */
   batch_message: string;
+
+  /**
+   * Indicate if the shipment is carbon offset
+   */
+  carbon_offset: boolean;
 }
 
 export declare class Shipment implements IShipment {
@@ -181,6 +186,7 @@ export declare class Shipment implements IShipment {
   batch_id: string;
   batch_status: TBatchStatus;
   batch_message: string;
+  carbon_offset: boolean;
   created_at: string;
   updated_at: string;
 
@@ -195,8 +201,10 @@ export declare class Shipment implements IShipment {
    * You can limit the CarrierAccounts to use for rating by passing the carrier_accounts parameter.
    *
    * @see https://www.easypost.com/docs/api/node#create-a-shipment
+   *
+   * @param carbonOffset
    */
-  public save(): Promise<Shipment>;
+  public save(carbonOffset?: boolean): Promise<Shipment>;
 
   /**
    * The Shipment List is a paginated list of all Shipment objects associated with the given API Key.
@@ -236,8 +244,13 @@ export declare class Shipment implements IShipment {
    *
    * @param rate rate id (begins with "rate_") or rate object
    * @param insuranceAmount
+   * @param carbonOffset
    */
-  public buy(rate: string | IRate, insuranceAmount?: number): Promise<Shipment>;
+  public buy(
+    rate: string | IRate,
+    insuranceAmount?: number,
+    carbonOffset?: boolean,
+  ): Promise<Shipment>;
 
   /**
    * Refunding a Shipment is available for many carriers supported by EasyPost.
@@ -273,8 +286,10 @@ export declare class Shipment implements IShipment {
    * This operation respects the carrier_accounts attribute.
    *
    * @see https://www.easypost.com/docs/api/node#regenerate-rates-for-a-shipment
+   *
+   * @param carbonOffset
    */
-  public regenerateRates(): Promise<Shipment>;
+  public regenerateRates(carbonOffset?: boolean): Promise<Shipment>;
 
   /**
    * Insuring your Shipment is as simple as sending us the value of the contents.

--- a/types/Shipment/Shipment.d.ts
+++ b/types/Shipment/Shipment.d.ts
@@ -150,7 +150,7 @@ export declare interface IShipment extends IObjectWithId<'Shipment'>, IDatedObje
   batch_message: string;
 
   /**
-   * Indicate if the shipment is carbon offset
+   * Indicate if the shipment includes a carbon offset fee
    */
   carbon_offset: boolean;
 }


### PR DESCRIPTION
# Description

Adds the ability to create a shipment with carbon_offset
Adds the ability to buy a shipment with carbon_offset
Adds the ability to one-call-buy a shipment with carbon_offset
Adds the ability to rerate a shipment with carbon_offset

# Testing

Add three new unit tests and pass 

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
