### PR TITLE
fix: ignore cassettes via gitattributes for real

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 
-tests/cassettes/**/* -diff
-tests/cassettes/**/* linguist-generated
+*.har -diff
+*.har linguist-generated


### PR DESCRIPTION
# Description

Finally fixed the gitattributes for ignoring cassette diffs. This doesn't work as nicely for this lib because Polly stores them two directories deep. We can safely ignore `.har` files because those are the cassettes and nothing else.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
