### PR TITLE
feat: adds validateWebhook function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Adds `validateWebhook` function that returns your webhook or raises an error if there is a `webhookSecret` mismatch
+
 ## v5.4.0 (2022-07-18)
 
 - Adds the ability to generate shipment forms via `Shipment.generateForm()` function

--- a/src/resources/webhook.js
+++ b/src/resources/webhook.js
@@ -1,5 +1,8 @@
 import T from 'proptypes';
+
 import base from './base';
+
+const crypto = require('crypto');
 
 export const propTypes = {
   id: T.string,
@@ -19,4 +22,38 @@ export default (api) =>
     static key = 'webhook';
 
     static propTypes = propTypes;
+
+    static validateWebhook(eventBody, headers, webhookSecret) {
+      let webhook = {};
+      const easypostHmacSignature = headers['X-Hmac-Signature'] ?? null;
+
+      if (easypostHmacSignature != null) {
+        const normalizedSecret = webhookSecret.normalize('NFKD');
+        const encodedSecret = Buffer.from(normalizedSecret, 'utf8');
+
+        const expectedSignature = crypto
+          .createHmac('sha256', encodedSecret)
+          .update(eventBody, 'utf-8')
+          .digest('hex');
+
+        const digest = `hmac-sha256-hex=${expectedSignature}`;
+
+        if (
+          crypto.timingSafeEqual(
+            Buffer.from(easypostHmacSignature, 'utf8'),
+            Buffer.from(digest, 'utf8'),
+          )
+        ) {
+          webhook = JSON.parse(eventBody.toString());
+        } else {
+          throw new Error(
+            'Webhook received did not originate from EasyPost or had a webhook secret mismatch.',
+          );
+        }
+      } else {
+        throw new Error('Webhook received does not contain an HMAC signature.');
+      }
+
+      return webhook;
+    }
   };

--- a/src/resources/webhook.js
+++ b/src/resources/webhook.js
@@ -23,6 +23,16 @@ export default (api) =>
 
     static propTypes = propTypes;
 
+    /**
+     * Validate a webhook by comparing the HMAC signature header sent from EasyPost to your shared secret.
+     * If the signatures do not match, an error will be raised signifying the webhook either did not originate
+     * from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned
+     * as JSON.
+     * @param {buffer} eventBody
+     * @param {object} headers
+     * @param {string} webhookSecret
+     * @returns {object}
+     */
     static validateWebhook(eventBody, headers, webhookSecret) {
       let webhook = {};
       const easypostHmacSignature = headers['X-Hmac-Signature'] ?? null;

--- a/test/helpers/fixture.js
+++ b/test/helpers/fixture.js
@@ -234,4 +234,40 @@ export default class Fixture {
       ],
     };
   }
+
+  static eventBody() {
+    const data = {
+      result: {
+        id: 'batch_123...',
+        object: 'Batch',
+        mode: 'test',
+        state: 'created',
+        num_shipments: 0,
+        reference: null,
+        created_at: '2022-07-26T17:22:32Z',
+        updated_at: '2022-07-26T17:22:32Z',
+        scan_form: null,
+        shipments: [],
+        status: {
+          created: 0,
+          queued_for_purchase: 0,
+          creation_failed: 0,
+          postage_purchased: 0,
+          postage_purchase_failed: 0,
+        },
+        pickup: null,
+        label_url: null,
+      },
+      description: 'batch.created',
+      mode: 'test',
+      previous_attributes: null,
+      completed_urls: null,
+      user_id: 'user_123...',
+      status: 'pending',
+      object: 'Event',
+      id: 'evt_123...',
+    };
+
+    return Buffer.from(JSON.stringify(data), 'utf8');
+  }
 }

--- a/types/Webhook/Webhook.d.ts
+++ b/types/Webhook/Webhook.d.ts
@@ -71,4 +71,16 @@ export declare class Webhook implements IWebhook {
    * @see https://www.easypost.com/docs/api/node#delete-a-webhook
    */
   static delete(webhookId: string): Promise<{}>;
+
+  /**
+   * Validate a webhook by comparing the HMAC signature header sent from EasyPost to your shared secret.
+   * If the signatures do not match, an error will be raised signifying the webhook either did not originate
+   * from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned
+   * as JSON.
+   *
+   * @param eventBody The event body of the webhook sent from EasyPost.
+   * @param headers The headers of the webhook sent from EasyPost.
+   * @param webhookSecret The local webhook secret that should match what is stored with EasyPost for this webhook.
+   */
+  static validateWebhook(eventBody: Buffer, headers: object, webhookSecret: string): object;
 }


### PR DESCRIPTION
# Description

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

Adds a new `validateWebhook` function which takes in an `event_body` and `headers` from an EasyPost webhook and your locally stored `webhook_secret` and ensures the webhook originated from EasyPost. Will raise an error if the secrets don't match and produce your webhook if they do.

# Testing

Adds 3 unit tests to ensure all branches of this function work as intended.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
