### PR TITLE
chore: looser params for verify and verify_strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 - Adds `validateWebhook` function that returns your webhook or raises an error if there is a `webhookSecret` mismatch
+- Allows for looser values to the `verify` and `verify_strict` params when creating an address (can accept strings or bools outside of an array)
 
 ## v5.4.0 (2022-07-18)
 

--- a/src/resources/address.js
+++ b/src/resources/address.js
@@ -1,4 +1,5 @@
 import T from 'proptypes';
+
 import base from './base';
 import { baseAddress as baseAddressPropTypes } from './base_address';
 
@@ -8,8 +9,8 @@ export const propTypes = Object.assign({}, baseAddressPropTypes, {
   carrier_facility: T.string,
   federal_tax_id: T.string,
   state_tax_id: T.string,
-  verify: T.array,
-  verify_strict: T.array,
+  verify: T.oneOfType([T.bool, T.string, T.array]),
+  verify_strict: T.oneOfType([T.bool, T.string, T.array]),
   verifications: T.object,
 });
 

--- a/test/cassettes/Address-Resource_3542783961/creates-an-address-with-an-array-verify-param_1154761701/recording.har
+++ b/test/cassettes/Address-Resource_3542783961/creates-an-address-with-an-array-verify-param_1154761701/recording.har
@@ -1,6 +1,6 @@
 {
   "log": {
-    "_recordingName": "Address Resource/creates an address with verify_strict param",
+    "_recordingName": "Address Resource/creates an address with an array verify param",
     "creator": {
       "comment": "persister:fs",
       "name": "Polly.JS",
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "328e54ca68311c9d99505cf00cfb4bfa",
+        "_id": "d49186dfee05ff144349a18686106454",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 195,
+          "bodySize": 189,
           "cookies": [],
           "headers": [
             {
@@ -29,7 +29,7 @@
             },
             {
               "name": "content-length",
-              "value": 195
+              "value": 189
             },
             {
               "name": "host",
@@ -42,18 +42,18 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"phone\":\"5555555555\"},\"verify_strict\":true}"
+            "text": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"415-123-4567\"},\"verify\":[true]}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/addresses"
         },
         "response": {
-          "bodySize": 556,
+          "bodySize": 672,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 556,
-            "text": "{\"id\":\"adr_74c04ab20f6911eda95bac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-07-29T18:08:32+00:00\",\"updated_at\":\"2022-07-29T18:08:32+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}"
+            "size": 672,
+            "text": "{\"id\":\"adr_f4fb94a40f6611ed9d0dac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T17:50:38+00:00\",\"updated_at\":\"2022-07-29T17:50:38+00:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "2415913b62e42220e786c08100085d81"
+              "value": "2415914062e41deee786b8810006ed6f"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/addresses/adr_74c04ab20f6911eda95bac1f6b0a0d1e"
+              "value": "/api/v2/addresses/adr_f4fb94a40f6611ed9d0dac1f6bc72124"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"8c7d57aa75139422bbbc763ba8527662\""
+              "value": "W/\"cae2448d4ebfaf88a48628023ed58956\""
             },
             {
               "name": "x-runtime",
-              "value": "0.046951"
+              "value": "0.057262"
             },
             {
               "name": "content-encoding",
@@ -123,7 +123,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb4nuq"
+              "value": "bigweb6nuq"
             },
             {
               "name": "x-version-label",
@@ -135,7 +135,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
+              "value": "intlb1nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -148,12 +148,12 @@
           ],
           "headersSize": 810,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/addresses/adr_74c04ab20f6911eda95bac1f6b0a0d1e",
+          "redirectURL": "/api/v2/addresses/adr_f4fb94a40f6611ed9d0dac1f6bc72124",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-07-29T18:08:32.121Z",
-        "time": 238,
+        "startedDateTime": "2022-07-29T17:50:38.729Z",
+        "time": 287,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +161,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 238
+          "wait": 287
         }
       }
     ],

--- a/test/cassettes/Address-Resource_3542783961/creates-an-address-with-verify-param_348500273/recording.har
+++ b/test/cassettes/Address-Resource_3542783961/creates-an-address-with-verify-param_348500273/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "d49186dfee05ff144349a18686106454",
+        "_id": "3a329bf5f61ec34306247e61fd00aab5",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 189,
+          "bodySize": 187,
           "cookies": [],
           "headers": [
             {
@@ -29,20 +29,20 @@
             },
             {
               "name": "content-length",
-              "value": 189
+              "value": 187
             },
             {
               "name": "host",
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 493,
+          "headersSize": 391,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"415-123-4567\"},\"verify\":[true]}"
+            "text": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"phone\":\"415-123-4567\"},\"verify\":true}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/addresses"
@@ -53,7 +53,7 @@
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
             "size": 672,
-            "text": "{\"id\":\"adr_b99daccbe1e311ec9429ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-06-01T19:47:52+00:00\",\"updated_at\":\"2022-06-01T19:47:52+00:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}"
+            "text": "{\"id\":\"adr_749afabe0f6911ed9f73ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-07-29T18:08:32+00:00\",\"updated_at\":\"2022-07-29T18:08:32+00:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "f5a1f0476297c268e786c05f0009656e"
+              "value": "2415913d62e42220e786c08000085d6e"
             },
             {
               "name": "cache-control",
@@ -99,7 +99,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/addresses/adr_b99daccbe1e311ec9429ac1f6bc7b362"
+              "value": "/api/v2/addresses/adr_749afabe0f6911ed9f73ac1f6bc72124"
             },
             {
               "name": "content-type",
@@ -107,11 +107,11 @@
             },
             {
               "name": "etag",
-              "value": "W/\"8cd09111b7715ac226dcf843edbdc421\""
+              "value": "W/\"4ff6f373cf446adaa23e70e603161375\""
             },
             {
               "name": "x-runtime",
-              "value": "0.041234"
+              "value": "0.042057"
             },
             {
               "name": "content-encoding",
@@ -123,19 +123,23 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb5nuq"
+              "value": "bigweb7nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202206011908-268b477d75-master"
+              "value": "easypost-202207291722-ecd5579616-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-proxied",
-              "value": "intlb1nuq 570dfcbc0a, extlb2nuq 0910011e7e"
+              "value": "intlb2nuq 403f17ff97, extlb2nuq 403f17ff97"
             },
             {
               "name": "strict-transport-security",
@@ -146,14 +150,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 810,
+          "headersSize": 828,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/addresses/adr_b99daccbe1e311ec9429ac1f6bc7b362",
+          "redirectURL": "/api/v2/addresses/adr_749afabe0f6911ed9f73ac1f6bc72124",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2022-06-01T19:47:52.697Z",
-        "time": 234,
+        "startedDateTime": "2022-07-29T18:08:31.836Z",
+        "time": 277,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -161,7 +165,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 234
+          "wait": 277
         }
       }
     ],

--- a/test/resources/address.test.js
+++ b/test/resources/address.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Address Resource', function () {
   setupPolly.startPolly();
@@ -27,7 +28,7 @@ describe('Address Resource', function () {
 
   it('creates an address with verify param', async function () {
     const addressData = Fixture.incorrectAddressToVerify();
-    addressData.verify = [true];
+    addressData.verify = true;
 
     const address = await new this.easypost.Address(addressData).save();
 
@@ -38,13 +39,24 @@ describe('Address Resource', function () {
 
   it('creates an address with verify_strict param', async function () {
     const addressData = Fixture.basicAddress();
-    addressData.verify_strict = [true];
+    addressData.verify_strict = true;
 
     const address = await new this.easypost.Address(addressData).save();
 
     expect(address).to.be.an.instanceOf(this.easypost.Address);
     expect(address.id).to.match(/^adr_/);
     expect(address.street1).to.equal('388 TOWNSEND ST APT 20');
+  });
+
+  it('creates an address with an array verify param', async function () {
+    const addressData = Fixture.incorrectAddressToVerify();
+    addressData.verify = [true];
+
+    const address = await new this.easypost.Address(addressData).save();
+
+    expect(address).to.be.an.instanceOf(this.easypost.Address);
+    expect(address.id).to.match(/^adr_/);
+    expect(address.street1).to.equal('417 MONTGOMERY ST FL 5');
   });
 
   it('retrieves an address', async function () {

--- a/types/Address/AddressCreateParameters.ts
+++ b/types/Address/AddressCreateParameters.ts
@@ -11,12 +11,12 @@ export declare interface IAddressCreateParameters
    * verify_strict takes precedence.
    * true will perform both delivery and zip4.
    */
-  verify?: boolean | ['delivery', 'zip4'] | null;
+  verify?: boolean | string | ['true', 'delivery', 'zip4'] | null;
 
   /**
    * The verifications to perform when creating.
    * The failure of any of these verifications causes the whole request to fail.
    * true will perform both delivery and zip4
    */
-  verify_strict?: boolean | ['delivery', 'zip4'] | null;
+  verify_strict?: boolean | string | ['true', 'delivery', 'zip4'] | null;
 }


### PR DESCRIPTION
# Description

Allows for looser values to the `verify` and `verify_strict` params when creating an address (can accept strings or bools outside of an array)
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- Updates old unit tests to use a bool
- Adds a new unit test to ensure arrays still work
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
