### PR TITLE
fix: assert that items are undefined instead of null

### DIFF
--- a/test/resources/address.test.js
+++ b/test/resources/address.test.js
@@ -73,7 +73,7 @@ describe('Address Resource', function () {
     const addressesArray = addresses.addresses;
 
     expect(addressesArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(addresses.has_more).to.not.be.null;
+    expect(addresses.has_more).to.not.be.undefined;
     addressesArray.forEach((address) => {
       expect(address).to.be.an.instanceOf(this.easypost.Address);
     });

--- a/test/resources/api_key.test.js
+++ b/test/resources/api_key.test.js
@@ -1,8 +1,9 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
 import NotImplementedError from '../../src/errors/not_implemented';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('ApiKey Resource', function () {
   setupPolly.startPolly();
@@ -19,7 +20,9 @@ describe('ApiKey Resource', function () {
   it('retrieves all apiKeys', async function () {
     const apiKeys = await this.easypost.ApiKey.all();
 
-    expect(apiKeys.keys).not.to.be.null;
+    // TODO: `api_keys` does not match the expectation or docs of the API and
+    // should instead be `keys` and `children`.
+    expect(apiKeys.api_keys).to.not.be.undefined;
   });
 
   it('throws on save', function () {

--- a/test/resources/batch.test.js
+++ b/test/resources/batch.test.js
@@ -2,10 +2,11 @@
 import fs from 'fs';
 import { expect } from 'chai';
 import { resolve } from 'path';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Batch Resource', function () {
   setupPolly.startPolly();
@@ -26,7 +27,7 @@ describe('Batch Resource', function () {
 
     expect(batch).to.be.an.instanceOf(this.easypost.Batch);
     expect(batch.id).to.match(/^batch_/);
-    expect(batch.shipments).to.not.be.null;
+    expect(batch.shipments).to.not.be.undefined;
   });
 
   it('retrieves a batch', async function () {
@@ -46,7 +47,7 @@ describe('Batch Resource', function () {
     const addressesArray = batches.batches;
 
     expect(addressesArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(batches.has_more).to.not.be.null;
+    expect(batches.has_more).to.not.be.undefined;
     addressesArray.forEach((batch) => {
       expect(batch).to.be.an.instanceOf(this.easypost.Batch);
     });

--- a/test/resources/beta/referral.test.js
+++ b/test/resources/beta/referral.test.js
@@ -1,8 +1,9 @@
 /* eslint-disable func-names,jest/no-disabled-tests */
 import { expect } from 'chai';
-import * as setupPolly from '../../helpers/setup_polly';
+
 import EasyPost from '../../../src/beta/easypost';
 import Fixture from '../../helpers/fixture';
+import * as setupPolly from '../../helpers/setup_polly';
 
 describe('Referral Resource', function () {
   setupPolly.startPolly();
@@ -43,7 +44,7 @@ describe('Referral Resource', function () {
     const referralsArray = referrals.referral_customers;
 
     expect(referralsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(referrals.has_more).to.not.be.null;
+    expect(referrals.has_more).to.not.be.undefined;
     referralsArray.forEach((referral) => {
       expect(referral).to.be.an.instanceOf(this.easypost.Referral);
     });

--- a/test/resources/billing.test.js
+++ b/test/resources/billing.test.js
@@ -1,7 +1,8 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Billing Resource', function () {
   setupPolly.startPolly();
@@ -36,7 +37,7 @@ describe('Billing Resource', function () {
     // Skipping due to the lack of an available real payment method in tests
     const paymentMethods = await this.easypost.Billing.retrievePaymentMethods();
 
-    expect(paymentMethods.primary_payment_method).to.not.null;
-    expect(paymentMethods.secondary_payment_method).to.not.be.null;
+    expect(paymentMethods.primary_payment_method).to.not.be.undefined;
+    expect(paymentMethods.secondary_payment_method).to.not.be.undefined;
   });
 });

--- a/test/resources/event.test.js
+++ b/test/resources/event.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Event Resource', function () {
   setupPolly.startPolly();
@@ -36,7 +37,7 @@ describe('Event Resource', function () {
     const eventsArray = events.events;
 
     expect(eventsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(events.has_more).to.not.be.null;
+    expect(events.has_more).to.not.be.undefined;
     eventsArray.forEach((event) => {
       expect(event).to.be.an.instanceOf(this.easypost.Event);
     });

--- a/test/resources/insurance.test.js
+++ b/test/resources/insurance.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Insurance Resource', function () {
   setupPolly.startPolly();
@@ -52,7 +53,7 @@ describe('Insurance Resource', function () {
     const insuranceArray = insurance.insurances;
 
     expect(insuranceArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(insurance.has_more).to.not.be.null;
+    expect(insurance.has_more).to.not.be.undefined;
     insuranceArray.forEach((event) => {
       expect(event).to.be.an.instanceOf(this.easypost.Insurance);
     });

--- a/test/resources/order.test.js
+++ b/test/resources/order.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Order Resource', function () {
   setupPolly.startPolly();
@@ -22,7 +23,7 @@ describe('Order Resource', function () {
 
     expect(order).to.be.an.instanceOf(this.easypost.Order);
     expect(order.id).to.match(/^order_/);
-    expect(order.rates).to.not.be.null;
+    expect(order.rates).to.not.be.undefined;
   });
 
   it('retrieves an order', async function () {
@@ -56,7 +57,7 @@ describe('Order Resource', function () {
     const shipmentsArray = order.shipments;
 
     shipmentsArray.forEach((shipment) => {
-      expect(shipment.postage_label).to.not.be.null;
+      expect(shipment.postage_label).to.not.be.undefined;
     });
   });
 

--- a/test/resources/pickup.test.js
+++ b/test/resources/pickup.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Pickup Resource', function () {
   setupPolly.startPolly();
@@ -27,7 +28,7 @@ describe('Pickup Resource', function () {
 
     expect(pickup).to.be.an.instanceOf(this.easypost.Pickup);
     expect(pickup.id).to.match(/^pickup_/);
-    expect(pickup.pickup_rates).to.not.be.null;
+    expect(pickup.pickup_rates).to.not.be.undefined;
   });
 
   it('retrieves a pickup', async function () {
@@ -57,7 +58,7 @@ describe('Pickup Resource', function () {
 
     expect(boughtPickup).to.be.an.instanceOf(this.easypost.Pickup);
     expect(boughtPickup.id).to.match(/^pickup_/);
-    expect(boughtPickup.confirmation).to.not.be.null;
+    expect(boughtPickup.confirmation).to.not.be.undefined;
     expect(boughtPickup.status).to.equal('scheduled');
   });
 

--- a/test/resources/refund.test.js
+++ b/test/resources/refund.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Refund Resource', function () {
   setupPolly.startPolly();
@@ -40,7 +41,7 @@ describe('Refund Resource', function () {
     const refundsArray = refunds.refunds;
 
     expect(refundsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(refunds.has_more).to.not.be.null;
+    expect(refunds.has_more).to.not.be.undefined;
     refundsArray.forEach((address) => {
       expect(address).to.be.an.instanceOf(this.easypost.Refund);
     });

--- a/test/resources/report.test.js
+++ b/test/resources/report.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Report Resource', function () {
   setupPolly.startPolly();
@@ -76,7 +77,7 @@ describe('Report Resource', function () {
     const reportsArray = reports.reports;
 
     expect(reportsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(reports.has_more).to.not.be.null;
+    expect(reports.has_more).to.not.be.undefined;
     reportsArray.forEach((report) => {
       expect(report).to.be.an.instanceOf(this.easypost.Report);
     });

--- a/test/resources/scan_form.test.js
+++ b/test/resources/scan_form.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('ScanForm Resource', function () {
   setupPolly.startPolly();
@@ -50,7 +51,7 @@ describe('ScanForm Resource', function () {
     const scanformsArray = scanforms.scan_forms;
 
     expect(scanformsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(scanforms.has_more).to.not.be.null;
+    expect(scanforms.has_more).to.not.be.undefined;
     scanformsArray.forEach((scanform) => {
       expect(scanform).to.be.an.instanceOf(this.easypost.ScanForm);
     });

--- a/test/resources/shipment.test.js
+++ b/test/resources/shipment.test.js
@@ -23,7 +23,7 @@ describe('Shipment Resource', function () {
 
     expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
     expect(shipment.id).to.match(/^shp_/);
-    expect(shipment.rates).to.not.be.null;
+    expect(shipment.rates).to.not.be.undefined;
     expect(shipment.options.label_format).to.equal('PNG');
     expect(shipment.options.invoice_number).to.equal('123');
     expect(shipment.reference).to.equal('123');
@@ -34,17 +34,17 @@ describe('Shipment Resource', function () {
     const shipmentData = Fixture.basicShipment();
     shipmentData.customs_info = null;
     shipmentData.options = null;
-    shipmentData.tax_identifiers = null;
+    shipmentData.tax_identifiers = undefined;
     shipmentData.reference = '';
 
     const shipment = await new this.easypost.Shipment(shipmentData).save();
 
     expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
     expect(shipment.id).to.match(/^shp_/);
-    expect(shipment.options).to.not.be.null; // The EasyPost API populates some default values here
+    expect(shipment.options).to.not.be.undefined; // The EasyPost API populates some default values here
     expect(shipment.customs_info).to.be.null;
     expect(shipment.reference).to.be.null;
-    expect(shipment.tax_identifiers).to.be.null;
+    expect(shipment.tax_identifiers).to.be.undefined;
   });
 
   it('creates a shipment with tax_identifiers', async function () {
@@ -94,7 +94,7 @@ describe('Shipment Resource', function () {
     const shipmentsArray = shipments.shipments;
 
     expect(shipmentsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(shipments.has_more).to.not.be.null;
+    expect(shipments.has_more).to.not.be.undefined;
     shipmentsArray.forEach((shipment) => {
       expect(shipment).to.be.an.instanceOf(this.easypost.Shipment);
     });
@@ -105,7 +105,7 @@ describe('Shipment Resource', function () {
 
     await shipment.buy(shipment.lowestRate());
 
-    expect(shipment.postage_label).to.not.be.null;
+    expect(shipment.postage_label).to.not.be.undefined;
   });
 
   it('regenerates rates for a shipment', async function () {
@@ -129,7 +129,7 @@ describe('Shipment Resource', function () {
 
     await shipment.convertLabelFormat('ZPL');
 
-    expect(shipment.postage_label.label_zpl_url).to.not.be.null;
+    expect(shipment.postage_label.label_zpl_url).to.not.be.undefined;
   });
 
   // TODO: Skipped because the `insurance` field is not sending properly when scrubbing is enabled
@@ -161,17 +161,17 @@ describe('Shipment Resource', function () {
   it('retrieves smartrates of a shipment', async function () {
     const shipment = await new this.easypost.Shipment(Fixture.oneCallBuyShipment()).save();
 
-    expect(shipment.rates).to.not.be.null;
+    expect(shipment.rates).to.not.be.undefined;
 
     const smartrates = await shipment.getSmartrates();
 
-    expect(smartrates[0].time_in_transit.percentile_50).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_75).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_85).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_90).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_95).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_97).to.not.be.null;
-    expect(smartrates[0].time_in_transit.percentile_99).to.not.be.null;
+    expect(smartrates[0].time_in_transit.percentile_50).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_75).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_85).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_90).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_95).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_97).to.not.be.undefined;
+    expect(smartrates[0].time_in_transit.percentile_99).to.not.be.undefined;
   });
 
   it('throws on delete', function () {
@@ -280,7 +280,7 @@ describe('Shipment Resource', function () {
     const form = shipment.forms[0];
 
     expect(form.form_type).to.equal(formType);
-    expect(form.form_url).to.not.be.null;
+    expect(form.form_url).to.not.be.undefined;
   });
 
   it('create a shipment with carbon offset', async function () {

--- a/test/resources/tracker.test.js
+++ b/test/resources/tracker.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable func-names */
 import { expect } from 'chai';
-import * as setupPolly from '../helpers/setup_polly';
+
 import EasyPost from '../../src/easypost';
-import Fixture from '../helpers/fixture';
 import NotImplementedError from '../../src/errors/not_implemented';
+import Fixture from '../helpers/fixture';
+import * as setupPolly from '../helpers/setup_polly';
 
 describe('Tracker Resource', function () {
   setupPolly.startPolly();
@@ -46,7 +47,7 @@ describe('Tracker Resource', function () {
     const trackersArray = trackers.trackers;
 
     expect(trackersArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(trackers.has_more).to.not.be.null;
+    expect(trackers.has_more).to.not.be.undefined;
     trackersArray.forEach((tracker) => {
       expect(tracker).to.be.an.instanceOf(this.easypost.Tracker);
     });

--- a/test/resources/webhook.test.js
+++ b/test/resources/webhook.test.js
@@ -52,7 +52,6 @@ describe('Webhook Resource', function () {
     const webhooksArray = webhooks.webhooks;
 
     expect(webhooksArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    expect(webhooks.has_more).to.not.be.null;
     webhooksArray.forEach((webhook) => {
       expect(webhook).to.be.an.instanceOf(this.easypost.Webhook);
     });


### PR DESCRIPTION
# Description

We want to be asserting that items are present. In Javascript, we should be using `undefined` instead of `null` to do this. We found we got burned by using `null` on a few items that provided false-positives. These were corrected:

1. Carbon offset not getting set properly (fixed in a previous PR that spurred these fixes here)
2. API keys are being massaged into a differing format than what we have documented (TODO left for the future as to not break the behavior here)
3. Webhooks are unpaginated and do not have a `has_more` key, assertion removed
4. Fixes a couple spots where we weren't using the proper `mocha` assertion syntax

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- All tests that test against `null` were changed to `undefined` for presence checks
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
