### PR TITLE
fix: only include the response body for errors instead of the entire response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## NEXT RELEASE
+
+- Fixes a regression introduced in v5.1.0 that included the entire response instead of the response body when errors are returned from the API
+
 ## v5.6.0 (2022-08-25)
 
 - Moves EndShipper out of beta to the general library namespace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@easypost/api",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@easypost/api",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "MIT",
       "dependencies": {
         "core-js": "3.19.3",

--- a/src/beta/resources/referral.js
+++ b/src/beta/resources/referral.js
@@ -1,19 +1,16 @@
 /* eslint-disable no-dupe-class-members,no-unused-vars,class-methods-use-this */
+import T from 'proptypes';
 import superagent from 'superagent';
 
-import T from 'proptypes';
+import API from '../../easypost';
 import base from '../../resources/base';
 import { propTypes as userPropTypes } from '../../resources/user';
-import RequestError from '../../errors/request';
-import API from '../../easypost';
 
 export const propTypes = Object.assign({}, userPropTypes, {
   name: T.string.isRequired,
   email: T.string.isRequired,
   phone: T.string.isRequired,
 });
-
-const stripeCreditCardUrl = 'https://api.stripe.com/v1/tokens';
 
 /**
  * Get an instance of the API client using the referral user's API key.
@@ -48,8 +45,8 @@ async function getEasyPostStripeKey(api) {
  * @returns {Promise<string>} - Stripe credit card token.
  */
 async function sendCardDetailsToStripe(stripeKey, number, expirationMonth, expirationYear, cvc) {
-  // need to form-encode per Stripe's API
-  const request = superagent.post(stripeCreditCardUrl).set({
+  // Stripe's endpoint requires form-encoded requests
+  const request = superagent.post('https://api.stripe.com/v1/tokens').set({
     Authorization: `Bearer ${stripeKey}`,
     'Content-Type': 'application/x-www-form-urlencoded',
   });
@@ -67,10 +64,7 @@ async function sendCardDetailsToStripe(stripeKey, number, expirationMonth, expir
 
     return response.body.id;
   } catch (error) {
-    throw new RequestError(
-      'Could not send card details to Stripe, please try again later',
-      stripeCreditCardUrl,
-    );
+    throw new Error('Could not send card details to Stripe, please try again later');
   }
 }
 

--- a/src/easypost.js
+++ b/src/easypost.js
@@ -2,14 +2,14 @@ import os from 'os';
 import superagent from 'superagent';
 
 import pkg from '../package.json';
-
+import RequestError from './errors/request';
 import Address, { propTypes as addressPropTypes } from './resources/address';
 import ApiKey, { propTypes as apiKeyPropTypes } from './resources/api_key';
 import Batch, { propTypes as batchPropTypes } from './resources/batch';
+import Billing, { propTypes as BillingPropTypes } from './resources/billing';
 import Brand, { propTypes as brandPropTypes } from './resources/brand';
 import CarrierAccount, { propTypes as carrierAccountPropTypes } from './resources/carrier_account';
 import CarrierType, { propTypes as carrierTypePropTypes } from './resources/carrier_type';
-import Billing, { propTypes as BillingPropTypes } from './resources/billing';
 import CustomsInfo, { propTypes as customsInfoPropTypes } from './resources/customs_info';
 import CustomsItem, { propTypes as customsItemPropTypes } from './resources/customs_item';
 import EndShipper, { propTypes as endShipperPropTypes } from './resources/end_shipper';
@@ -27,8 +27,6 @@ import Shipment, { propTypes as shipmentPropTypes } from './resources/shipment';
 import Tracker, { propTypes as trackerPropTypes } from './resources/tracker';
 import User, { propTypes as userPropTypes } from './resources/user';
 import Webhook, { propTypes as webhookPropTypes } from './resources/webhook';
-
-import RequestError from './errors/request';
 
 export const MS_SECOND = 1000;
 export const DEFAULT_TIMEOUT = 60 * MS_SECOND;
@@ -195,33 +193,33 @@ export default class API {
    * @returns {*}
    */
   async request(path = '', method = METHODS.GET, params = {}, headers = {}) {
-    let req = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
+    let request = this.agent[method](this.buildPath(path)).set(API.buildHeaders(headers));
 
     if (this.requestMiddleware) {
-      req = this.requestMiddleware(req);
+      request = this.requestMiddleware(request);
     }
 
     if (this.key) {
-      req.auth(this.key);
+      request.auth(this.key);
     }
 
     if (params !== {} && params !== undefined) {
       if (method === METHODS.GET || method === METHODS.DELETE) {
-        req.query(params);
+        request.query(params);
       } else {
-        req.send(params);
+        request.send(params);
       }
     }
 
     try {
-      const res = await req;
-      return res;
-    } catch (e) {
-      if (e.response && e.response.body) {
-        throw new RequestError(e.response, path);
+      const response = await request;
+      return response;
+    } catch (error) {
+      if (error.response && error.response.body) {
+        throw new RequestError(error.response, path);
       }
 
-      throw e;
+      throw error;
     }
   }
 

--- a/src/errors/request.js
+++ b/src/errors/request.js
@@ -22,8 +22,7 @@ export default class RequestError extends FakeError {
     );
 
     super(message);
-    this.error = response;
-
+    this.error = response.body;
     this.name = NAME;
     this.status = response.status || response.code;
 

--- a/src/errors/request.js
+++ b/src/errors/request.js
@@ -22,7 +22,7 @@ export default class RequestError extends FakeError {
     );
 
     super(message);
-    this.error = response.body;
+    this.error = response.body || response;
     this.name = NAME;
     this.status = response.status || response.code;
 

--- a/test/errors/request.js
+++ b/test/errors/request.js
@@ -1,4 +1,4 @@
-import RequestError, { NAME, createMessage } from '../../src/errors/request';
+import RequestError, { createMessage, NAME } from '../../src/errors/request';
 
 describe('Request Errors', () => {
   const error = {


### PR DESCRIPTION
# Description

Fixes a regression introduced in v5.1.0 that included the entire response instead of the response body when errors are returned from the API. We will continue to fallback to the entire response when a body isn't present. 

This also switches the `RequestError` to `Error` for the referral function when we cannot connect to Stripe since that was the wrong error type and would blow up at runtime due to the message being passed in not being a response object. This wasn't caught because we don't run this unit test.

# Testing

A/B tested the output of an error with/without the fix.

Without the fix:

```bash
...
    },
    created: false,
    accepted: false,
    noContent: false,
    badRequest: false,
    unauthorized: false,
    notAcceptable: false,
    forbidden: false,
    notFound: false,
    unprocessableEntity: true,
    type: 'application/json',
    charset: 'utf-8',
    links: {},
    setEncoding: [Function: bound ],
    redirects: [],
    _body: {
      error: {
        code: 'TRACKER.CREATE.ERROR',
        message: 'A duplicate request is currently in-flight',
        errors: []
      }
    },
    pipe: [Function (anonymous)],
    [Symbol(kCapture)]: false
  },
  name: 'RequestError',
  status: 422,
  detail: 'A duplicate request is currently in-flight',
  errors: []
}
```

With the fix:

```bash
RequestError {
  error: {
    error: {
      code: 'TRACKER.CREATE.ERROR',
      message: 'A duplicate request is currently in-flight',
      errors: []
    }
  },
  name: 'RequestError',
  status: 422,
  detail: 'A duplicate request is currently in-flight',
  errors: []
}
```

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
