### PR TITLE
tests: adds error test

### DIFF
--- a/src/errors/request.js
+++ b/src/errors/request.js
@@ -16,6 +16,7 @@ export default class RequestError extends FakeError {
       throw new Error('No url passed to RequestError');
     }
 
+    // TODO: concatenate the `error.message` field if it comes back from the API as an array since it should be a string
     const message = createMessage(
       response.status || response.statusCode || response.code || response.body.code,
       url,

--- a/test/cassettes/Error-Resource_153777519/pulls-out-error-properties-of-an-API-error_2733221812/recording.har
+++ b/test/cassettes/Error-Resource_153777519/pulls-out-error-properties-of-an-API-error_2733221812/recording.har
@@ -1,0 +1,163 @@
+{
+  "log": {
+    "_recordingName": "Error Resource/pulls out error properties of an API error",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "4555226759cce83a949ae8ad247e2a60",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 37,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 37
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 292,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"shipment\":{},\"carbon_offset\":false}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/v2/shipments"
+        },
+        "response": {
+          "bodySize": 196,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 196,
+            "text": "{\"error\":{\"code\":\"PARAMETER.REQUIRED\",\"message\":\"Missing required parameter.\",\"errors\":[{\"field\":\"shipment\",\"message\":\"cannot be blank\"}]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "1f49c27d63518cdae787d9c4001b39d9"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.034505"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb1nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202210192121-de6c7d8326-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 29913d444b, extlb1nuq 29913d444b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 709,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2022-10-20T18:00:58.426Z",
+        "time": 274,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 274
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import 'core-js/stable';
+
 import chai from 'chai';
 
 process.on('unhandledRejection', (err) => {
@@ -8,6 +9,7 @@ process.on('unhandledRejection', (err) => {
 
 chai.should();
 chai.use(require('chai-as-promised'));
+chai.config.truncateThreshold = 0;
 
 global.expect = chai.expect;
 global.AssertionError = chai.AssertionError;

--- a/test/resources/error.test.js
+++ b/test/resources/error.test.js
@@ -1,0 +1,28 @@
+import { assert, expect } from 'chai';
+
+import EasyPost from '../../src/easypost';
+import * as setupPolly from '../helpers/setup_polly';
+
+/* eslint-disable func-names,jest/no-disabled-tests */
+describe('Error Resource', function () {
+  setupPolly.startPolly();
+
+  before(function () {
+    this.easypost = new EasyPost(process.env.EASYPOST_TEST_API_KEY);
+  });
+
+  beforeEach(function () {
+    const { server } = this.polly;
+    setupPolly.setupCassette(server);
+  });
+
+  it('pulls out error properties of an API error', async function () {
+    await new this.easypost.Shipment().save().catch((error) => {
+      expect(error.status).to.equal(422);
+      // TODO: `error.message` is useless in this lib and doesn't follow the documented pattern for what this should be
+      expect(error.message).to.equal('Status 422 returned from API request to shipments');
+      expect(error.detail).to.equal('Missing required parameter.'); // TODO: This should really be error.message
+      assert.deepEqual(error.errors[0], { field: 'shipment', message: 'cannot be blank' });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Adds an error test to ensure the error object can have properties pulled out of it. 

This lib deviates wildly from what our API docs state and the expectations of the Error object that we can't yet concatenate the error message without doing a bunch of other work. I left a bunch of TODOs for now and will revisit fixing error handling when we do the thread-safe rewrite
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Adds a new test to check that unpacking error properties works
<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
