### PR TITLE
add stripe refund and add payment functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Next Release
+
+- [ADDED] Adds new beta billing functionality for ReferralCustomer users
+  - `addPaymentMethod` can add a pre-existing Stripe bank account or credit card to your EasyPost account
+  - `refundByAmount` refunds your wallet by a dollar amount
+  - `refundByPaymentLog` refunds you wallet by a PaymentLog ID
+
 ## v5.8.0 (2022-12-07)
 
 - Routes requests for creating a carrier account with a custom workflow (eg: FedEx, UPS) to the correct endpoint when using the `save` function

--- a/README.md
+++ b/README.md
@@ -240,4 +240,4 @@ Some tests may require an EasyPost user with a particular set of enabled feature
 
 - `USPS_CARRIER_ACCOUNT_ID` (eg: one-call buying a shipment for non-EasyPost employees)
 - `PARTNER_USER_PROD_API_KEY` (eg: creating a referral user)
-- `REFERRAL_USER_PROD_API_KEY` (eg: adding a credit card to a referral user)
+- `REFERRAL_CUSTOMER_PROD_API_KEY` (eg: adding a credit card to a referral user)

--- a/src/beta/easypost.js
+++ b/src/beta/easypost.js
@@ -1,3 +1,6 @@
+import BetaPaymentRefund, {
+  propTypes as betaPaymentRefundTypes,
+} from './resources/beta_payment_refund';
 import Referral, { propTypes as referralPropTypes } from './resources/referral';
 
 import API from '../easypost';
@@ -5,10 +8,12 @@ import API from '../easypost';
 export const DEFAULT_BASE_URL = 'https://api.easypost.com/beta/';
 
 export const RESOURCES = {
+  BetaPaymentRefund,
   Referral,
 };
 
 export const PROP_TYPES = {
+  betaPaymentRefundTypes,
   referralPropTypes,
 };
 

--- a/src/beta/resources/beta_payment_refund.js
+++ b/src/beta/resources/beta_payment_refund.js
@@ -1,0 +1,13 @@
+import T from 'proptypes';
+
+export const propTypes = {
+  refunded_amount: T.number,
+  payment_log_id: T.string,
+  refunded_payment_logs: T.array,
+  errors: T.array,
+};
+
+export default () =>
+  class BetaPaymentRefund {
+    static propTypes = propTypes;
+  };

--- a/src/beta/resources/referral.js
+++ b/src/beta/resources/referral.js
@@ -150,4 +150,56 @@ export default (api) =>
 
       return paymentMethod;
     }
+
+    /**
+     * Add Stripe payment method to referral customer.
+     * @param {string} stripeCustomerId - The Stripe account's ID.
+     * @param {string} paymentMethodReference - Reference of Stripe payment method.
+     * @param {string} primaryOrSecondary - Primary or secondary of this payment method.
+     * @returns {object} - Returns PaymentMethod object.
+     */
+    static async addPaymentMethod(
+      stripeCustomerId,
+      paymentMethodReference,
+      primaryOrSecondary = 'primary',
+    ) {
+      const wrappedParams = {
+        payment_method: {
+          stripe_customer_id: stripeCustomerId,
+          payment_method_reference: paymentMethodReference,
+          priority: primaryOrSecondary,
+        },
+      };
+
+      const response = await api.post('referral_customers/payment_method', wrappedParams);
+      return response;
+    }
+
+    /**
+     * Refund by amount for a recent payment.
+     * @param {number} refundAmount - Amount to be refunded by cents.
+     * @returns {object} - Returns BetaPaymentRefund object.
+     */
+    static async refundByAmount(refundAmount) {
+      const params = {
+        refund_amount: refundAmount,
+      };
+
+      const response = await api.post('referral_customers/refunds', params);
+      return response;
+    }
+
+    /**
+     * Refund a payment by a payment log ID.
+     * @param {string} paymentLogId - ID of the payment log.
+     * @returns {object} - Returns BetaPaymentRefund object.
+     */
+    static async refundByPaymentLog(paymentLogId) {
+      const params = {
+        payment_log_id: paymentLogId,
+      };
+
+      const response = await api.post('referral_customers/refunds', params);
+      return response;
+    }
   };

--- a/test/cassettes/Referral-Beta-Resource_682743806/Refund-a-payment-by-a-payment-log-ID_834598297/recording.har
+++ b/test/cassettes/Referral-Beta-Resource_682743806/Refund-a-payment-by-a-payment-log-ID_834598297/recording.har
@@ -1,0 +1,167 @@
+{
+  "log": {
+    "_recordingName": "Referral Beta Resource/Refund a payment by a payment log ID",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "0a76572f15f6f4bde79e3b38f8ed3db8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 31,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 31
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 408,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"payment_log_id\":\"paylog_...\"}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/beta/referral_customers/refunds"
+        },
+        "response": {
+          "bodySize": 188,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 188,
+            "text": "{\"error\":{\"code\":\"TRANSACTION.DOES_NOT_EXIST\",\"message\":\"We could not find a transaction with that id.\",\"errors\":[]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "6baa8e7c63bc81d2e786a3a300102a57"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.044415"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb7nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202301092005-3309c91c2c-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 29913d444b, extlb1nuq 29913d444b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 727,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2023-01-09T21:06:26.424Z",
+        "time": 459,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 459
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Referral-Beta-Resource_682743806/Refund-by-amount-for-a-recent-payment_2095459785/recording.har
+++ b/test/cassettes/Referral-Beta-Resource_682743806/Refund-by-amount-for-a-recent-payment_2095459785/recording.har
@@ -1,0 +1,163 @@
+{
+  "log": {
+    "_recordingName": "Referral Beta Resource/Refund by amount for a recent payment",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "a92f8186a404321b7ef1b617bf52c81b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 22,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 22
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 408,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"refund_amount\":2000}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/beta/referral_customers/refunds"
+        },
+        "response": {
+          "bodySize": 208,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 208,
+            "text": "{\"error\":{\"code\":\"TRANSACTION.AMOUNT_INVALID\",\"message\":\"Refund amount is invalid. Please use a valid amount or escalate to finance.\",\"errors\":[]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "8bfbdf7f63bc8180e786a37b0010a94b"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.510758"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb4nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202301092005-3309c91c2c-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb2nuq 29913d444b, extlb2nuq 29913d444b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 709,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2023-01-09T21:05:04.465Z",
+        "time": 966,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 966
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/cassettes/Referral-Beta-Resource_682743806/add-payment-method-to-a-referral-customer-account_202490475/recording.har
+++ b/test/cassettes/Referral-Beta-Resource_682743806/add-payment-method-to-a-referral-customer-account_202490475/recording.har
@@ -1,0 +1,163 @@
+{
+  "log": {
+    "_recordingName": "Referral Beta Resource/add payment method to a referral customer account",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "1da7a2d3e35d0d9d92e97555d7329020",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 108,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "accept-encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "accept",
+              "value": "application/json"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "content-length",
+              "value": 108
+            },
+            {
+              "name": "host",
+              "value": "api.easypost.com"
+            }
+          ],
+          "headersSize": 416,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"payment_method\":{\"stripe_customer_id\":\"cus_123\",\"payment_method_reference\":\"ba_123\",\"priority\":\"primary\"}}"
+          },
+          "queryString": [],
+          "url": "https://api.easypost.com/beta/referral_customers/payment_method"
+        },
+        "response": {
+          "bodySize": 192,
+          "content": {
+            "encoding": "base64",
+            "mimeType": "application/json; charset=utf-8",
+            "size": 192,
+            "text": "{\"error\":{\"code\":\"BILLING.INVALID_PAYMENT_GATEWAY_REFERENCE\",\"message\":\"Invalid Payment Gateway Reference.\",\"errors\":[]}}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "x-download-options",
+              "value": "noopen"
+            },
+            {
+              "name": "x-permitted-cross-domain-policies",
+              "value": "none"
+            },
+            {
+              "name": "referrer-policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            {
+              "name": "x-ep-request-uuid",
+              "value": "8bfbdf7d63bc7aeae7799849000daa34"
+            },
+            {
+              "name": "cache-control",
+              "value": "private, no-cache, no-store"
+            },
+            {
+              "name": "pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "expires",
+              "value": "0"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.056137"
+            },
+            {
+              "name": "content-encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "x-node",
+              "value": "bigweb1nuq"
+            },
+            {
+              "name": "x-version-label",
+              "value": "easypost-202301092005-3309c91c2c-master"
+            },
+            {
+              "name": "x-backend",
+              "value": "easypost"
+            },
+            {
+              "name": "x-proxied",
+              "value": "intlb1nuq 29913d444b, extlb2nuq 29913d444b"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000; includeSubDomains; preload"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 709,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 422,
+          "statusText": "Unprocessable Entity"
+        },
+        "startedDateTime": "2023-01-09T20:36:58.124Z",
+        "time": 483,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 483
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test/resources/referral.test.js
+++ b/test/resources/referral.test.js
@@ -10,7 +10,7 @@ describe('Referral Resource', function () {
 
   before(function () {
     const partnerUserProdApiKey = process.env.PARTNER_USER_PROD_API_KEY || '123';
-    this.referralUserProdApiKey = process.env.REFERRAL_USER_PROD_API_KEY || '123';
+    this.referralUserProdApiKey = process.env.REFERRAL_CUSTOMER_PROD_API_KEY || '123';
     this.easypost = new EasyPost(partnerUserProdApiKey);
   });
 

--- a/types/Referral/Referral.d.ts
+++ b/types/Referral/Referral.d.ts
@@ -1,0 +1,29 @@
+/**
+ * The Referral class allow you to add Stripe payment method to referral account, and refund payment
+ * by amount or payment log id.
+ *
+ * TODO: Add link when the Referral API doc is added
+ */
+export declare class Referral {
+  /**
+   * Add Stripe payment method to referral customer.
+   * TODO: Add the link to API doc when its updated
+   */
+  static addPaymentMethod(
+    stripeCustomerId: string,
+    paymentMethodReference: string,
+    primaryOrSecondary?: string,
+  ): object;
+
+  /**
+   * Refund by amount for a recent payment.
+   * TODO: Add the link to API doc when its updated
+   */
+  static refundByAmount(refundAmount: number): object;
+
+  /**
+   * Refund a payment by a payment log ID.
+   * TODO: Add the link to API doc when its updated
+   */
+  static refundByPaymentLog(paymentLogId: string): object;
+}

--- a/types/Referral/index.d.ts
+++ b/types/Referral/index.d.ts
@@ -1,0 +1,1 @@
+export * from './Referral';


### PR DESCRIPTION
# Description

- [ADDED] Adds new beta billing functionality for ReferralCustomer users
  - `addPaymentMethod` can add a pre-existing Stripe bank account or credit card to your EasyPost account
  - `refundByAmount` refunds your wallet by a dollar amount
  - `refundByPaymentLog` refunds you wallet by a PaymentLog ID
# Testing

Add unit tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
