### PR TITLE
fix: ports the npmignore from v5 to master

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,19 @@
-test
-coverage
-circle.yml
-webpack.config.js
+# This file is written to be an allowlist instead of a disallow. Start by ignoring everything, 
+# then add back the files we want to be included in the final NPM package:
+*
+
+# These are the files that are allowed:
+!/CHANGELOG.md
+!/dist/**/*
+!/LICENSE
+!/package.json
+!/prop_types.js
+!/README.md
+!/src/**/*
+!/types/**/*
+!/UPGRADE_GUIDE.md
+
+# Here we exclude files that we pulled in from above that should be removed
+.DS_Store
+types/.eslintrc
+types/demo


### PR DESCRIPTION
# Description

Ports the npmignore file changes from v5 to master after confirming they worked to greatly reduce the size of our final package while including what was needed.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
