### PR TITLE
update style guide to use eslint:recommended

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,8 +25,7 @@
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
+    "ecmaVersion": 13
   },
   "env": {
     "node": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@easypost/eslint-config-easypost-base",
+    "eslint:recommended",
     "prettier",
     "prettier/@typescript-eslint",
     "prettier/babel",
@@ -20,6 +20,16 @@
     "import/ignore": [".ejs$", ".yml$", ".jsx", "node_modules"]
   },
   "rules": {
-    "lines-between-class-members": "off"
+    "lines-between-class-members": "off",
+    "global-require": "off"
+  },
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "env": {
+    "node": true,
+    "es6": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "watch": "webpack --config webpack.config.babel.js --watch"
   },
   "dependencies": {
+    "@babel/eslint-parser": "^7.19.1",
     "core-js": "~3.27.2",
     "nodent-runtime": "~3.2.1",
     "proptypes": "~1.1.0",
@@ -53,7 +54,6 @@
     "@babel/plugin-transform-react-inline-elements": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/register": "^7.18.9",
-    "@easypost/eslint-config-easypost-base": "~2.2.3",
     "@pollyjs/adapter-node-http": "^6.0.5",
     "@pollyjs/core": "^6.0.5",
     "@pollyjs/persister-fs": "^6.0.5",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@easypost/eslint-config-easypost-base",
+    "eslint:recommended",
     "prettier",
     "prettier/@typescript-eslint",
     "prettier/babel",
@@ -33,10 +33,16 @@
 
     // @easypost/eslint-config-easypost-base assumes all tests are jest. so turn these rules off
     "jest/consistent-test-it": 0,
-    "jest/valid-expect": 0
+    "jest/valid-expect": 0,
+    "global-require": "off"
   },
 
   "globals": {
     "expect": true
+  },
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -42,7 +42,6 @@
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module"
+    "ecmaVersion": 13
   }
 }

--- a/test/helpers/common.js
+++ b/test/helpers/common.js
@@ -3,6 +3,7 @@ import 'core-js/stable';
 import chai from 'chai';
 
 /* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
 process.on('unhandledRejection', (err) => {
   console.error(err, err.stack);
 });


### PR DESCRIPTION
# Description

Removed `@easypost/eslint-config-easypost-base` as it's no longer maintained and is about to get deprecated, replaced the style guide with `eslint:recommended` and set up some basic config.

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
