### PR TITLE
remove validateWebhook in the typescript file

### DIFF
--- a/types/Webhook/Webhook.d.ts
+++ b/types/Webhook/Webhook.d.ts
@@ -90,16 +90,4 @@ export declare class Webhook implements IWebhook {
    * @see https://www.easypost.com/docs/api/node#delete-a-webhook
    */
   static delete(webhookId: string): void;
-
-  /**
-   * Validate a webhook by comparing the HMAC signature header sent from EasyPost to your shared secret.
-   * If the signatures do not match, an error will be raised signifying the webhook either did not originate
-   * from EasyPost or the secrets do not match. If the signatures do match, the `event_body` will be returned
-   * as JSON.
-   *
-   * @param eventBody The event body of the webhook sent from EasyPost.
-   * @param headers The headers of the webhook sent from EasyPost.
-   * @param webhookSecret The local webhook secret that should match what is stored with EasyPost for this webhook.
-   */
-  static validateWebhook(eventBody: Buffer, headers: object, webhookSecret: string): object;
 }


### PR DESCRIPTION
# Description

remove `validateWebhook` in the typescript file because it no longer belongs to `webhook` class

Closes #377 
# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
