### PR TITLE
fix incorrect typescript definitions for multiple classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Adds missing typescript definitions for `Utility` class
+- Fixs incorrect typescript definitions for `Address`, `EndShipper`m and `Webhook` classes methods
 
 ## v6.4.0 (2023-05-02)
 

--- a/types/Address/Address.d.ts
+++ b/types/Address/Address.d.ts
@@ -117,7 +117,7 @@ export declare class Address implements IAddress {
    * @param {Object} params - Parameters for the address to be created.
    * @returns {Address} - The created address.
    */
-  public create(params: Object): Promise<Address>;
+  static create(params: Object): Promise<Address>;
 
   /**
    * Retrieve a list of all Addresses.

--- a/types/EndShipper/EndShipper.d.ts
+++ b/types/EndShipper/EndShipper.d.ts
@@ -92,7 +92,7 @@ export declare class EndShipper implements IEndshipper {
    * @param {Object} params The parameters to create an {@link EndShipper} with.
    * @returns {Promise<EndShipper>} The created and verified {@link EndShipper}.
    */
-  public create(params: Object): Promise<EndShipper>;
+  static create(params: Object): Promise<EndShipper>;
 
   /**
    * An EndShipper object may be updated using the EndShipper API.
@@ -104,7 +104,7 @@ export declare class EndShipper implements IEndshipper {
    * @param params The parameters to update an {@link EndShipper} with.
    * @returns {Promise<EndShipper>} The updated {@link EndShipper}.
    */
-  public update(id: string, params: Object): Promise<EndShipper>;
+  static update(id: string, params: Object): Promise<EndShipper>;
 
   /**
    * Similar to retrieving a list of EndShippers, you can retrieve an individual EndShipper.
@@ -114,7 +114,7 @@ export declare class EndShipper implements IEndshipper {
    * @param id Unique, start with "es_".
    * @returns {Promise<EndShipper>} The retrieved {@link EndShipper}.
    */
-  public retrieve(id: string): Promise<EndShipper>;
+  static retrieve(id: string): Promise<EndShipper>;
 
   /**
    * List the EndShippers that have been created.
@@ -124,7 +124,7 @@ export declare class EndShipper implements IEndshipper {
    * @param params - The parameters to use for the request.
    * @returns {Object} - An object containing a list of {@link EndShipper endshippers} and pagination information.
    */
-  public all(
+  static all(
     params: IEndShipperListParameters,
   ): Promise<{ endshippers: EndShipper[]; has_more: boolean }>;
 }

--- a/types/Webhook/Webhook.d.ts
+++ b/types/Webhook/Webhook.d.ts
@@ -48,7 +48,7 @@ export declare class Webhook implements IWebhook {
    * @param {Object} params The parameters to create an {@link Webhook} with
    * @returns {Promise<Webhook>} The created and verified {@link Webhook}
    */
-  public create(params: Object): Promise<Webhook>;
+  static create(params: Object): Promise<Webhook>;
 
   /**
    * Enables a Webhook that has been disabled. You can also secure your webhook by adding a webhook_secret.


### PR DESCRIPTION
# Description

- Fixs incorrect typescript definitions for `Address`, `EndShipper`m and `Webhook` classes methods

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
