### PR TITLE
import correct `PickupRate` type

### DIFF
--- a/types/Pickup/PickupCreateParameters.d.ts
+++ b/types/Pickup/PickupCreateParameters.d.ts
@@ -1,4 +1,4 @@
-import PickupRate from '../../src/models/pickup_rate';
+import { IPickupRate } from './PickupRate';
 import { Address } from '../Address';
 import { Batch } from '../Batch';
 import { CarrierAccount } from '../Carrier';
@@ -12,7 +12,7 @@ interface BasePickupCreateParameters {
   is_account_address?: boolean | null;
   max_datetime: string;
   min_datetime: string;
-  pickup_rates: PickupRate;
+  pickup_rates: IPickupRate;
   reference?: string | null;
   status: string;
 }


### PR DESCRIPTION
closes #390 

# Description

Instead of importing the `PickupRate` class from the Javascript library, I imported the `IPickupRate` interface from the local `PickupRate.d.ts` declaration files. This fixes the compilation issues described in #390.

# Testing

TypeScript using this package compiles correctly. Like the rest of the types code, this can't be tested.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
