### PR TITLE
Adds request and response hooks to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .nyc_output
 .Spotlight-V100
 .Trashes
+.vscode/
 build.tar.gz
 coverage
 dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.7 (2023-07-12)
+
+- Adds `requestHook` and `responseHook` config options
+
 ## v6.6.1 (2023-06-20)
 
 - Fixes the `pickup_rates` Typescript property of a Pickup

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "regenerator-runtime": "~0.13.11",
         "source-map-support": "~0.5.21",
         "superagent": "~8.0.9",
+        "uuid": "^9.0.0",
         "yargs": "~17.7.2",
         "yargs-parser": "~21.1.1"
       },
@@ -6717,6 +6718,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -9770,10 +9780,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@easypost/api",
   "description": "EasyPost Node Client Library",
-  "version": "6.6.1",
+  "version": "6.7",
   "author": "Easypost Engineering <oss@easypost.com>",
   "homepage": "https://easypost.com",
   "bin": {
@@ -38,6 +38,7 @@
     "regenerator-runtime": "~0.13.11",
     "source-map-support": "~0.5.21",
     "superagent": "~8.0.9",
+    "uuid": "^9.0.0",
     "yargs": "~17.7.2",
     "yargs-parser": "~21.1.1"
   },

--- a/test/services/easypost.test.js
+++ b/test/services/easypost.test.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
 
-import EasyPost from '../../src/easypost';
+import EasyPost, { METHODS } from '../../src/easypost';
 import MissingParameterError from '../../src/errors/general/missing_parameter_error';
+import Fixture from '../helpers/fixture';
 
 /* eslint-disable func-names */
 describe('EasyPost', function () {
@@ -9,6 +10,45 @@ describe('EasyPost', function () {
     expect(() => new EasyPost()).to.throw(
       MissingParameterError,
       'Missing required parameter: API Key.',
+    );
+  });
+
+  it('will log the appropriate values when a request and response hooks are provided', async function () {
+    let requestConfig;
+    const requestHook = (response) => (requestConfig = response);
+    let responseConfig;
+    const responseHook = (response) => (responseConfig = response);
+
+    const client = new EasyPost(process.env.EASYPOST_TEST_API_KEY, {
+      requestHook,
+      responseHook,
+    });
+
+    await client.Address.create(Fixture.caAddress1());
+
+    expect(requestConfig).to.be.an('object');
+    expect(requestConfig.method).to.equal(METHODS.POST);
+    expect(requestConfig.path).to.equal('https://api.easypost.com/v2/addresses');
+    expect(requestConfig.requestHeaders).to.be.an('object');
+    expect(requestConfig.requestHeaders['Content-Type']).to.equal('application/json');
+    expect(requestConfig.requestTimestamp).to.be.a('number');
+    expect(requestConfig.requestUUID).to.be.a('string');
+
+    expect(responseConfig).to.be.an('object');
+    expect(responseConfig.method).to.equal(METHODS.POST);
+    expect(responseConfig.path).to.equal('https://api.easypost.com/v2/addresses');
+    expect(responseConfig.requestHeaders).to.be.an('object');
+    expect(responseConfig.requestHeaders['Content-Type']).to.equal('application/json');
+    expect(responseConfig.requestTimestamp).to.be.a('number');
+    expect(responseConfig.requestUUID).to.be.a('string');
+    expect(responseConfig.httpStatus).to.be.a('number');
+    expect(responseConfig.responseBody).to.be.an('object');
+    expect(responseConfig.responseBody.object).to.equal('Address');
+    expect(responseConfig.responseHeaders).to.be.an('object');
+    expect(responseConfig.responseHeaders['content-type']).to.contain('application/json');
+    expect(responseConfig.responseTimestamp).to.be.a('number');
+    expect(responseConfig.responseTimestamp).to.be.greaterThanOrEqual(
+      responseConfig.requestTimestamp,
     );
   });
 });

--- a/types/EasyPost.d.ts
+++ b/types/EasyPost.d.ts
@@ -16,6 +16,21 @@ import { User } from './User';
 import { Utils } from './Utility';
 import { Webhook } from './Webhook';
 
+export interface IEasyPostRequest {
+  method: 'get' | 'post' | 'put' | 'patch' | 'del';
+  path: string;
+  requestBody: any;
+  requestHeaders: Record<string, any>;
+  requestTimestamp: number;
+  requestUUID: string;
+}
+export interface IEasyPostResponse extends IEasyPostRequest {
+  httpStatus: number;
+  responseBody: any;
+  responseHeaders: Record<string, any>;
+  responseTimestamp: number;
+}
+
 export interface IEasyPostOptions {
   /**
    * Time in milliseconds that should fail requests.
@@ -44,6 +59,18 @@ export interface IEasyPostOptions {
    * Useful if you need to hook into a request:
    */
   requestMiddleware?: (request: any) => any;
+
+  /**
+   * Function that provides information about the current outgoing request.
+   * Useful for logging or debugging.
+   */
+  requestHook?: (request: IEasyPostRequest) => void;
+
+  /**
+   * Function that provides information about the current outgoing response.
+   * Useful for logging or debugging.
+   */
+  responseHook?: (response: IEasyPostResponse) => void;
 }
 
 export default class EasyPost {


### PR DESCRIPTION
# Description

Adds config options for an optional `requestHook` and `responseHook`. These functions provide various useful debugging values, outlined in the `.d.ts`

```ts
export interface IEasyPostRequest {
  method: 'get' | 'post' | 'put' | 'patch' | 'del';
  path: string;
  requestBody: any;
  requestHeaders: Record<string, any>;
  requestTimestamp: number;
  requestUUID: string;
}
export interface IEasyPostResponse extends IEasyPostRequest {
  httpStatus: number;
  responseBody: any;
  responseHeaders: Record<string, any>;
  responseTimestamp: number;
}
```

# Testing

I added a unit test to make sure when providing hooks, that the values are set to somewhat what we would expect them to be.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
