### PR TITLE
[fix] FedEx SmartPost hits register endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix endpoint for creating a FedEx Smartpost carrier account
+
 ## v6.7.2 (2023-08-09)
 
 - Corrects the Typescript definition for `lowestRate` of Shipment, Order, and Pickup objects

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,7 +5,7 @@ import Utils from './utils/util';
  */
 export default class Constants {
   static get CARRIER_ACCOUNTS_WITH_CUSTOM_WORKFLOWS() {
-    return ['FedexAccount', 'UpsAccount'];
+    return ['FedexAccount', 'FedexSmartpostAccount', 'UpsAccount'];
   }
   static EXTERNAL_API_CALL_FAILED = 'Communication with %s failed, please try again later';
   static INVALID_API_KEY_TYPE = 'Invalid API key type.';


### PR DESCRIPTION
# Description

- FedEx SmartPost carrier account registration should hit `/register` endpoint for creation

# Testing

<!-- 
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
