### PR TITLE
Fix docstring for apiKeys method

### DIFF
--- a/src/services/user_service.js
+++ b/src/services/user_service.js
@@ -125,7 +125,7 @@ export default (easypostClient) =>
      * Retrieve API Keys for a specified {@link User user}.
      * See {@link https://www.easypost.com/docs/api/node#retrieve-an-api-key EasyPost API Documentation} for more information.
      * @param {string} id - The ID of the user to retrieve keys for.
-     * @returns {Array[ApiKey]} - List of associated API Keys.
+     * @returns {Array} - List of associated API Keys.
      * @throws {FilteringError} If user or API Keys are not found.
      */
     static async apiKeys(id) {


### PR DESCRIPTION
# Description

There was an error in the docstring for `apiKeys` that prevents docs generation to happen. This fixes it.

# Testing

`make docs` now succeeds

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
