### PR TITLE
Fix incorrect types

### DIFF
--- a/types/Address/Address.d.ts
+++ b/types/Address/Address.d.ts
@@ -36,7 +36,7 @@ export declare interface IAddress extends IObjectWithId<'Address'> {
   /**
    * ZIP or postal code the address is located in
    */
-  zip: string;
+  zip?: string;
 
   /**
    * ISO 3166 country code for the country the address is located in
@@ -99,7 +99,7 @@ export declare class Address implements IAddress {
   street2?: string | null;
   city?: string | null;
   state?: string | null;
-  zip: string;
+  zip?: string;
   country: string;
   residential?: boolean | null;
   carrier_facility?: string | null;

--- a/types/Shipment/ShipmentCreateParameters.d.ts
+++ b/types/Shipment/ShipmentCreateParameters.d.ts
@@ -15,6 +15,19 @@ export declare interface IShipmentCreateParameters {
    */
   carrier_accounts?: string[] | null;
 
+  /**
+   * Optional service name to create one-call-buy shipment
+   */
+  service?: string | null;
+
+  tax_identifiers?: TaxIdentifier[] | null
   customs_info?: DeepPartial<ICustomsInfo> | null;
   options?: DeepPartial<IOptions> | null;
+}
+
+type TaxIdentifier = {
+    entity: "SENDER" | "RECIPIENT"
+    tax_id: string,
+    tax_id_type: string;
+    issuing_country: string
 }


### PR DESCRIPTION
I made zip optional in IAddressCreateParameters since a zip code is not required in many countries.  Also added optional service and tax_identifiers to IShipmentCreateParameteres to enable one-call buys.