### PR TITLE
[bug] Cannot determine payment method when funding/deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix payment method funding and deletion failures due to undetermined payment method type
+
 ## v7.2.0 (2024-01-22)
 
 - Adds missing exports to Typescript definitions (ApiKey, Billing, Brand, EndShipper, Fee, PaymentMethod, Rate, Refund) - closes #433

--- a/src/services/billing_service.js
+++ b/src/services/billing_service.js
@@ -73,14 +73,16 @@ export default (easypostClient) =>
 
       const paymentMethodToUse = paymentMethodMap[priority];
       let paymentMethodID;
+      let paymentMethodObjectType;
       let endpoint;
       const errorString = 'The chosen payment method is not valid. Please try again.';
 
       if (paymentMethodToUse !== undefined && paymentMethods[paymentMethodToUse] !== null) {
         paymentMethodID = paymentMethods[paymentMethodToUse].id;
-        if (paymentMethodID.startsWith('card_')) {
+        paymentMethodObjectType = paymentMethods[paymentMethodToUse].object;
+        if (paymentMethodID.startsWith('card_') || paymentMethodObjectType === 'CreditCard') {
           endpoint = 'credit_cards';
-        } else if (paymentMethodID.startsWith('bank_')) {
+        } else if (paymentMethodID.startsWith('bank_') || paymentMethodObjectType === 'BankAccount') {
           endpoint = 'bank_accounts';
         } else {
           throw new InvalidObjectError({ message: errorString });

--- a/src/services/billing_service.js
+++ b/src/services/billing_service.js
@@ -82,7 +82,10 @@ export default (easypostClient) =>
         paymentMethodObjectType = paymentMethods[paymentMethodToUse].object;
         if (paymentMethodID.startsWith('card_') || paymentMethodObjectType === 'CreditCard') {
           endpoint = 'credit_cards';
-        } else if (paymentMethodID.startsWith('bank_') || paymentMethodObjectType === 'BankAccount') {
+        } else if (
+          paymentMethodID.startsWith('bank_') ||
+          paymentMethodObjectType === 'BankAccount'
+        ) {
           endpoint = 'bank_accounts';
         } else {
           throw new InvalidObjectError({ message: errorString });

--- a/test/services/billing.test.js
+++ b/test/services/billing.test.js
@@ -87,22 +87,23 @@ describe('Billing Service', function () {
       requestMiddleware: (request) => {
         return new MockMiddleware(request, [
           new MockRequest(
-              new MockRequestMatchRule('GET', 'v2\\/payment_methods$'),
-              new MockRequestResponseInfo(200, {
-                id: 'summary_123',
-                primary_payment_method: {
-                  id: 'card_123',
-                  last4: '1234',
-                  // No object field, force use of id prefix to determine type
-                },
-                secondary_payment_method: {
-                  id: 'bank_123',
-                  bank_name: 'Mock Bank',
-                  // No object field, force use of id prefix to determine type
-                },
-              }),
+            new MockRequestMatchRule('GET', 'v2\\/payment_methods$'),
+            new MockRequestResponseInfo(200, {
+              id: 'summary_123',
+              primary_payment_method: {
+                id: 'card_123',
+                last4: '1234',
+                // No object field, force use of id prefix to determine type
+              },
+              secondary_payment_method: {
+                id: 'bank_123',
+                bank_name: 'Mock Bank',
+                // No object field, force use of id prefix to determine type
+              },
+            }),
           ),
-        ])}
+        ]);
+      },
     });
 
     const paymentInfo = await this.client.Billing._getPaymentInfo('primary');

--- a/test/services/billing.test.js
+++ b/test/services/billing.test.js
@@ -81,4 +81,36 @@ describe('Billing Service', function () {
 
     expect(paymentInfo2).to.deep.equal(['bank_accounts', 'pm_123']);
   });
+
+  it('get payment info with legacy prefix', async function () {
+    this.client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY, {
+      requestMiddleware: (request) => {
+        return new MockMiddleware(request, [
+          new MockRequest(
+              new MockRequestMatchRule('GET', 'v2\\/payment_methods$'),
+              new MockRequestResponseInfo(200, {
+                id: 'summary_123',
+                primary_payment_method: {
+                  id: 'card_123',
+                  last4: '1234',
+                  // No object field, force use of id prefix to determine type
+                },
+                secondary_payment_method: {
+                  id: 'bank_123',
+                  bank_name: 'Mock Bank',
+                  // No object field, force use of id prefix to determine type
+                },
+              }),
+          ),
+        ])}
+    });
+
+    const paymentInfo = await this.client.Billing._getPaymentInfo('primary');
+
+    expect(paymentInfo).to.deep.equal(['credit_cards', 'card_123']);
+
+    const paymentInfo2 = await this.client.Billing._getPaymentInfo('secondary');
+
+    expect(paymentInfo2).to.deep.equal(['bank_accounts', 'bank_123']);
+  });
 });

--- a/test/services/billing.test.js
+++ b/test/services/billing.test.js
@@ -32,12 +32,14 @@ const middleware = (request) => {
       new MockRequestResponseInfo(200, {
         id: 'summary_123',
         primary_payment_method: {
-          id: 'card_123',
+          id: 'pm_123',
           last4: '1234',
+          object: 'CreditCard',
         },
         secondary_payment_method: {
-          id: 'bank_123',
+          id: 'pm_123',
           bank_name: 'Mock Bank',
+          object: 'BankAccount',
         },
       }),
     ),
@@ -68,5 +70,15 @@ describe('Billing Service', function () {
 
     expect(paymentMethods.primary_payment_method).to.exist;
     expect(paymentMethods.secondary_payment_method).to.exist;
+  });
+
+  it('get payment info', async function () {
+    const paymentInfo = await this.client.Billing._getPaymentInfo('primary');
+
+    expect(paymentInfo).to.deep.equal(['credit_cards', 'pm_123']);
+
+    const paymentInfo2 = await this.client.Billing._getPaymentInfo('secondary');
+
+    expect(paymentInfo2).to.deep.equal(['bank_accounts', 'pm_123']);
   });
 });


### PR DESCRIPTION
# Description

Newer payment method objects have `pm_` prefixes for their IDs rather than `card_` or `bank_`, meaning we can no longer rely on the prefix to determine the payment method type (to determine the endpoint needed for funding and deleting a payment method).

This now falls back to the `object` key ("CreditCard" or "BankAccount") to determine the payment method type.

# Testing

- Unit tests for funding and deleting payment methods are mocked, so we can't test this E2E.
  - Add unit test to confirm switch-case working for type determination when prefix is `pm_`

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
