### PR TITLE
[chore] Add Node 22 check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x, 21.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: make install
       - run: make install-styleguide
       - run: make build
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - run: make install
       - run: make install-styleguide
       - run: make build
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Install Dependencies
         run: make install
       - name: Generate Docs

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,12 +1,25 @@
 {
   "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
-  "critical": true, // Only fail the audit if there are critical vulnerabilities.
+  "critical": true,
+  // Only fail the audit if there are critical vulnerabilities.
   "allowlist": [
     {
       "GHSA-8cp3-66vr-3r4c": {
         "active": true,
-        "expiry": "2024-10-22", // Re-evaluate this vulnerability after this date.
-        "notes": "Transitive dependency of `superagent`, awaiting new `superagent` release." // https://github.com/ladjs/superagent/issues/1799
+        "expiry": "2024-10-22",
+        // Re-evaluate this vulnerability after this date.
+        "notes": "Transitive dependency of `superagent`, awaiting new `superagent` release."
+        // https://github.com/ladjs/superagent/issues/1799
+        // Vulnerability fix only available in `superagent@9.0.0+`: Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight.
+      }
+    },
+    {
+      "GHSA-grv7-fg5c-xmjg|braces": {
+        "active": true,
+        "expiry": "2024-12-22", // Re-evaluate this vulnerability after this date.
+        "notes": "Transitive dependency of `chokidar` and `micromatch`"
+        // (`braces` -> `chokidar` -> `mocha`), chokidar unlikely to get patched: https://github.com/paulmillr/chokidar/issues/1301, mocha maintenance questionable: https://github.com/mochajs/mocha/issues/5027
+        // (`braces` -> `micromatch` -> `fast-glob` -> `globby` -> `typescript-eslint/typescript-estree`), micromatch is patched, but fast-glob not maintained: https://github.com/mrmlnc/fast-glob/issues/443
       }
     }
   ]


### PR DESCRIPTION
# Description

- Add Node 22 to CI compatibility matrix
- Test all Node versions, not just LTS
- Suppress warning for transitive vulnerability: https://github.com/advisories/GHSA-grv7-fg5c-xmjg

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
