### PR TITLE
Cleans up tests a little bit

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,5 @@
+{
+  "timeout": 10000,
+  "require": ["@babel/register", "dotenv/config", "./test/helpers/common.js"],
+  "recursive": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "chai": "4.3.10",
         "chai-as-promised": "^7.1.1",
         "cross-env": "^7.0.3",
+        "dotenv": "^16.4.5",
         "eslint": "^8.40.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-import-resolver-webpack": "^0.13.2",
@@ -4163,6 +4164,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer": {

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "lint": "eslint --ext .js,.ts .",
     "lintFix": "eslint --ext .js,.ts --fix .",
     "prepublishOnly": "npm run clean && npm run build && npm run test && npm run lint && npm run formatCheck",
-    "repl": "./repl.js --local easypost.js",
+    "repl": "./repl.js --local ./dist/easypost.js",
     "scan": "npx audit-ci -m --config ./audit-ci.jsonc",
-    "test": "cross-env NODE_ENV=test mocha --timeout 10000 --require @babel/register --require ./test/helpers/common.js --recursive ./test",
+    "test": "cross-env NODE_ENV=test mocha",
     "watch": "webpack --config webpack.config.babel.js --watch"
   },
   "dependencies": {
@@ -65,6 +65,7 @@
     "chai": "4.3.10",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^7.0.3",
+    "dotenv": "^16.4.5",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-import-resolver-webpack": "^0.13.2",


### PR DESCRIPTION
# Description

This adds support for environment variables in the `.env` when running tests, and adds a `mocharc.json` file to hold the mocha commands. 

I just added a requirement on the `dotenv` package, the standard Node.js package for reading .env files, and moved the command line flags from the package.json into a mocharc.json file.

This solves the issues of like:
- Its been months since I worked on this, what were my API keys again?
- I need to pass 3 env variables to the tests, and now my command is like 3 lines tall in the terminal

Also fixes the repl command, since that was pointing to a file that didn't exist.

# Testing

This is a change to the testing suite itself, so if the tests pass, this is tested, I guess?

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
