### PR TITLE
fix: webhook validation when float weight field is present (closes #467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fixes webhook validation when the `weight` field contains a float by converting it back into a float after conversion from a string (closes #467)
+
 ## v7.5.1 (2024-08-09)
 
 - Adds missing properties to `Rate` model

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -123,7 +123,7 @@ export default class Utils {
       // Fixes Javascript's float to string conversion. See https://github.com/EasyPost/easypost-node/issues/467
       const correctedEventBody = Buffer.from(eventBody)
         .toString('utf8')
-        .replace(/("weight":)(\d+)(?!\.\d)/g, '$1$2.0');
+        .replace(/("weight":\s*)(\d+)(\s*)(?=,|\})/g, '$1$2.0');
 
       const expectedSignature = crypto
         .createHmac('sha256', encodedSecret)

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -120,9 +120,14 @@ export default class Utils {
       const normalizedSecret = webhookSecret.normalize('NFKD');
       const encodedSecret = Buffer.from(normalizedSecret, 'utf8');
 
+      // Fixes Javascript's float to string conversion. See https://github.com/EasyPost/easypost-node/issues/467
+      const correctedEventBody = Buffer.from(eventBody)
+        .toString('utf8')
+        .replace(/("weight":)(\d+)(?!\.\d)/g, '$1$2.0');
+
       const expectedSignature = crypto
         .createHmac('sha256', encodedSecret)
-        .update(eventBody, 'utf-8')
+        .update(correctedEventBody, 'utf-8')
         .digest('hex');
 
       const digest = `hmac-sha256-hex=${expectedSignature}`;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -139,7 +139,7 @@ export default class Utils {
             Buffer.from(digest, 'utf8'),
           )
         ) {
-          webhook = JSON.parse(eventBody.toString());
+          webhook = JSON.parse(correctedEventBody);
         } else {
           throw new SignatureVerificationError({ message: Constants.WEBHOOK_DOES_NOT_MATCH });
         }

--- a/test/helpers/fixture.js
+++ b/test/helpers/fixture.js
@@ -42,10 +42,6 @@ export default class Fixture {
     return '2022-04-11';
   }
 
-  static webhookUrl() {
-    return this.readFixtureData().webhook_url;
-  }
-
   static caAddress1() {
     return this.readFixtureData().addresses.ca_address_1;
   }
@@ -141,6 +137,18 @@ export default class Fixture {
     );
 
     return Buffer.from(JSON.stringify(eventBody), 'utf8');
+  }
+
+  static webhookHmacSignature() {
+    return this.readFixtureData().webhook_hmac_signature;
+  }
+
+  static webhookSecret() {
+    return this.readFixtureData().webhook_secret;
+  }
+
+  static webhookUrl() {
+    return this.readFixtureData().webhook_url;
   }
 
   static plannedShipDate() {

--- a/test/services/webhook.test.js
+++ b/test/services/webhook.test.js
@@ -98,9 +98,7 @@ describe('Webhook Service', function () {
     );
 
     expect(webhookBody.description).to.equal('tracker.updated');
-    // JS converts this from `136.0` in the response to `136` on the user's end which is unfortunate; however, we
-    // compare signatures with the correct number prior to JSON parsing it and returning it to the user.
-    expect(webhookBody.result.weight).to.equal(136.0);
+    expect(webhookBody.result.weight).to.equal(614.4); // Ensure we convert floats properly
   });
 
   it('throws an error when a webhook secret is a differing length', function () {

--- a/test/services/webhook.test.js
+++ b/test/services/webhook.test.js
@@ -98,6 +98,9 @@ describe('Webhook Service', function () {
     );
 
     expect(webhookBody.description).to.equal('tracker.updated');
+    // JS converts this from `136.0` in the response to `136` on the user's end which is unfortunate; however, we
+    // compare signatures with the correct number prior to JSON parsing it and returning it to the user.
+    expect(webhookBody.result.weight).to.equal(136.0);
   });
 
   it('throws an error when a webhook secret is a differing length', function () {

--- a/test/services/webhook.test.js
+++ b/test/services/webhook.test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 
 import EasyPostClient from '../../src/easypost';
+import SignatureVerificationError from '../../src/errors/general/signature_verification_error';
 import Webhook from '../../src/models/webhook';
 import Fixture from '../helpers/fixture';
-import SignatureVerificationError from '../../src/errors/general/signature_verification_error';
 import * as setupPolly from '../helpers/setup_polly';
 import { withoutParams } from '../helpers/utils';
 
@@ -87,20 +87,17 @@ describe('Webhook Service', function () {
   });
 
   it('validates a webhook secret', function () {
-    const webhookSecret = 'sécret';
-    const expectedHmacSignature =
-      'hmac-sha256-hex=e93977c8ccb20363d51a62b3fe1fc402b7829be1152da9e88cf9e8d07115a46b';
     const headers = {
-      'X-Hmac-Signature': expectedHmacSignature,
+      'X-Hmac-Signature': Fixture.webhookHmacSignature(),
     };
 
     const webhookBody = this.client.Utils.validateWebhook(
       Fixture.eventBody(),
       headers,
-      webhookSecret,
+      Fixture.webhookSecret(),
     );
 
-    expect(webhookBody.description).to.equal('batch.created');
+    expect(webhookBody.description).to.equal('tracker.updated');
   });
 
   it('throws an error when a webhook secret is a differing length', function () {


### PR DESCRIPTION
# Description

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

When the `weight` field is present on a webhook (eg: tracking update), it gets converted but JS drops the decimal if `.0` which often is the case. This breaks webhook validation because HMAC signatures won't match if it's altered at all. This properly puts back the `.0` if necessary and missing to ensure that validation will continue to work. Tests validate that we properly compare the signatures

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
