### PR TITLE
[fix] Outdated TypeScript definition for Shipment buy function

### DIFF
--- a/test/cassettes/Shipment-Service_2987889512/buys-a-shipment-with-end_shipper_id_3098977158/recording.har
+++ b/test/cassettes/Shipment-Service_2987889512/buys-a-shipment-with-end_shipper_id_3098977158/recording.har
@@ -36,7 +36,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 394,
+          "headersSize": 393,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -48,12 +48,12 @@
           "url": "https://api.easypost.com/v2/end_shippers"
         },
         "response": {
-          "bodySize": 383,
+          "bodySize": 376,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 383,
-            "text": "{\"id\":\"es_96c715104d8848bab91512b908604f96\",\"object\":\"EndShipper\",\"mode\":\"test\",\"created_at\":\"2024-07-30T16:12:25+00:00\",\"updated_at\":\"2024-07-30T16:12:25+00:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\"}"
+            "size": 376,
+            "text": "{\"id\":\"es_6fd4458bb11b4f1f894e4045be978e04\",\"object\":\"EndShipper\",\"mode\":\"test\",\"created_at\":\"2024-09-27T23:37:15+00:00\",\"updated_at\":\"2024-09-27T23:37:15+00:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\"}"
           },
           "cookies": [],
           "headers": [
@@ -83,7 +83,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "6107a17066a910e9e2b87c1d0035737b"
+              "value": "d40d1bb466f741abe1763dd8009a5a7e"
             },
             {
               "name": "cache-control",
@@ -103,7 +103,7 @@
             },
             {
               "name": "x-runtime",
-              "value": "0.052315"
+              "value": "0.086366"
             },
             {
               "name": "content-encoding",
@@ -115,11 +115,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb33nuq"
+              "value": "bigweb34nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202407300015-6e288fe720-master"
+              "value": "easypost-202409271855-d9784f7bfb-master"
             },
             {
               "name": "x-backend",
@@ -127,7 +127,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq c0f5e722d1, extlb2nuq fa152d4755"
+              "value": "intlb3nuq b6e1b5034c, extlb1nuq b6e1b5034c"
             },
             {
               "name": "strict-transport-security",
@@ -144,8 +144,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-07-30T16:12:25.754Z",
-        "time": 377,
+        "startedDateTime": "2024-09-27T23:37:15.343Z",
+        "time": 261,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -153,7 +153,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 377
+          "wait": 261
         }
       },
       {
@@ -185,7 +185,7 @@
               "value": "api.easypost.com"
             }
           ],
-          "headersSize": 391,
+          "headersSize": 390,
           "httpVersion": "HTTP/1.1",
           "method": "POST",
           "postData": {
@@ -197,12 +197,12 @@
           "url": "https://api.easypost.com/v2/shipments"
         },
         "response": {
-          "bodySize": 1430,
+          "bodySize": 1439,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 1430,
-            "text": "{\"created_at\":\"2024-07-30T16:12:26Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2024-07-30T16:12:26Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_831334574e8e11ef8bc93cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_455e724f26ba4511b20511350591dc36\",\"object\":\"Parcel\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_eb540de7c41e4301a1da0c9aef738a25\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"33.10\",\"currency\":\"USD\",\"retail_rate\":\"37.90\",\"retail_currency\":\"USD\",\"list_rate\":\"33.10\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6ccb43bdf61c41f5a1d4062c69b00d6c\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"6.90\",\"currency\":\"USD\",\"retail_rate\":\"9.80\",\"retail_currency\":\"USD\",\"list_rate\":\"8.25\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_45fb23b6e5f0435698dfd00a714a3f98\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_83109e924e8e11ef9057ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_831334574e8e11ef8bc93cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_83109e924e8e11ef9057ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"object\":\"Shipment\"}"
+            "size": 1439,
+            "text": "{\"id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"created_at\":\"2024-09-27T23:37:16Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2024-09-27T23:37:16Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_6dbcec377d2911efb3ecac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:16+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_f729467d16f04f93af4b7043ede66a30\",\"object\":\"Parcel\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_f5eba08193924c10b01077ca601c2108\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"6.90\",\"currency\":\"USD\",\"retail_rate\":\"9.80\",\"retail_currency\":\"USD\",\"list_rate\":\"8.25\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_44bf232fbc82435883423489a3df187f\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6abc5aab22c84a45ba81537726c19485\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"33.10\",\"currency\":\"USD\",\"retail_rate\":\"37.90\",\"retail_currency\":\"USD\",\"list_rate\":\"33.10\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_6db9e27b7d2911ef8190ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:15+00:00\",\"updated_at\":\"2024-09-27T23:37:15+00:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_6dbcec377d2911efb3ecac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:16+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_6db9e27b7d2911ef8190ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:15+00:00\",\"updated_at\":\"2024-09-27T23:37:15+00:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -232,7 +232,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "6107a16c66a910eae2b87c1e003573d5"
+              "value": "d40d1bb766f741abf03d53ad009a5a98"
             },
             {
               "name": "cache-control",
@@ -248,7 +248,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_bfdaf6ccca0245b6b37befd97be761db"
+              "value": "/api/v2/shipments/shp_7c70046a250c4451b6d3853a22949388"
             },
             {
               "name": "content-type",
@@ -256,7 +256,7 @@
             },
             {
               "name": "x-runtime",
-              "value": "0.341730"
+              "value": "0.268944"
             },
             {
               "name": "content-encoding",
@@ -268,11 +268,11 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb35nuq"
+              "value": "bigweb34nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202407300015-6e288fe720-master"
+              "value": "easypost-202409271855-d9784f7bfb-master"
             },
             {
               "name": "x-backend",
@@ -280,7 +280,7 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq c0f5e722d1, extlb2nuq fa152d4755"
+              "value": "intlb3nuq b6e1b5034c, extlb1nuq b6e1b5034c"
             },
             {
               "name": "strict-transport-security",
@@ -293,12 +293,12 @@
           ],
           "headersSize": 776,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_bfdaf6ccca0245b6b37befd97be761db",
+          "redirectURL": "/api/v2/shipments/shp_7c70046a250c4451b6d3853a22949388",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2024-07-30T16:12:26.139Z",
-        "time": 449,
+        "startedDateTime": "2024-09-27T23:37:15.608Z",
+        "time": 400,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -306,15 +306,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 449
+          "wait": 400
         }
       },
       {
-        "_id": "12bfb65799cd95e52b8a0fdd1fe1b370",
+        "_id": "89716a5249e28bab8b172ab66a07fe68",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 55,
+          "bodySize": 110,
           "cookies": [],
           "headers": [
             {
@@ -331,7 +331,7 @@
             },
             {
               "name": "content-length",
-              "value": 55
+              "value": 110
             },
             {
               "name": "host",
@@ -344,18 +344,18 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_45fb23b6e5f0435698dfd00a714a3f98\"}}"
+            "text": "{\"rate\":{\"id\":\"rate_44bf232fbc82435883423489a3df187f\"},\"end_shipper_id\":\"es_6fd4458bb11b4f1f894e4045be978e04\"}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_bfdaf6ccca0245b6b37befd97be761db/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_7c70046a250c4451b6d3853a22949388/buy"
         },
         "response": {
-          "bodySize": 2207,
+          "bodySize": 2200,
           "content": {
             "encoding": "base64",
             "mimeType": "application/json; charset=utf-8",
-            "size": 2207,
-            "text": "{\"created_at\":\"2024-07-30T16:12:26Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100110368068953525\",\"updated_at\":\"2024-07-30T16:12:27Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_831334574e8e11ef8bc93cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_455e724f26ba4511b20511350591dc36\",\"object\":\"Parcel\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_74e130986a44452a93dda9257826470c\",\"created_at\":\"2024-07-30T16:12:27Z\",\"updated_at\":\"2024-07-30T16:12:27Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2024-07-30T16:12:27Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20240730/e8f9a36b4e1003461281596ec29bb5c0d6.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_eb540de7c41e4301a1da0c9aef738a25\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"33.10\",\"currency\":\"USD\",\"retail_rate\":\"37.90\",\"retail_currency\":\"USD\",\"list_rate\":\"33.10\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6ccb43bdf61c41f5a1d4062c69b00d6c\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"6.90\",\"currency\":\"USD\",\"retail_rate\":\"9.80\",\"retail_currency\":\"USD\",\"list_rate\":\"8.25\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_45fb23b6e5f0435698dfd00a714a3f98\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:26Z\",\"updated_at\":\"2024-07-30T16:12:26Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_45fb23b6e5f0435698dfd00a714a3f98\",\"object\":\"Rate\",\"created_at\":\"2024-07-30T16:12:27Z\",\"updated_at\":\"2024-07-30T16:12:27Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_ab346939cd0d4670abf22cb86d593e20\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100110368068953525\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2024-07-30T16:12:27Z\",\"updated_at\":\"2024-07-30T16:12:27Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2FiMzQ2OTM5Y2QwZDQ2NzBhYmYyMmNiODZkNTkzZTIw\"},\"to_address\":{\"id\":\"adr_83109e924e8e11ef9057ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_831334574e8e11ef8bc93cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_83109e924e8e11ef9057ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-07-30T16:12:26+00:00\",\"updated_at\":\"2024-07-30T16:12:26+00:00\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.93000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_bfdaf6ccca0245b6b37befd97be761db\",\"object\":\"Shipment\"}"
+            "size": 2200,
+            "text": "{\"id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"created_at\":\"2024-09-27T23:37:16Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100208271094511512\",\"updated_at\":\"2024-09-27T23:37:17Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_6dbcec377d2911efb3ecac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:16+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"50.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_f729467d16f04f93af4b7043ede66a30\",\"object\":\"Parcel\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_25dfe97f6ff6426797b5592c4dbd1338\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:17Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2024-09-27T23:37:16Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20240927/e80098262b04034463a2630bfaa34cc481.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_f5eba08193924c10b01077ca601c2108\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"6.90\",\"currency\":\"USD\",\"retail_rate\":\"9.80\",\"retail_currency\":\"USD\",\"list_rate\":\"8.25\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_44bf232fbc82435883423489a3df187f\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_6abc5aab22c84a45ba81537726c19485\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"33.10\",\"currency\":\"USD\",\"retail_rate\":\"37.90\",\"retail_currency\":\"USD\",\"list_rate\":\"33.10\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_44bf232fbc82435883423489a3df187f\",\"object\":\"Rate\",\"created_at\":\"2024-09-27T23:37:16Z\",\"updated_at\":\"2024-09-27T23:37:16Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"5.93\",\"currency\":\"USD\",\"retail_rate\":\"8.45\",\"retail_currency\":\"USD\",\"list_rate\":\"6.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":3,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":3,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_5bac50573c65468fbbcd7373124103da\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208271094511512\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2024-09-27T23:37:17Z\",\"updated_at\":\"2024-09-27T23:37:17Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_7c70046a250c4451b6d3853a22949388\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzViYWM1MDU3M2M2NTQ2OGZiYmNkNzM3MzEyNDEwM2Rh\"},\"to_address\":{\"id\":\"adr_6db9e27b7d2911ef8190ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:15+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_6dbcec377d2911efb3ecac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:16+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_6db9e27b7d2911ef8190ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-09-27T23:37:15+00:00\",\"updated_at\":\"2024-09-27T23:37:16+00:00\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8436,\"longitude\":-118.39177,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.93000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"0.50000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -385,7 +385,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "6107a16e66a910eae2b87c360035743f"
+              "value": "d40d1bb966f741acf04efd70009a5adc"
             },
             {
               "name": "cache-control",
@@ -405,7 +405,7 @@
             },
             {
               "name": "x-runtime",
-              "value": "0.967063"
+              "value": "0.970144"
             },
             {
               "name": "content-encoding",
@@ -417,23 +417,19 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb43nuq"
+              "value": "bigweb42nuq"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202407300015-6e288fe720-master"
+              "value": "easypost-202409271855-d9784f7bfb-master"
             },
             {
               "name": "x-backend",
               "value": "easypost"
             },
             {
-              "name": "x-canary",
-              "value": "direct"
-            },
-            {
               "name": "x-proxied",
-              "value": "intlb4nuq c0f5e722d1, extlb2nuq fa152d4755"
+              "value": "intlb3nuq b6e1b5034c, extlb1nuq b6e1b5034c"
             },
             {
               "name": "strict-transport-security",
@@ -444,14 +440,14 @@
               "value": "close"
             }
           ],
-          "headersSize": 728,
+          "headersSize": 710,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2024-07-30T16:12:26.593Z",
-        "time": 1070,
+        "startedDateTime": "2024-09-27T23:37:16.014Z",
+        "time": 1094,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -459,7 +455,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1070
+          "wait": 1094
         }
       }
     ],

--- a/test/services/shipment.test.js
+++ b/test/services/shipment.test.js
@@ -314,7 +314,6 @@ describe('Shipment Service', function () {
       shipment.id,
       shipment.lowestRate(),
       null,
-      null,
       endShipper.id,
     );
 

--- a/types/Shipment/Shipment.d.ts
+++ b/types/Shipment/Shipment.d.ts
@@ -245,7 +245,12 @@ export declare class Shipment implements IShipment {
    * @param endShipperId The ID of the end shipper to purchase the shipment with.
    * @returns {Promise<Shipment>} The created {@link Shipment}.
    */
-  static buy(id: string, rate: string | IRate, insuranceAmount?: number, endShipperId?: string): Promise<Shipment>;
+  static buy(
+    id: string,
+    rate: string | IRate,
+    insuranceAmount?: number,
+    endShipperId?: string,
+  ): Promise<Shipment>;
 
   /**
    * Refunding a Shipment is available for many carriers supported by EasyPost.

--- a/types/Shipment/Shipment.d.ts
+++ b/types/Shipment/Shipment.d.ts
@@ -242,9 +242,10 @@ export declare class Shipment implements IShipment {
    * @param id shipment id (begins with "shp_").
    * @param rate rate id (begins with "rate_") or rate object.
    * @param insuranceAmount amount to insure the shipment for.
+   * @param endShipperId The ID of the end shipper to purchase the shipment with.
    * @returns {Promise<Shipment>} The created {@link Shipment}.
    */
-  static buy(id: string, rate: string | IRate, insuranceAmount?: number): Promise<Shipment>;
+  static buy(id: string, rate: string | IRate, insuranceAmount?: number, endShipperId?: string): Promise<Shipment>;
 
   /**
    * Refunding a Shipment is available for many carriers supported by EasyPost.


### PR DESCRIPTION
# Description

- Fix outdated TypeScript definition for Shipment buy function, account for EndShipper ID
- Fix unit test for Shipment buy with EndShipper that wasn't passing variables properly

Closes #478 

# Testing

- Re-recorded cassette for Shipment buy with EndShipper

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
