### PR TITLE
Makes esm and cjs build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/easypost.js');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,16 @@
   "version": "7.5.5",
   "author": "Easypost Engineering <oss@easypost.com>",
   "homepage": "https://easypost.com",
+  "exports": {
+    ".": {
+      "import": "./dist/easypost.mjs",
+      "require": "./dist/easypost.js",
+      "types": "./types/index.d.ts"
+    }
+  },
+  "main": "./dist/easypost.js",
+  "module": "./dist/easypost.mjs",
+  "types": "./types/index.d.ts",
   "bin": {
     "easypost": "./repl.js"
   },
@@ -11,8 +21,6 @@
     "type": "git",
     "url": "git://github.com/easypost/easypost-node.git"
   },
-  "main": "index.js",
-  "types": "types/index.d.ts",
   "license": "MIT",
   "engines": {
     "node": ">= 16.0"

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,14 +12,21 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/easypost.js'),
       fileName: 'easypost',
-      formats: ['cjs'],
+      formats: ['cjs', 'es'],
     },
     sourcemap: isDev,
     rollupOptions: {
       external: [/^node:.*/, /^@?[a-zA-Z\-_]+\/?[a-zA-Z\-_]*$/],
-      output: {
-        dir: 'dist',
-      },
+      output: [
+        {
+          format: 'cjs',
+          entryFileNames: '[name].js',
+        },
+        {
+          format: 'esm',
+          entryFileNames: '[name].mjs',
+        },
+      ],
     },
   },
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -21,10 +21,12 @@ export default defineConfig({
         {
           format: 'cjs',
           entryFileNames: '[name].js',
+          dir: 'dist',
         },
         {
           format: 'esm',
           entryFileNames: '[name].mjs',
+          dir: 'dist',
         },
       ],
     },


### PR DESCRIPTION
# Description

This adds an ESM build alongside a CJS build, so projects that are not CJS or are `"type": "module"` can use the project now.

I believe this should fix #446

# Testing

I made a separate Next.js 15 app and tried to install and use the project. I confirmed that it did not work. After these changes, it started working. 

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
