### PR TITLE
Remove bin entry from package.json for removed "repl" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   "main": "./dist/easypost.js",
   "module": "./dist/easypost.mjs",
   "types": "./types/index.d.ts",
-  "bin": {
-    "easypost": "./repl.js"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/easypost/easypost-node.git"


### PR DESCRIPTION
# Description

v8.0 removed the "repl" script, but it's still referenced in the `bin` section of package.json.  `pnpm` complains about this when installing.

```
 WARN  Failed to create bin at /Users/dimfeld/.pnpm/5/.pnpm/@easypost+api@file+..+..+Documents+src+easypost-node_461784133dc0ee17d7247d322e58791e/node_modules/@easypost/api/node_modules/.bin/easypost. ENOENT: no such file or directory, open '/Users/dimfeld/.pnpm/5/.pnpm/@easypost+api@file+..+..+Documents+src+easypost-node_461784133dc0ee17d7247d322e58791e/node_modules/@easypost/api/repl.js'
 WARN  Failed to create bin at /Users/dimfeld/Library/pnpm/easypost. ENOENT: no such file or directory, open '/Users/dimfeld/.pnpm/5/.pnpm/@easypost+api@file+..+..+Documents+src+easypost-node_461784133dc0ee17d7247d322e58791e/node_modules/@easypost/api/repl.js'
```

This PR updates the package.json accordingly to no longer reference it.

# Testing

Installed the package with this branch and verified that the warning no longer appears.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [X] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
