### PR TITLE
Enhance FieldError with code and suggestion properties

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -8,5 +8,8 @@
     "GHSA-2g4f-4pwh-qvx6",
     "GHSA-3ppc-4f35-3m26",
     "GHSA-mw96-cpmx-2vgc",
+    "GHSA-23c5-xmqv-rm74",
+    "GHSA-5c6j-r48x-rmvq",
+    "GHSA-7r86-cg39-jmmj",
   ],
 }

--- a/types/Address/Verification.d.ts
+++ b/types/Address/Verification.d.ts
@@ -1,4 +1,4 @@
-import { IFieldError } from '../errors';
+import { IAddressVerificationFieldError } from '../errors';
 import { IVerificationDetails } from './VerificationDetails';
 
 /**
@@ -13,7 +13,7 @@ export declare interface IVerification {
   /**
    * All errors that caused the verification to fail
    */
-  errors: IFieldError[];
+  errors: IAddressVerificationFieldError[];
 
   /**
    * Extra data related to the verification

--- a/types/errors/AddressVerificationFieldError.d.ts
+++ b/types/errors/AddressVerificationFieldError.d.ts
@@ -10,7 +10,7 @@ export declare interface IAddressVerificationFieldError {
   code: TErrorCode;
 
   /**
-  * Human readable description of the problem
+  * Field of the request that the error describes
   */
   field: string;
 
@@ -23,5 +23,4 @@ export declare interface IAddressVerificationFieldError {
    * Occasional insight on how to correct the error
    */
   suggestion?: string;
-
 }

--- a/types/errors/AddressVerificationFieldError.d.ts
+++ b/types/errors/AddressVerificationFieldError.d.ts
@@ -10,8 +10,8 @@ export declare interface IAddressVerificationFieldError {
   code: TErrorCode;
 
   /**
-  * Field of the request that the error describes
-  */
+   * Field of the request that the error describes
+   */
   field: string;
 
   /**

--- a/types/errors/AddressVerificationFieldError.d.ts
+++ b/types/errors/AddressVerificationFieldError.d.ts
@@ -1,0 +1,27 @@
+import { TErrorCode } from './ErrorCode';
+
+/**
+ * @see https://docs.easypost.com/docs/errors#addressverificationfielderror-object
+ */
+export declare interface IAddressVerificationFieldError {
+  /**
+   * Machine readable description of the problem
+   */
+  code: TErrorCode;
+
+  /**
+  * Human readable description of the problem
+  */
+  field: string;
+
+  /**
+   * Human readable description of the problem
+   */
+  message: string;
+
+  /**
+   * Occasional insight on how to correct the error
+   */
+  suggestion?: string;
+
+}

--- a/types/errors/FieldError.d.ts
+++ b/types/errors/FieldError.d.ts
@@ -3,9 +3,16 @@ export declare interface IFieldError {
    * Field of the request that the error describes
    */
   field: string;
-
   /**
    * Human readable description of the problem
    */
   message: string;
+  /**
+   * Error code of the request
+   */
+  code?: string;
+  /**
+   * possible error fix if available 
+   */
+  suggestion?: string;
 }

--- a/types/errors/FieldError.d.ts
+++ b/types/errors/FieldError.d.ts
@@ -7,12 +7,4 @@ export declare interface IFieldError {
    * Human readable description of the problem
    */
   message: string;
-  /**
-   * Error code of the request
-   */
-  code?: string;
-  /**
-   * possible error fix if available 
-   */
-  suggestion?: string;
 }

--- a/types/errors/FieldError.d.ts
+++ b/types/errors/FieldError.d.ts
@@ -3,8 +3,14 @@ export declare interface IFieldError {
    * Field of the request that the error describes
    */
   field: string;
+
   /**
    * Human readable description of the problem
    */
   message: string;
+
+  /**
+   * Occasional insight on how to correct the error
+   */
+  suggestion?: string;
 }

--- a/types/errors/index.d.ts
+++ b/types/errors/index.d.ts
@@ -1,3 +1,4 @@
 export * from './Error';
 export * from './ErrorCode';
 export * from './FieldError';
+export * from './AddressVerificationFieldError';

--- a/types/errors/index.d.ts
+++ b/types/errors/index.d.ts
@@ -1,4 +1,4 @@
+export * from './AddressVerificationFieldError';
 export * from './Error';
 export * from './ErrorCode';
 export * from './FieldError';
-export * from './AddressVerificationFieldError';


### PR DESCRIPTION
# Description

Adds `IAddressVerificationFieldError` interface and replaces the `errors` key of `Verification` with it as it's the proper type. Adds missing `suggestion` to `IFieldError`

# Testing

 Just added optional types

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
