### PR TITLE
TSM-02: Add CJS/ESM export compatibility test

### DIFF
--- a/test/services/module_exports_compat.test.js
+++ b/test/services/module_exports_compat.test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+describe('Package export compatibility', function () {
+  it('supports CommonJS require', function () {
+    const EasyPostClient = require('../..');
+
+    expect(EasyPostClient).to.be.a('function');
+
+    const client = new EasyPostClient('apiKey');
+    expect(client).to.be.an('object');
+  });
+
+  it('supports ESM import default', async function () {
+    const module = await import('../..');
+    const EasyPostClient = module.default;
+
+    expect(EasyPostClient).to.be.a('function');
+
+    const client = new EasyPostClient('apiKey');
+    expect(client).to.be.an('object');
+  });
+});


### PR DESCRIPTION
## Summary
Implements topology item 2 by adding explicit package export compatibility coverage for both CJS and ESM consumption paths.

## Changes in this PR
- adds `test/services/module_exports_compat.test.js`.
- validates CommonJS `require('../..')` returns constructable client.
- validates ESM `import('../..')` default export returns constructable client.

## Testing
- `npx vitest run test/services/module_exports_compat.test.js`

## Stack Context
Depends on PR #557.
