### PR TITLE
TSM-08: convert Group C services to TypeScript

### DIFF
--- a/src/services/billing_service.ts
+++ b/src/services/billing_service.ts
@@ -2,6 +2,17 @@ import Constants from '../constants';
 import InvalidObjectError from '../errors/general/invalid_object_error';
 import baseService from './base_service';
 
+type PaymentMethodObject = {
+  id: string;
+  object: string;
+};
+
+type PaymentMethodsResponse = Record<string, unknown> & {
+  id: string | null;
+  primary_payment_method?: PaymentMethodObject | null;
+  secondary_payment_method?: PaymentMethodObject | null;
+};
+
 export default (easypostClient) =>
   /**
    * The BillingService class provides methods for interacting with EasyPost's billing capabilities.
@@ -14,7 +25,7 @@ export default (easypostClient) =>
      * @param {String} amount - The amount to charge to your payment method.
      * @param {String} priority - The priority of the payment method to charge. Can be either 'primary' or 'secondary'.
      */
-    static async fundWallet(amount, priority = 'primary') {
+    static async fundWallet(amount: string, priority: string = 'primary'): Promise<void> {
       const paymentInfo = await this._getPaymentInfo(priority.toLowerCase());
       const endpoint = paymentInfo[0];
       const paymentMethodID = paymentInfo[1];
@@ -30,7 +41,7 @@ export default (easypostClient) =>
      * See {@link https://docs.easypost.com/docs/users/billing#delete-a-payment-method EasyPost API Documentation} for more information.
      * @param {String} priority - The priority of the payment method to delete. Can be either 'primary' or 'secondary'.
      */
-    static async deletePaymentMethod(priority) {
+    static async deletePaymentMethod(priority: string): Promise<void> {
       const paymentInfo = await this._getPaymentInfo(priority.toLowerCase());
       const endpoint = paymentInfo[0];
       const paymentMethodID = paymentInfo[1];
@@ -45,7 +56,7 @@ export default (easypostClient) =>
      * See {@link https://docs.easypost.com/docs/users/billing#retrieve-payment-methods EasyPost API Documentation} for more information.
      * @returns {Object} - An object containing the payment methods associated with the current authenticated user.
      */
-    static async retrievePaymentMethods() {
+    static async retrievePaymentMethods(): Promise<PaymentMethodsResponse> {
       const url = 'payment_methods';
 
       const res = await easypostClient._get(url);
@@ -64,22 +75,26 @@ export default (easypostClient) =>
      * @param {String} priority - The priority of the payment method to retrieve. Can be either 'primary' or 'secondary'.
      * @returns {string[]} - An array of two strings, the first being the endpoint of the payment method and the second being the ID of the payment method.
      */
-    static async _getPaymentInfo(priority) {
+    static async _getPaymentInfo(priority: string): Promise<[string, string]> {
       const paymentMethods = await this.retrievePaymentMethods();
-      const paymentMethodMap = {
+      const paymentMethodMap: Record<
+        string,
+        'primary_payment_method' | 'secondary_payment_method'
+      > = {
         primary: 'primary_payment_method',
         secondary: 'secondary_payment_method',
       };
 
       const paymentMethodToUse = paymentMethodMap[priority];
-      let paymentMethodID;
-      let paymentMethodObjectType;
-      let endpoint;
+      let paymentMethodID: string;
+      let paymentMethodObjectType: string;
+      let endpoint: string;
       const errorString = 'The chosen payment method is not valid. Please try again.';
 
       if (paymentMethodToUse !== undefined && paymentMethods[paymentMethodToUse] !== null) {
-        paymentMethodID = paymentMethods[paymentMethodToUse].id;
-        paymentMethodObjectType = paymentMethods[paymentMethodToUse].object;
+        const paymentMethod = paymentMethods[paymentMethodToUse] as PaymentMethodObject;
+        paymentMethodID = paymentMethod.id;
+        paymentMethodObjectType = paymentMethod.object;
         if (paymentMethodObjectType === 'CreditCard') {
           endpoint = 'credit_cards';
         } else if (paymentMethodObjectType === 'BankAccount') {

--- a/src/services/carrier_account_service.ts
+++ b/src/services/carrier_account_service.ts
@@ -2,6 +2,7 @@ import util from 'util';
 
 import Constants from '../constants';
 import InvalidParameterError from '../errors/general/invalid_parameter_error';
+import CarrierAccount from '../models/carrier_account';
 import baseService from './base_service';
 
 type CarrierAccountCreateParameters = Record<string, unknown> & {
@@ -28,7 +29,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be created.
      * @returns {CarrierAccount} - The created carrier account.
      */
-    static async create(params: CarrierAccountCreateParameters): Promise<unknown> {
+    static async create(params: CarrierAccountCreateParameters): Promise<CarrierAccount> {
       const carrierAccountType = params.type;
 
       if (typeof carrierAccountType !== 'string' || carrierAccountType.length === 0) {
@@ -50,7 +51,10 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be updated.
      * @returns {CarrierAccount} - The updated carrier account.
      */
-    static async update(id: string, params: CarrierAccountCreateParameters): Promise<unknown> {
+    static async update(
+      id: string,
+      params: CarrierAccountCreateParameters,
+    ): Promise<CarrierAccount> {
       const wrappedParams = { carrier_account: params };
 
       try {
@@ -120,7 +124,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of carrier accounts.
      * @returns {Object} - An object containing a list of {@link CarrierAccount carrier accounts} and pagination information.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<CarrierAccount[]> {
       const url = 'carrier_accounts';
 
       return this._all(url, params);
@@ -132,7 +136,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the carrier account to retrieve.
      * @returns {CarrierAccount} - The retrieved carrier account.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<CarrierAccount> {
       const url = `carrier_accounts/${id}`;
 
       return this._retrieve(url);

--- a/src/services/carrier_account_service.ts
+++ b/src/services/carrier_account_service.ts
@@ -4,6 +4,8 @@ import Constants from '../constants';
 import InvalidParameterError from '../errors/general/invalid_parameter_error';
 import baseService from './base_service';
 
+type CarrierAccountParams = Record<string, unknown> & { type?: string };
+
 export default (easypostClient) =>
   /**
    * The CarrierAccountService class provides methods for interacting with EasyPost @{link CarrierAccount} objects.
@@ -16,7 +18,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be created.
      * @returns {CarrierAccount} - The created carrier account.
      */
-    static async create(params) {
+    static async create(params: CarrierAccountParams): Promise<unknown> {
       const carrierAccountType = params.type;
 
       if (!carrierAccountType) {
@@ -38,7 +40,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be updated.
      * @returns {CarrierAccount} - The updated carrier account.
      */
-    static async update(id, params) {
+    static async update(id: string, params: Record<string, unknown>): Promise<unknown> {
       const wrappedParams = { carrier_account: params };
 
       try {
@@ -56,7 +58,7 @@ export default (easypostClient) =>
      * @param {string} id - The id of the carrier account to be deleted.
      * @returns {Promise|Promise<never>} - A promise that resolves when the carrier account has been deleted.
      */
-    static async delete(id) {
+    static async delete(id: string): Promise<void> {
       const url = `carrier_accounts/${id}`;
 
       try {
@@ -74,7 +76,7 @@ export default (easypostClient) =>
      * @param {string} carrierAccountType - The type of carrier account to be created.
      * @returns {string} - The endpoint to be used for the carrier account creation request.
      */
-    static _selectCarrierAccountCreationEndpoint(carrierAccountType) {
+    static _selectCarrierAccountCreationEndpoint(carrierAccountType: string): string {
       if (Constants.CARRIER_ACCOUNTS_WITH_CUSTOM_CREATE_WORKFLOWS.includes(carrierAccountType)) {
         return 'carrier_accounts/register';
       } else if (Constants.CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_OAUTH.includes(carrierAccountType)) {
@@ -91,7 +93,10 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters for the carrier account to be created.
      * @returns {Object} - The wrapped carrier account parameters.
      */
-    static _wrapCarrierAccountParams(carrierAccountType, params) {
+    static _wrapCarrierAccountParams(
+      carrierAccountType: string,
+      params: Record<string, unknown>,
+    ): Record<string, unknown> {
       if (Constants.CARRIER_ACCOUNT_TYPES_WITH_CUSTOM_OAUTH.includes(carrierAccountType)) {
         return { carrier_account_oauth_registrations: params };
       }
@@ -105,7 +110,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of carrier accounts.
      * @returns {Object} - An object containing a list of {@link CarrierAccount carrier accounts} and pagination information.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'carrier_accounts';
 
       return this._all(url, params);
@@ -117,7 +122,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the carrier account to retrieve.
      * @returns {CarrierAccount} - The retrieved carrier account.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `carrier_accounts/${id}`;
 
       return this._retrieve(url);

--- a/src/services/carrier_account_service.ts
+++ b/src/services/carrier_account_service.ts
@@ -4,7 +4,17 @@ import Constants from '../constants';
 import InvalidParameterError from '../errors/general/invalid_parameter_error';
 import baseService from './base_service';
 
-type CarrierAccountParams = Record<string, unknown> & { type?: string };
+type CarrierAccountCreateParameters = Record<string, unknown> & {
+  type?: string | null;
+  fields?: Record<string, unknown> | null;
+  clone?: boolean | null;
+  description?: string | null;
+  reference?: string | null;
+  readable?: string | null;
+  credentials?: Record<string, unknown> | null;
+  test_credentials?: Record<string, unknown> | null;
+  billing_type?: string | null;
+};
 
 export default (easypostClient) =>
   /**
@@ -18,10 +28,10 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be created.
      * @returns {CarrierAccount} - The created carrier account.
      */
-    static async create(params: CarrierAccountParams): Promise<unknown> {
+    static async create(params: CarrierAccountCreateParameters): Promise<unknown> {
       const carrierAccountType = params.type;
 
-      if (!carrierAccountType) {
+      if (typeof carrierAccountType !== 'string' || carrierAccountType.length === 0) {
         throw new InvalidParameterError({
           message: util.format(Constants.MISSING_REQUIRED_PARAMETER, 'CarrierAccount type'),
         });
@@ -40,7 +50,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the carrier account to be updated.
      * @returns {CarrierAccount} - The updated carrier account.
      */
-    static async update(id: string, params: Record<string, unknown>): Promise<unknown> {
+    static async update(id: string, params: CarrierAccountCreateParameters): Promise<unknown> {
       const wrappedParams = { carrier_account: params };
 
       try {

--- a/src/services/carrier_metadata_service.ts
+++ b/src/services/carrier_metadata_service.ts
@@ -1,5 +1,7 @@
 import baseService from './base_service';
 
+type CarrierMetadata = Record<string, unknown>;
+
 /**
  * @extends baseService
  */
@@ -14,7 +16,7 @@ export default (easypostClient) =>
     static async retrieve(
       carriers: string[] | null = null,
       types: string[] | null = null,
-    ): Promise<unknown> {
+    ): Promise<CarrierMetadata[]> {
       const url = 'metadata/carriers';
       const params = {
         ...(carriers && carriers.length > 0 && { carriers: carriers.join(',') }),

--- a/src/services/carrier_metadata_service.ts
+++ b/src/services/carrier_metadata_service.ts
@@ -11,7 +11,10 @@ export default (easypostClient) =>
      * @param {Array} type - List of types in string
      * @returns {Object[]} - List of carrier metadata
      */
-    static async retrieve(carriers = null, types = null) {
+    static async retrieve(
+      carriers: string[] | null = null,
+      types: string[] | null = null,
+    ): Promise<unknown> {
       const url = 'metadata/carriers';
       const params = {
         ...(carriers && carriers.length > 0 && { carriers: carriers.join(',') }),

--- a/src/services/carrier_type_service.ts
+++ b/src/services/carrier_type_service.ts
@@ -12,7 +12,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of carrier types.
      * @returns {CarrierType[]} - A list of {@link CarrierType carrier types}.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'carrier_types';
 
       try {

--- a/src/services/carrier_type_service.ts
+++ b/src/services/carrier_type_service.ts
@@ -1,4 +1,5 @@
 import baseService from './base_service';
+import CarrierType from '../models/carrier_type';
 
 export default (easypostClient) =>
   /**
@@ -12,7 +13,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of carrier types.
      * @returns {CarrierType[]} - A list of {@link CarrierType carrier types}.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<CarrierType[]> {
       const url = 'carrier_types';
 
       try {

--- a/test/services/billing.test.ts
+++ b/test/services/billing.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import {

--- a/test/services/carrier_account.test.ts
+++ b/test/services/carrier_account.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import CarrierAccount from '../../src/models/carrier_account';

--- a/test/services/carrier_account.test.ts
+++ b/test/services/carrier_account.test.ts
@@ -3,9 +3,12 @@ import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import CarrierAccount from '../../src/models/carrier_account';
+import type CarrierAccountServiceFactory from '../../src/services/carrier_account_service';
 import Fixture from '../helpers/fixture';
 import * as setupPolly from '../helpers/setup_polly';
 import { withoutParams } from '../helpers/utils';
+
+type CarrierAccountTestCreateInput = Parameters<ReturnType<typeof CarrierAccountServiceFactory>['create']>[0];
 
 /* eslint-disable func-names */
 describe('CarrierAccount Service', function () {
@@ -22,7 +25,9 @@ describe('CarrierAccount Service', function () {
   });
 
   it('creates a carrier account', async function () {
-    const carrierAccount = await client.CarrierAccount.create(Fixture.basicCarrierAccount());
+    const carrierAccount = await client.CarrierAccount.create(
+      Fixture.basicCarrierAccount() as CarrierAccountTestCreateInput,
+    );
 
     expect(carrierAccount).to.be.an.instanceOf(CarrierAccount);
     expect(carrierAccount.id).to.match(/^ca_/);
@@ -65,7 +70,9 @@ describe('CarrierAccount Service', function () {
   });
 
   it('retrieves a carrier account', async function () {
-    const carrierAccount = await client.CarrierAccount.create(Fixture.basicCarrierAccount());
+    const carrierAccount = await client.CarrierAccount.create(
+      Fixture.basicCarrierAccount() as CarrierAccountTestCreateInput,
+    );
     const retrievedCarrierAccount = await client.CarrierAccount.retrieve(carrierAccount.id);
 
     expect(retrievedCarrierAccount).to.be.an.instanceOf(CarrierAccount);
@@ -84,7 +91,9 @@ describe('CarrierAccount Service', function () {
   });
 
   it('updates a carrier account', async function () {
-    const carrierAccount = await client.CarrierAccount.create(Fixture.basicCarrierAccount());
+    const carrierAccount = await client.CarrierAccount.create(
+      Fixture.basicCarrierAccount() as CarrierAccountTestCreateInput,
+    );
 
     const testDescription = 'My custom description';
     const updateParams = {
@@ -127,7 +136,9 @@ describe('CarrierAccount Service', function () {
   });
 
   it('deletes a carrier account', async function () {
-    const carrierAccount = await client.CarrierAccount.create(Fixture.basicCarrierAccount());
+    const carrierAccount = await client.CarrierAccount.create(
+      Fixture.basicCarrierAccount() as CarrierAccountTestCreateInput,
+    );
 
     await client.CarrierAccount.delete(carrierAccount.id).then(
       expect(function (result) {

--- a/test/services/carrier_account.test.ts
+++ b/test/services/carrier_account.test.ts
@@ -8,7 +8,9 @@ import Fixture from '../helpers/fixture';
 import * as setupPolly from '../helpers/setup_polly';
 import { withoutParams } from '../helpers/utils';
 
-type CarrierAccountTestCreateInput = Parameters<ReturnType<typeof CarrierAccountServiceFactory>['create']>[0];
+type CarrierAccountTestCreateInput = Parameters<
+  ReturnType<typeof CarrierAccountServiceFactory>['create']
+>[0];
 
 /* eslint-disable func-names */
 describe('CarrierAccount Service', function () {

--- a/test/services/carrier_metadata.test.ts
+++ b/test/services/carrier_metadata.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import * as setupPolly from '../helpers/setup_polly';

--- a/test/services/carrier_type.test.ts
+++ b/test/services/carrier_type.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import CarrierType from '../../src/models/carrier_type';


### PR DESCRIPTION
## Summary
- Convert Group C services to TypeScript: Billing, CarrierAccount, CarrierMetadata, and CarrierType.
- Preserve existing service APIs and runtime behavior.

## Validation
- npm run typescript
- npm run build
- Targeted Group C service tests
