### PR TITLE
TSM-09: convert Group D services to TypeScript

### DIFF
--- a/src/services/claim_service.ts
+++ b/src/services/claim_service.ts
@@ -1,6 +1,17 @@
 import baseService from './base_service';
 
-type ClaimParams = Record<string, unknown>;
+type ClaimCreateParameters = Record<string, unknown> & {
+  tracking_code?: string | null;
+  type?: string | null;
+  amount?: string | null;
+  email_evidence_attachments?: string[] | null;
+  invoice_attachments?: string[] | null;
+  supporting_documentation_attachments?: string[] | null;
+  description?: string | null;
+  recipient_name?: string | null;
+  contact_email?: string | null;
+  payment_method?: string | null;
+};
 type ClaimCollection = Record<string, unknown>;
 
 export default (easypostClient) =>
@@ -14,7 +25,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the claim to be created.
      * @returns {Claim} - The created claim.
      */
-    static async create(params: ClaimParams): Promise<unknown> {
+    static async create(params: ClaimCreateParameters): Promise<unknown> {
       const url = 'claims';
 
       return this._create(url, params);

--- a/src/services/claim_service.ts
+++ b/src/services/claim_service.ts
@@ -1,5 +1,8 @@
 import baseService from './base_service';
 
+type ClaimParams = Record<string, unknown>;
+type ClaimCollection = Record<string, unknown>;
+
 export default (easypostClient) =>
   /**
    * The ClaimService class provides methods for interacting with EasyPost {@link Claim} objects.
@@ -11,7 +14,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the claim to be created.
      * @returns {Claim} - The created claim.
      */
-    static async create(params) {
+    static async create(params: ClaimParams): Promise<unknown> {
       const url = 'claims';
 
       return this._create(url, params);
@@ -22,7 +25,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the claim records.
      * @returns {Object} - An object containing the list of {@link Claim claim} records and pagination information.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'claims';
 
       return this._all(url, params);
@@ -34,7 +37,10 @@ export default (easypostClient) =>
      * @param {Number} pageSize The number of records to return on each page
      * @returns {EasyPostObject|Promise<never>} The retrieved {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async getNextPage(claims, pageSize = null) {
+    static async getNextPage(
+      claims: ClaimCollection,
+      pageSize: number | null = null,
+    ): Promise<unknown> {
       const url = 'claims';
       return this._getNextPage(url, 'claims', claims, pageSize);
     }
@@ -44,7 +50,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the claim to retrieve.
      * @returns {Claim} - The retrieved claim.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `claims/${id}`;
 
       return this._retrieve(url);
@@ -55,8 +61,8 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the claim to be canceled.
      * @returns {Claim} - The canceled claim.
      */
-    static async cancel(id) {
+    static async cancel(id: string): Promise<unknown> {
       const url = `claims/${id}/cancel`;
-      return this._create(url);
+      return this._create(url, {});
     }
   };

--- a/src/services/claim_service.ts
+++ b/src/services/claim_service.ts
@@ -1,4 +1,5 @@
 import baseService from './base_service';
+import Claim from '../models/claim';
 
 type ClaimCreateParameters = Record<string, unknown> & {
   tracking_code?: string | null;
@@ -13,6 +14,7 @@ type ClaimCreateParameters = Record<string, unknown> & {
   payment_method?: string | null;
 };
 type ClaimCollection = Record<string, unknown>;
+type ClaimListResponse = { claims: Claim[]; has_more: boolean };
 
 export default (easypostClient) =>
   /**
@@ -25,7 +27,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the claim to be created.
      * @returns {Claim} - The created claim.
      */
-    static async create(params: ClaimCreateParameters): Promise<unknown> {
+    static async create(params: ClaimCreateParameters): Promise<Claim> {
       const url = 'claims';
 
       return this._create(url, params);
@@ -36,7 +38,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the claim records.
      * @returns {Object} - An object containing the list of {@link Claim claim} records and pagination information.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<ClaimListResponse> {
       const url = 'claims';
 
       return this._all(url, params);
@@ -51,7 +53,7 @@ export default (easypostClient) =>
     static async getNextPage(
       claims: ClaimCollection,
       pageSize: number | null = null,
-    ): Promise<unknown> {
+    ): Promise<ClaimListResponse> {
       const url = 'claims';
       return this._getNextPage(url, 'claims', claims, pageSize);
     }
@@ -61,7 +63,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the claim to retrieve.
      * @returns {Claim} - The retrieved claim.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<Claim> {
       const url = `claims/${id}`;
 
       return this._retrieve(url);
@@ -72,7 +74,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the claim to be canceled.
      * @returns {Claim} - The canceled claim.
      */
-    static async cancel(id: string): Promise<unknown> {
+    static async cancel(id: string): Promise<Claim> {
       const url = `claims/${id}/cancel`;
       return this._create(url, {});
     }

--- a/src/services/event_service.ts
+++ b/src/services/event_service.ts
@@ -1,5 +1,7 @@
 import baseService from './base_service';
 
+type EventCollection = Record<string, unknown>;
+
 export default (easypostClient) =>
   /**
    * The EventService class provides methods for interacting with EasyPost {@link Event} objects.
@@ -12,7 +14,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the event to retrieve payloads for.
      * @returns {Payload[]} - A list of {@link Payload payloads} for the event.
      */
-    static async retrieveAllPayloads(id) {
+    static async retrieveAllPayloads(id: string): Promise<unknown> {
       const url = `events/${id}/payloads`;
 
       try {
@@ -31,7 +33,7 @@ export default (easypostClient) =>
      * @param {string} payloadId - The ID of the payload to retrieve.
      * @returns {Payload} - The {@link Payload payload} for the event.
      */
-    static async retrievePayload(id, payloadId) {
+    static async retrievePayload(id: string, payloadId: string): Promise<unknown> {
       const url = `events/${id}/payloads/${payloadId}`;
 
       try {
@@ -49,7 +51,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of events.
      * @returns {Object} - An object containing the list of {@link Event events} and pagination information.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'events';
 
       return this._all(url, params);
@@ -61,7 +63,10 @@ export default (easypostClient) =>
      * @param {Number} pageSize The number of records to return on each page
      * @returns {EasyPostObject|Promise<never>} The retrieved {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async getNextPage(events, pageSize = null) {
+    static async getNextPage(
+      events: EventCollection,
+      pageSize: number | null = null,
+    ): Promise<unknown> {
       const url = 'events';
       return this._getNextPage(url, 'events', events, pageSize);
     }
@@ -72,7 +77,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the event to retrieve.
      * @returns {Event} - The retrieved event.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `events/${id}`;
 
       return this._retrieve(url);

--- a/src/services/event_service.ts
+++ b/src/services/event_service.ts
@@ -1,6 +1,9 @@
 import baseService from './base_service';
+import Event from '../models/event';
+import Payload from '../models/payload';
 
 type EventCollection = Record<string, unknown>;
+type EventListResponse = { events: Event[]; has_more: boolean };
 
 export default (easypostClient) =>
   /**
@@ -14,7 +17,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the event to retrieve payloads for.
      * @returns {Payload[]} - A list of {@link Payload payloads} for the event.
      */
-    static async retrieveAllPayloads(id: string): Promise<unknown> {
+    static async retrieveAllPayloads(id: string): Promise<Payload[]> {
       const url = `events/${id}/payloads`;
 
       try {
@@ -33,7 +36,7 @@ export default (easypostClient) =>
      * @param {string} payloadId - The ID of the payload to retrieve.
      * @returns {Payload} - The {@link Payload payload} for the event.
      */
-    static async retrievePayload(id: string, payloadId: string): Promise<unknown> {
+    static async retrievePayload(id: string, payloadId: string): Promise<Payload> {
       const url = `events/${id}/payloads/${payloadId}`;
 
       try {
@@ -51,7 +54,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the list of events.
      * @returns {Object} - An object containing the list of {@link Event events} and pagination information.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<EventListResponse> {
       const url = 'events';
 
       return this._all(url, params);
@@ -66,7 +69,7 @@ export default (easypostClient) =>
     static async getNextPage(
       events: EventCollection,
       pageSize: number | null = null,
-    ): Promise<unknown> {
+    ): Promise<EventListResponse> {
       const url = 'events';
       return this._getNextPage(url, 'events', events, pageSize);
     }
@@ -77,7 +80,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the event to retrieve.
      * @returns {Event} - The retrieved event.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<Event> {
       const url = `events/${id}`;
 
       return this._retrieve(url);

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -1,6 +1,13 @@
 import baseService from './base_service';
 
-type InsuranceParams = Record<string, unknown>;
+type InsuranceCreateParameters = Record<string, unknown> & {
+  reference?: string | null;
+  to_address?: Record<string, unknown> | string | null;
+  from_address?: Record<string, unknown> | string | null;
+  carrier?: string | null;
+  tracking_code?: string | null;
+  amount?: string | null;
+};
 type InsuranceCollection = Record<string, unknown>;
 
 export default (easypostClient) =>
@@ -15,7 +22,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the insurance to be created.
      * @returns {Insurance} - The created insurance.
      */
-    static async create(params: InsuranceParams): Promise<unknown> {
+    static async create(params: InsuranceCreateParameters): Promise<unknown> {
       const url = 'insurances';
 
       const wrappedParams = {

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -1,5 +1,8 @@
 import baseService from './base_service';
 
+type InsuranceParams = Record<string, unknown>;
+type InsuranceCollection = Record<string, unknown>;
+
 export default (easypostClient) =>
   /**
    * The InsuranceService class provides methods for interacting with EasyPost {@link Insurance} objects.
@@ -12,7 +15,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the insurance to be created.
      * @returns {Insurance} - The created insurance.
      */
-    static async create(params) {
+    static async create(params: InsuranceParams): Promise<unknown> {
       const url = 'insurances';
 
       const wrappedParams = {
@@ -28,7 +31,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the insurance records.
      * @returns {Object} - An object containing the list of {@link Insurance insurance} records and pagination information.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'insurances';
 
       return this._all(url, params);
@@ -40,7 +43,10 @@ export default (easypostClient) =>
      * @param {Number} pageSize The number of records to return on each page
      * @returns {EasyPostObject|Promise<never>} The retrieved {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async getNextPage(insurances, pageSize = null) {
+    static async getNextPage(
+      insurances: InsuranceCollection,
+      pageSize: number | null = null,
+    ): Promise<unknown> {
       const url = 'insurances';
       return this._getNextPage(url, 'insurances', insurances, pageSize);
     }
@@ -51,7 +57,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the insurance to retrieve.
      * @returns {Insurance} - The retrieved insurance.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `insurances/${id}`;
 
       return this._retrieve(url);
@@ -63,7 +69,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the insurance to be refunded.
      * @returns {Insurance} - The refunded insurance.
      */
-    static async refund(id) {
+    static async refund(id: string): Promise<unknown> {
       const url = `insurances/${id}/refund`;
       const response = await easypostClient._post(url);
 

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -1,4 +1,5 @@
 import baseService from './base_service';
+import Insurance from '../models/insurance';
 
 type InsuranceCreateParameters = Record<string, unknown> & {
   reference?: string | null;
@@ -9,6 +10,7 @@ type InsuranceCreateParameters = Record<string, unknown> & {
   amount?: string | null;
 };
 type InsuranceCollection = Record<string, unknown>;
+type InsuranceListResponse = { insurances: Insurance[]; has_more: boolean };
 
 export default (easypostClient) =>
   /**
@@ -22,7 +24,7 @@ export default (easypostClient) =>
      * @param {Object} params - Parameters for the insurance to be created.
      * @returns {Insurance} - The created insurance.
      */
-    static async create(params: InsuranceCreateParameters): Promise<unknown> {
+    static async create(params: InsuranceCreateParameters): Promise<Insurance> {
       const url = 'insurances';
 
       const wrappedParams = {
@@ -38,7 +40,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - Parameters to filter the insurance records.
      * @returns {Object} - An object containing the list of {@link Insurance insurance} records and pagination information.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<InsuranceListResponse> {
       const url = 'insurances';
 
       return this._all(url, params);
@@ -53,7 +55,7 @@ export default (easypostClient) =>
     static async getNextPage(
       insurances: InsuranceCollection,
       pageSize: number | null = null,
-    ): Promise<unknown> {
+    ): Promise<InsuranceListResponse> {
       const url = 'insurances';
       return this._getNextPage(url, 'insurances', insurances, pageSize);
     }
@@ -64,7 +66,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the insurance to retrieve.
      * @returns {Insurance} - The retrieved insurance.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<Insurance> {
       const url = `insurances/${id}`;
 
       return this._retrieve(url);
@@ -76,7 +78,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the insurance to be refunded.
      * @returns {Insurance} - The refunded insurance.
      */
-    static async refund(id: string): Promise<unknown> {
+    static async refund(id: string): Promise<Insurance> {
       const url = `insurances/${id}/refund`;
       const response = await easypostClient._post(url);
 

--- a/src/services/tracker_service.ts
+++ b/src/services/tracker_service.ts
@@ -1,5 +1,8 @@
 import baseService from './base_service';
 
+type TrackerParams = Record<string, unknown>;
+type TrackerCollection = Record<string, unknown>;
+
 export default (easypostClient) =>
   /**
    * The TrackerService class provides methods for interacting with EasyPost {@link Tracker} objects.
@@ -12,7 +15,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a tracker with.
      * @returns {Tracker} - The created tracker.
      */
-    static async create(params) {
+    static async create(params: TrackerParams): Promise<unknown> {
       const url = 'trackers';
 
       const wrappedParams = {
@@ -28,7 +31,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - The parameters to filter the trackers by.
      * @returns {Object} - An object containing the list of {@link Tracker trackers} and pagination information.
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'trackers';
 
       return this._all(url, params);
@@ -40,7 +43,10 @@ export default (easypostClient) =>
      * @param {Number} pageSize The number of records to return on each page
      * @returns {EasyPostObject|Promise<never>} The retrieved {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async getNextPage(trackers, pageSize = null) {
+    static async getNextPage(
+      trackers: TrackerCollection,
+      pageSize: number | null = null,
+    ): Promise<unknown> {
       const url = 'trackers';
 
       return this._getNextPage(url, 'trackers', trackers, pageSize);
@@ -52,7 +58,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the tracker to retrieve.
      * @returns {Tracker} - The retrieved tracker.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `trackers/${id}`;
 
       return this._retrieve(url);
@@ -63,7 +69,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - The parameters to filter the trackers by.
      * @returns {Object} - An object containing the list of {@link Tracker trackers}.
      */
-    static async retrieveBatch(params = {}) {
+    static async retrieveBatch(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'trackers/batch';
 
       try {
@@ -81,7 +87,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the tracker to delete.
      * @returns {Promise<void>}
      */
-    static async delete(id) {
+    static async delete(id: string): Promise<void> {
       const url = `trackers/${id}`;
 
       try {

--- a/src/services/tracker_service.ts
+++ b/src/services/tracker_service.ts
@@ -1,6 +1,9 @@
 import baseService from './base_service';
 
-type TrackerParams = Record<string, unknown>;
+type TrackerCreateParameters = Record<string, unknown> & {
+  tracking_code?: string | null;
+  carrier?: string | null;
+};
 type TrackerCollection = Record<string, unknown>;
 
 export default (easypostClient) =>
@@ -15,7 +18,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a tracker with.
      * @returns {Tracker} - The created tracker.
      */
-    static async create(params: TrackerParams): Promise<unknown> {
+    static async create(params: TrackerCreateParameters): Promise<unknown> {
       const url = 'trackers';
 
       const wrappedParams = {

--- a/src/services/tracker_service.ts
+++ b/src/services/tracker_service.ts
@@ -1,10 +1,12 @@
 import baseService from './base_service';
+import Tracker from '../models/tracker';
 
 type TrackerCreateParameters = Record<string, unknown> & {
   tracking_code?: string | null;
   carrier?: string | null;
 };
 type TrackerCollection = Record<string, unknown>;
+type TrackerListResponse = { trackers: Tracker[]; has_more: boolean };
 
 export default (easypostClient) =>
   /**
@@ -18,7 +20,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a tracker with.
      * @returns {Tracker} - The created tracker.
      */
-    static async create(params: TrackerCreateParameters): Promise<unknown> {
+    static async create(params: TrackerCreateParameters): Promise<Tracker> {
       const url = 'trackers';
 
       const wrappedParams = {
@@ -34,7 +36,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - The parameters to filter the trackers by.
      * @returns {Object} - An object containing the list of {@link Tracker trackers} and pagination information.
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<TrackerListResponse> {
       const url = 'trackers';
 
       return this._all(url, params);
@@ -49,7 +51,7 @@ export default (easypostClient) =>
     static async getNextPage(
       trackers: TrackerCollection,
       pageSize: number | null = null,
-    ): Promise<unknown> {
+    ): Promise<TrackerListResponse> {
       const url = 'trackers';
 
       return this._getNextPage(url, 'trackers', trackers, pageSize);
@@ -61,7 +63,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the tracker to retrieve.
      * @returns {Tracker} - The retrieved tracker.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<Tracker> {
       const url = `trackers/${id}`;
 
       return this._retrieve(url);
@@ -72,7 +74,7 @@ export default (easypostClient) =>
      * @param {Object} [params] - The parameters to filter the trackers by.
      * @returns {Object} - An object containing the list of {@link Tracker trackers}.
      */
-    static async retrieveBatch(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async retrieveBatch(params: Record<string, unknown> = {}): Promise<TrackerListResponse> {
       const url = 'trackers/batch';
 
       try {

--- a/src/services/webhook_service.ts
+++ b/src/services/webhook_service.ts
@@ -1,5 +1,7 @@
 import baseService from './base_service';
 
+type WebhookParams = Record<string, unknown>;
+
 export default (easypostClient) =>
   /**
    * The WebhookService class provides methods for interacting with EasyPost {@link Webhook} objects.
@@ -12,7 +14,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a webhook with.
      * @returns {Webhook} - The created webhook.
      */
-    static async create(params) {
+    static async create(params: WebhookParams): Promise<unknown> {
       const url = 'webhooks';
 
       const wrappedParams = {
@@ -30,7 +32,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to update the webhook with.
      * @returns {Webhook} - The updated webhook.
      */
-    static async update(id, params) {
+    static async update(id: string, params: Record<string, unknown>): Promise<unknown> {
       const url = `webhooks/${id}`;
 
       try {
@@ -48,7 +50,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the webhook to delete.
      * @returns {Promise|Promise<never>} - A promise that resolves if the webhook was successfully deleted.
      */
-    static async delete(id) {
+    static async delete(id: string): Promise<void> {
       const url = `webhooks/${id}`;
 
       try {
@@ -66,7 +68,7 @@ export default (easypostClient) =>
      * @param {Object} [params]
      * @returns {Webhook[]}
      */
-    static async all(params = {}) {
+    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
       const url = 'webhooks';
 
       return this._all(url, params);
@@ -78,7 +80,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the webhook to retrieve.
      * @returns {Webhook} - The retrieved webhook.
      */
-    static async retrieve(id) {
+    static async retrieve(id: string): Promise<unknown> {
       const url = `webhooks/${id}`;
 
       return this._retrieve(url);

--- a/src/services/webhook_service.ts
+++ b/src/services/webhook_service.ts
@@ -1,4 +1,7 @@
 import baseService from './base_service';
+import Webhook from '../models/webhook';
+
+type WebhookListResponse = { webhooks: Webhook[]; has_more?: boolean };
 
 type WebhookCreateParameters = Record<string, unknown> & {
   url?: string | null;
@@ -18,7 +21,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a webhook with.
      * @returns {Webhook} - The created webhook.
      */
-    static async create(params: WebhookCreateParameters): Promise<unknown> {
+    static async create(params: WebhookCreateParameters): Promise<Webhook> {
       const url = 'webhooks';
 
       const wrappedParams = {
@@ -36,7 +39,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to update the webhook with.
      * @returns {Webhook} - The updated webhook.
      */
-    static async update(id: string, params: WebhookCreateParameters): Promise<unknown> {
+    static async update(id: string, params: WebhookCreateParameters): Promise<Webhook> {
       const url = `webhooks/${id}`;
 
       try {
@@ -72,7 +75,7 @@ export default (easypostClient) =>
      * @param {Object} [params]
      * @returns {Webhook[]}
      */
-    static async all(params: Record<string, unknown> = {}): Promise<unknown> {
+    static async all(params: Record<string, unknown> = {}): Promise<WebhookListResponse> {
       const url = 'webhooks';
 
       return this._all(url, params);
@@ -84,7 +87,7 @@ export default (easypostClient) =>
      * @param {string} id - The ID of the webhook to retrieve.
      * @returns {Webhook} - The retrieved webhook.
      */
-    static async retrieve(id: string): Promise<unknown> {
+    static async retrieve(id: string): Promise<Webhook> {
       const url = `webhooks/${id}`;
 
       return this._retrieve(url);

--- a/src/services/webhook_service.ts
+++ b/src/services/webhook_service.ts
@@ -1,6 +1,10 @@
 import baseService from './base_service';
 
-type WebhookParams = Record<string, unknown>;
+type WebhookCreateParameters = Record<string, unknown> & {
+  url?: string | null;
+  webhook_secret?: string | null;
+  custom_headers?: Array<{ key?: string | null; value?: string | null }> | null;
+};
 
 export default (easypostClient) =>
   /**
@@ -14,7 +18,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to create a webhook with.
      * @returns {Webhook} - The created webhook.
      */
-    static async create(params: WebhookParams): Promise<unknown> {
+    static async create(params: WebhookCreateParameters): Promise<unknown> {
       const url = 'webhooks';
 
       const wrappedParams = {
@@ -32,7 +36,7 @@ export default (easypostClient) =>
      * @param {Object} params - The parameters to update the webhook with.
      * @returns {Webhook} - The updated webhook.
      */
-    static async update(id: string, params: Record<string, unknown>): Promise<unknown> {
+    static async update(id: string, params: WebhookCreateParameters): Promise<unknown> {
       const url = `webhooks/${id}`;
 
       try {

--- a/test/cassettes/Claim-Service_1417924316/cancels-a-standalone-claim_1710270578/recording.har
+++ b/test/cassettes/Claim-Service_1417924316/cancels-a-standalone-claim_1710270578/recording.har
@@ -52,7 +52,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 5301,
-            "text": "{\"id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"created_at\":\"2026-07-30T17:38:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-07-30T17:38:01Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_f9ca47d882354cea961f1390ead7a5e0\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_84ce3551428b4050a1b9980cd31b71fe\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_695b9d708c3d11f1890d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_bf5223880840435f9f40ec718598ed87\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_4a16a241d8fc491280bc5b997f2e86da\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d1ad16d75852469c822d868c6f300508\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f42c41b9743947e9af02213dc2f0c808\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_695b9d158c3d11f1890c0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_695b9d708c3d11f1890d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_695b9d158c3d11f1890c0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"created_at\":\"2026-08-12T17:19:45Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-08-12T17:19:45Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_1c8157696beb49999eb430ee0107fe30\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_15c903cb3f4943b9a3c448d4d722d7d0\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_0371c5fb967211f1abb300224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_ee43398dba484e48b1e5a843eefb46f1\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_1d64c42ee65b44b7a52c8cb665027350\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8a7255d638d04bfba19fb07957373cb4\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f48dfb048a864cafb94220fb504844bd\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_0371c53e967211f1abb200224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_0371c5fb967211f1abb300224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_0371c53e967211f1abb200224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -78,7 +78,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_4aad9f0ee06340409912a8efed97e13e"
+              "value": "/api/v2/shipments/shp_2ba88502c89b4612b993985fab9e8a77"
             },
             {
               "name": "pragma",
@@ -101,6 +101,10 @@
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
@@ -110,7 +114,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf9e0e306b703fd789d"
+              "value": "797fae856a7cab31e2b7e6f40093f2ee"
             },
             {
               "name": "x-frame-options",
@@ -118,7 +122,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb65nuq"
+              "value": "bigweb43nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -126,29 +130,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb6nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.267232"
+              "value": "0.285511"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 789,
+          "headersSize": 807,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_4aad9f0ee06340409912a8efed97e13e",
+          "redirectURL": "/api/v2/shipments/shp_2ba88502c89b4612b993985fab9e8a77",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:38:01.132Z",
-        "time": 398,
+        "startedDateTime": "2026-08-12T17:19:45.241Z",
+        "time": 324,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,11 +160,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 398
+          "wait": 324
         }
       },
       {
-        "_id": "8b7e8ec5fc5a11e41653ac48a49f0147",
+        "_id": "fe14faab96e0d08f99cb2a3733ef2683",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,17 +198,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_d1ad16d75852469c822d868c6f300508\"},\"insurance\":100}"
+            "text": "{\"rate\":{\"id\":\"rate_f48dfb048a864cafb94220fb504844bd\"},\"insurance\":100}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_4aad9f0ee06340409912a8efed97e13e/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_2ba88502c89b4612b993985fab9e8a77/buy"
         },
         "response": {
           "bodySize": 7544,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 7544,
-            "text": "{\"id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"created_at\":\"2026-07-30T17:38:01Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112554710\",\"updated_at\":\"2026-07-30T17:38:02Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_f9ca47d882354cea961f1390ead7a5e0\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_84ce3551428b4050a1b9980cd31b71fe\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_695b9d708c3d11f1890d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_bf5223880840435f9f40ec718598ed87\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_832f194ec348479e8c4cfb4844bb4afb\",\"created_at\":\"2026-07-30T17:38:02Z\",\"updated_at\":\"2026-07-30T17:38:02Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-07-30T17:38:02Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260730/e80434b2d4164c4262823a61442cf401f7.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_4a16a241d8fc491280bc5b997f2e86da\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_d1ad16d75852469c822d868c6f300508\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f42c41b9743947e9af02213dc2f0c808\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_d1ad16d75852469c822d868c6f300508\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:38:02Z\",\"updated_at\":\"2026-07-30T17:38:02Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_3436a630bd514857967cbe8eb3f8057e\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112554710\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-07-30T17:38:02Z\",\"updated_at\":\"2026-07-30T17:38:02Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrXzM0MzZhNjMwYmQ1MTQ4NTc5NjdjYmU4ZWIzZjgwNTdl\"},\"to_address\":{\"id\":\"adr_695b9d158c3d11f1890c0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_695b9d708c3d11f1890d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_695b9d158c3d11f1890c0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:38:01Z\",\"updated_at\":\"2026-07-30T17:38:01Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"created_at\":\"2026-08-12T17:19:45Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112624031\",\"updated_at\":\"2026-08-12T17:19:46Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_1c8157696beb49999eb430ee0107fe30\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_15c903cb3f4943b9a3c448d4d722d7d0\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_0371c5fb967211f1abb300224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_ee43398dba484e48b1e5a843eefb46f1\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_9653e8a4fbc84d58b5b69a128d674e1e\",\"created_at\":\"2026-08-12T17:19:46Z\",\"updated_at\":\"2026-08-12T17:19:46Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-08-12T17:19:46Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260812/e88f07336f2d774fc9be28b60df1b56926.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_1d64c42ee65b44b7a52c8cb665027350\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_8a7255d638d04bfba19fb07957373cb4\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_f48dfb048a864cafb94220fb504844bd\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_f48dfb048a864cafb94220fb504844bd\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:46Z\",\"updated_at\":\"2026-08-12T17:19:46Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_95d8910d644442f4afb1de796adda360\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112624031\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-08-12T17:19:46Z\",\"updated_at\":\"2026-08-12T17:19:46Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrXzk1ZDg5MTBkNjQ0NDQyZjRhZmIxZGU3OTZhZGRhMzYw\"},\"to_address\":{\"id\":\"adr_0371c53e967211f1abb200224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_0371c5fb967211f1abb300224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_0371c53e967211f1abb200224804dbec\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:45Z\",\"updated_at\":\"2026-08-12T17:19:45Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -258,7 +262,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf9e0e306b703fd795a"
+              "value": "797fae856a7cab31e2b7e6f40093f37c"
             },
             {
               "name": "x-frame-options",
@@ -266,7 +270,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb35nuq"
+              "value": "bigweb39nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -274,15 +278,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb4nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb5nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.959555"
+              "value": "1.002409"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -295,8 +299,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:01.530Z",
-        "time": 1069,
+        "startedDateTime": "2026-08-12T17:19:45.567Z",
+        "time": 1042,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -304,15 +308,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1069
+          "wait": 1042
         }
       },
       {
-        "_id": "4f62a321712367b4ca0c41497122fc0b",
+        "_id": "17537310038e666a06f6f23adf11dc73",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 598,
+          "bodySize": 600,
           "cookies": [],
           "headers": [
             {
@@ -333,7 +337,7 @@
             },
             {
               "name": "content-length",
-              "value": 598
+              "value": 600
             }
           ],
           "headersSize": 389,
@@ -342,7 +346,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112554710\",\"amount\":100}"
+            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112624031\",\"amount\":\"100\"}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/claims"
@@ -352,7 +356,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1156,
-            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ccfac6e689cc46578318a9f0212aadcc.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c7ae37dc4a354e7f8291976465f902cb.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/7c8cafebfd0e45fe84b42d050d334543.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:38:02Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:38:02Z\"}],\"id\":\"clm_0a47a5cd7ff04f95acafd6fe0c8944da\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a4f9f896ea4046639341f167e559ba33\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:38:02Z\",\"tracking_code\":\"9400100208303112554710\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:38:02Z\"}"
+            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/eb84e1b3e22f40029a4bf130a3c6e0ae.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/5c4205cf369d49a3abc406c41ccaba20.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/3c2f947a0f7b45619fbe101a5eaaf462.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:46Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:46Z\"}],\"id\":\"clm_0a497121e42049379708a90852c72989\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_b7a2af4bd4fb47ee929ba98fb57e0a6a\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:46Z\",\"tracking_code\":\"9400100208303112624031\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:46Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -397,6 +401,10 @@
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
@@ -406,7 +414,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bfae0e306b703fd7bbe"
+              "value": "797fae856a7cab32e2b7e6f40093f524"
             },
             {
               "name": "x-frame-options",
@@ -414,7 +422,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb57nuq"
+              "value": "bigweb43nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -422,29 +430,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb4nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.930380"
+              "value": "0.776611"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 723,
+          "headersSize": 741,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:38:02.601Z",
-        "time": 1054,
+        "startedDateTime": "2026-08-12T17:19:46.612Z",
+        "time": 1164,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -452,11 +460,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1054
+          "wait": 1164
         }
       },
       {
-        "_id": "92a9add8e3e549589d62c6955434e500",
+        "_id": "3d1e8633afb1e7bff68abeb7e3d4f628",
         "_order": 0,
         "cache": {},
         "request": {
@@ -493,14 +501,14 @@
             "text": "{}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/claims/clm_0a47a5cd7ff04f95acafd6fe0c8944da/cancel"
+          "url": "https://api.easypost.com/v2/claims/clm_0a497121e42049379708a90852c72989/cancel"
         },
         "response": {
           "bodySize": 1281,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1281,
-            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ccfac6e689cc46578318a9f0212aadcc.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c7ae37dc4a354e7f8291976465f902cb.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/7c8cafebfd0e45fe84b42d050d334543.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:38:02Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T17:38:04Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:38:02Z\"}],\"id\":\"clm_0a47a5cd7ff04f95acafd6fe0c8944da\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a4f9f896ea4046639341f167e559ba33\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T17:38:04Z\",\"tracking_code\":\"9400100208303112554710\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:38:03Z\"}"
+            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/eb84e1b3e22f40029a4bf130a3c6e0ae.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/5c4205cf369d49a3abc406c41ccaba20.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/3c2f947a0f7b45619fbe101a5eaaf462.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:46Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-08-12T17:19:48Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:46Z\"}],\"id\":\"clm_0a497121e42049379708a90852c72989\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_b7a2af4bd4fb47ee929ba98fb57e0a6a\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_2ba88502c89b4612b993985fab9e8a77\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-08-12T17:19:48Z\",\"tracking_code\":\"9400100208303112624031\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:47Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -554,7 +562,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bfbe0e306b703fd7e4e"
+              "value": "797fae856a7cab33e2b7e6f40093f76e"
             },
             {
               "name": "x-frame-options",
@@ -562,7 +570,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb59nuq"
+              "value": "bigweb53nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -570,15 +578,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb6nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb5nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.078963"
+              "value": "0.075529"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -591,8 +599,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:03.657Z",
-        "time": 192,
+        "startedDateTime": "2026-08-12T17:19:47.778Z",
+        "time": 113,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -600,7 +608,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 192
+          "wait": 113
         }
       }
     ],

--- a/test/cassettes/Claim-Service_1417924316/creates-a-claim-object_2101092128/recording.har
+++ b/test/cassettes/Claim-Service_1417924316/creates-a-claim-object_2101092128/recording.har
@@ -52,7 +52,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 5301,
-            "text": "{\"id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"created_at\":\"2026-07-30T17:37:55Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-07-30T17:37:55Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_39de3153eec047c1b47766fb6bc2a337\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_751dea30f9bc48e8b9375ee348724c40\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_65d331588c3d11f19537002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_154374f45b7b474ba4bd2490473f7b18\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_f7a66ec541a54a48b1db75e216b4cb8e\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c9d08e1337074120bcf711a4c5f906fb\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5e87690f7afd47e996d43eb0d53caa2c\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_65d330fd8c3d11f19536002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_65d331588c3d11f19537002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_65d330fd8c3d11f19536002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"created_at\":\"2026-08-12T17:19:39Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-08-12T17:19:40Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_692d29cc634c4b10905566676175b647\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a8604f7021bd4eafb5545500602ca207\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_0032fad3967211f1bb88002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_9156391ea7984d75a97185234590bb10\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_3dc052893c5742fda0204fa914d6b339\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_768fed0609b641fcb151a548095ff132\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_63b5eeb5d3464105805ae41ec486b44e\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_0032fa53967211f1bb87002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_0032fad3967211f1bb88002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_0032fa53967211f1bb87002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -78,7 +78,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_e603c5acbb3448658f18d5c5b2d25997"
+              "value": "/api/v2/shipments/shp_1b1a38c00cf4494992d4f7da97ee2dde"
             },
             {
               "name": "pragma",
@@ -110,7 +110,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf3e0e306b703fd6e39"
+              "value": "797fae856a7cab2be2b7e6f40093e925"
             },
             {
               "name": "x-frame-options",
@@ -118,7 +118,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb42nuq"
+              "value": "bigweb54nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -126,15 +126,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.264541"
+              "value": "0.259923"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -143,12 +143,12 @@
           ],
           "headersSize": 789,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_e603c5acbb3448658f18d5c5b2d25997",
+          "redirectURL": "/api/v2/shipments/shp_1b1a38c00cf4494992d4f7da97ee2dde",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:37:54.984Z",
-        "time": 627,
+        "startedDateTime": "2026-08-12T17:19:39.652Z",
+        "time": 451,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,11 +156,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 627
+          "wait": 451
         }
       },
       {
-        "_id": "798e90df122b12d1483f33b9d2957ccc",
+        "_id": "b8f3fae01c0e18cff052d1c37fa3126e",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,17 +194,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_c9d08e1337074120bcf711a4c5f906fb\"},\"insurance\":100}"
+            "text": "{\"rate\":{\"id\":\"rate_63b5eeb5d3464105805ae41ec486b44e\"},\"insurance\":100}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_e603c5acbb3448658f18d5c5b2d25997/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_1b1a38c00cf4494992d4f7da97ee2dde/buy"
         },
         "response": {
           "bodySize": 7544,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 7544,
-            "text": "{\"id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"created_at\":\"2026-07-30T17:37:55Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112554581\",\"updated_at\":\"2026-07-30T17:37:56Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_39de3153eec047c1b47766fb6bc2a337\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_751dea30f9bc48e8b9375ee348724c40\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_65d331588c3d11f19537002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_154374f45b7b474ba4bd2490473f7b18\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_51546c6dd0cd4386a69e7d4472038fc9\",\"created_at\":\"2026-07-30T17:37:56Z\",\"updated_at\":\"2026-07-30T17:37:56Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-07-30T17:37:56Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260730/e83f38cf81b29a4bb39bb4fc3661a1c730.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_f7a66ec541a54a48b1db75e216b4cb8e\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c9d08e1337074120bcf711a4c5f906fb\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_5e87690f7afd47e996d43eb0d53caa2c\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_c9d08e1337074120bcf711a4c5f906fb\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:56Z\",\"updated_at\":\"2026-07-30T17:37:56Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_5246cfc6c6fa4c92a60fd7f7139d9af4\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112554581\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-07-30T17:37:56Z\",\"updated_at\":\"2026-07-30T17:37:56Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrXzUyNDZjZmM2YzZmYTRjOTJhNjBmZDdmNzEzOWQ5YWY0\"},\"to_address\":{\"id\":\"adr_65d330fd8c3d11f19536002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_65d331588c3d11f19537002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_65d330fd8c3d11f19536002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:55Z\",\"updated_at\":\"2026-07-30T17:37:55Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"created_at\":\"2026-08-12T17:19:39Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112624017\",\"updated_at\":\"2026-08-12T17:19:41Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_692d29cc634c4b10905566676175b647\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_a8604f7021bd4eafb5545500602ca207\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_0032fad3967211f1bb88002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_9156391ea7984d75a97185234590bb10\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_ef6080f02cfc4143a67f741f50b7451f\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:41Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-08-12T17:19:40Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260812/e8735f11180bb9476f95ac5798e2c2e387.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_3dc052893c5742fda0204fa914d6b339\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_768fed0609b641fcb151a548095ff132\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_63b5eeb5d3464105805ae41ec486b44e\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_63b5eeb5d3464105805ae41ec486b44e\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:40Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_ff479edd63964219b8020b73bfc54c6b\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112624017\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-08-12T17:19:41Z\",\"updated_at\":\"2026-08-12T17:19:41Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrX2ZmNDc5ZWRkNjM5NjQyMTliODAyMGI3M2JmYzU0YzZi\"},\"to_address\":{\"id\":\"adr_0032fa53967211f1bb87002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_0032fad3967211f1bb88002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:39Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_0032fa53967211f1bb87002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:39Z\",\"updated_at\":\"2026-08-12T17:19:40Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -249,6 +249,10 @@
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
@@ -258,7 +262,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf3e0e306b703fd6ef3"
+              "value": "797fae856a7cab2ce2b7e6f40093e9b7"
             },
             {
               "name": "x-frame-options",
@@ -266,7 +270,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb36nuq"
+              "value": "bigweb43nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -274,29 +278,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb5nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb4nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "1.104415"
+              "value": "0.976709"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 723,
+          "headersSize": 741,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:37:55.616Z",
-        "time": 1220,
+        "startedDateTime": "2026-08-12T17:19:40.106Z",
+        "time": 1014,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -304,15 +308,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1220
+          "wait": 1014
         }
       },
       {
-        "_id": "144f3e2bb47781650309a7ab5fd1d2a2",
+        "_id": "45123c78cf2975ca1bb0f6701f70c628",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 598,
+          "bodySize": 600,
           "cookies": [],
           "headers": [
             {
@@ -333,7 +337,7 @@
             },
             {
               "name": "content-length",
-              "value": 598
+              "value": 600
             }
           ],
           "headersSize": 389,
@@ -342,7 +346,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112554581\",\"amount\":100}"
+            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112624017\",\"amount\":\"100\"}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/claims"
@@ -352,7 +356,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1156,
-            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/413febfc9c35407eae93c3bb6d8a1199.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ff6d8ce3b8614e86b2a1424a8f42c91c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/31ac5f9c9dff4df5a1aadaa4954abe18.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:57Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:57Z\"}],\"id\":\"clm_0a47e54f6408419ab0a8dba3c2ea3b1f\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_bfa2e974c4ef4473ba18294c06897915\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:57Z\",\"tracking_code\":\"9400100208303112554581\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:57Z\"}"
+            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f757002ac89a48859b0b6ee1156ab3ae.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f100eb11cc9745bab454b2d02a7fc682.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/b268e68d30e54e45896a43ef6b6f9a88.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:41Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:41Z\"}],\"id\":\"clm_0a49547e475c45a4bc02e7ea375d1fc4\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_749b9818c26e4a329a6d2ee9385e6203\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:41Z\",\"tracking_code\":\"9400100208303112624017\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:41Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -406,7 +410,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf5e0e306b703fd7111"
+              "value": "797fae856a7cab2de2b7e6f40093eb81"
             },
             {
               "name": "x-frame-options",
@@ -414,7 +418,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb53nuq"
+              "value": "bigweb41nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -422,15 +426,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb4nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.968474"
+              "value": "1.040241"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -443,8 +447,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:37:56.838Z",
-        "time": 1072,
+        "startedDateTime": "2026-08-12T17:19:41.122Z",
+        "time": 1077,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -452,7 +456,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1072
+          "wait": 1077
         }
       }
     ],

--- a/test/cassettes/Claim-Service_1417924316/retrieves-a-claim-object_3414227044/recording.har
+++ b/test/cassettes/Claim-Service_1417924316/retrieves-a-claim-object_3414227044/recording.har
@@ -52,7 +52,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 5301,
-            "text": "{\"id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"created_at\":\"2026-07-30T17:37:58Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-07-30T17:37:58Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4de439f71393464aa02e1a090e66d71a\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d7cafbd59eae4798bda7904bceeb34d6\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_676ecd9b8c3d11f196c9002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_79b52258fc124bba92a16131228f57b3\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_3f837669cbbe4b478156254dd4c415d3\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2515f4721d834864acfc5aed08d6e398\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_247c7c438a294a6fbdb8677835c14200\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_676ecd1c8c3d11f196c8002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_676ecd9b8c3d11f196c9002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_676ecd1c8c3d11f196c8002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"created_at\":\"2026-08-12T17:19:42Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":null,\"updated_at\":\"2026-08-12T17:19:42Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_f0d5082f92a74c9389f55d462190ce75\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_0a4d19595a62405db4791dc77402013f\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_01a1fb06967211f1a40e0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_c633ede2db534216b6d3abe72ee66f98\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\"},\"postage_label\":null,\"rates\":[{\"id\":\"rate_059d45fbf842427286887e27390eca18\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c62a7a701d564a9d835ee235d5594355\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_084f9ff56e884f9ea7b1a523fed34f09\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":null,\"tracker\":null,\"to_address\":{\"id\":\"adr_01a1fa92967211f1a40d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_01a1fb06967211f1a40e0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_01a1fa92967211f1a40d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"forms\":[],\"fees\":[],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -78,7 +78,7 @@
             },
             {
               "name": "location",
-              "value": "/api/v2/shipments/shp_4ee2293eaf6b4befb9d9a7266a51c437"
+              "value": "/api/v2/shipments/shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8"
             },
             {
               "name": "pragma",
@@ -110,7 +110,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf6e0e306b703fd72d8"
+              "value": "797fae856a7cab2ee2b7e6f40093edd7"
             },
             {
               "name": "x-frame-options",
@@ -118,7 +118,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb34nuq"
+              "value": "bigweb54nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -126,15 +126,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb5nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.307700"
+              "value": "0.307148"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -143,12 +143,12 @@
           ],
           "headersSize": 789,
           "httpVersion": "HTTP/1.1",
-          "redirectURL": "/api/v2/shipments/shp_4ee2293eaf6b4befb9d9a7266a51c437",
+          "redirectURL": "/api/v2/shipments/shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:37:57.915Z",
-        "time": 438,
+        "startedDateTime": "2026-08-12T17:19:42.208Z",
+        "time": 348,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -156,11 +156,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 438
+          "wait": 348
         }
       },
       {
-        "_id": "a20a6352e59daa2ad4aac0d9897a4b70",
+        "_id": "1194ad529069b97fae59e90d4e90bfa2",
         "_order": 0,
         "cache": {},
         "request": {
@@ -194,17 +194,17 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"rate\":{\"id\":\"rate_247c7c438a294a6fbdb8677835c14200\"},\"insurance\":100}"
+            "text": "{\"rate\":{\"id\":\"rate_c62a7a701d564a9d835ee235d5594355\"},\"insurance\":100}"
           },
           "queryString": [],
-          "url": "https://api.easypost.com/v2/shipments/shp_4ee2293eaf6b4befb9d9a7266a51c437/buy"
+          "url": "https://api.easypost.com/v2/shipments/shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8/buy"
         },
         "response": {
           "bodySize": 7544,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 7544,
-            "text": "{\"id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"created_at\":\"2026-07-30T17:37:58Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112554635\",\"updated_at\":\"2026-07-30T17:37:59Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_4de439f71393464aa02e1a090e66d71a\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_d7cafbd59eae4798bda7904bceeb34d6\",\"object\":\"CustomsItem\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_676ecd9b8c3d11f196c9002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_79b52258fc124bba92a16131228f57b3\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_bf89d529897b4141b271fc446730c62f\",\"created_at\":\"2026-07-30T17:37:59Z\",\"updated_at\":\"2026-07-30T17:37:59Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-07-30T17:37:59Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260730/e8d89d4283975a4a42a80ee572bb304030.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_3f837669cbbe4b478156254dd4c415d3\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_2515f4721d834864acfc5aed08d6e398\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_247c7c438a294a6fbdb8677835c14200\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_247c7c438a294a6fbdb8677835c14200\",\"object\":\"Rate\",\"created_at\":\"2026-07-30T17:37:59Z\",\"updated_at\":\"2026-07-30T17:37:59Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_a0a8efe32d384b488fad0e7018feae18\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112554635\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-07-30T17:37:59Z\",\"updated_at\":\"2026-07-30T17:37:59Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrX2EwYThlZmUzMmQzODRiNDg4ZmFkMGU3MDE4ZmVhZTE4\"},\"to_address\":{\"id\":\"adr_676ecd1c8c3d11f196c8002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_676ecd9b8c3d11f196c9002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_676ecd1c8c3d11f196c8002248041e50\",\"object\":\"Address\",\"created_at\":\"2026-07-30T17:37:58Z\",\"updated_at\":\"2026-07-30T17:37:58Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
+            "text": "{\"id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"created_at\":\"2026-08-12T17:19:42Z\",\"is_return\":false,\"messages\":[{\"carrier\":\"UPS\",\"carrier_account_id\":\"ca_3abe58dbb6c6463cbbc8d00a733634e8\",\"type\":\"rate_error\",\"message\":\"Account numbers should be 6 characters or less.\"}],\"mode\":\"test\",\"options\":{\"label_format\":\"PNG\",\"invoice_number\":\"123\",\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":\"123\",\"status\":\"unknown\",\"tracking_code\":\"9400100208303112624024\",\"updated_at\":\"2026-08-12T17:19:43Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":{\"id\":\"cstinfo_f0d5082f92a74c9389f55d462190ce75\",\"object\":\"CustomsInfo\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"contents_explanation\":\"\",\"contents_type\":\"merchandise\",\"customs_certify\":true,\"customs_signer\":\"Steve Brule\",\"eel_pfc\":\"NOEEI 30.37(a)\",\"non_delivery_option\":\"return\",\"restriction_comments\":null,\"restriction_type\":\"none\",\"mode\":\"test\",\"declaration\":null,\"customs_items\":[{\"id\":\"cstitem_0a4d19595a62405db4791dc77402013f\",\"object\":\"CustomsItem\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"description\":\"Sweet shirts\",\"hs_tariff_number\":\"654321\",\"origin_country\":\"US\",\"quantity\":2,\"value\":\"23.25\",\"weight\":11,\"code\":null,\"mode\":\"test\",\"manufacturer\":null,\"currency\":null,\"eccn\":null,\"printed_commodity_identifier\":null,\"export_license\":null}]},\"from_address\":{\"id\":\"adr_01a1fb06967211f1a40e0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":\"100.00\",\"order_id\":null,\"parcel\":{\"id\":\"prcl_c633ede2db534216b6d3abe72ee66f98\",\"object\":\"Parcel\",\"weight\":15.4,\"length\":10,\"width\":8,\"height\":4,\"predefined_package\":null,\"mode\":\"test\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_ad4ce54b614f441d99cfdc815d88efb0\",\"created_at\":\"2026-08-12T17:19:43Z\",\"updated_at\":\"2026-08-12T17:19:43Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2026-08-12T17:19:43Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20260812/e888e5dcfcf2dc41ff9e95a06b01a7abf4.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_059d45fbf842427286887e27390eca18\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"9.22\",\"currency\":\"USD\",\"retail_rate\":\"11.90\",\"retail_currency\":\"USD\",\"list_rate\":\"10.40\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_c62a7a701d564a9d835ee235d5594355\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},{\"id\":\"rate_084f9ff56e884f9ea7b1a523fed34f09\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"39.05\",\"currency\":\"USD\",\"retail_rate\":\"43.45\",\"retail_currency\":\"USD\",\"list_rate\":\"39.05\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_c62a7a701d564a9d835ee235d5594355\",\"object\":\"Rate\",\"created_at\":\"2026-08-12T17:19:43Z\",\"updated_at\":\"2026-08-12T17:19:43Z\",\"mode\":\"test\",\"service\":\"GroundAdvantage\",\"carrier\":\"USPS\",\"rate\":\"6.98\",\"currency\":\"USD\",\"retail_rate\":\"10.60\",\"retail_currency\":\"USD\",\"list_rate\":\"7.46\",\"list_currency\":\"USD\",\"billing_type\":\"easypost\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier_account_id\":\"ca_5ba7ca3632c54adeb17ad4bcac13c890\"},\"tracker\":{\"id\":\"trk_6c7f49c8523f49f0be39e6a2b3ebb333\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100208303112624024\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2026-08-12T17:19:43Z\",\"updated_at\":\"2026-08-12T17:19:43Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"delivery_evidence\":[],\"public_url\":\"https://track.easypost.com/djE6dHJrXzZjN2Y0OWM4NTIzZjQ5ZjBiZTM5ZTZhMmIzZWJiMzMz\"},\"to_address\":{\"id\":\"adr_01a1fa92967211f1a40d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":4,\"return_address\":{\"id\":\"adr_01a1fb06967211f1a40e0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_01a1fa92967211f1a40d0022480c5359\",\"object\":\"Address\",\"created_at\":\"2026-08-12T17:19:42Z\",\"updated_at\":\"2026-08-12T17:19:42Z\",\"name\":\"ELIZABETH SWAN\",\"company\":null,\"street1\":\"179 N HARBOR DR\",\"street2\":\"\",\"city\":\"REDONDO BEACH\",\"state\":\"CA\",\"zip\":\"90277-2506\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":33.8448,\"longitude\":-118.39278,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.00000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"6.98000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"InsuranceFee\",\"amount\":\"1.00000\",\"charged\":true,\"refunded\":false}],\"object\":\"Shipment\"}"
           },
           "cookies": [],
           "headers": [
@@ -258,7 +258,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf6e0e306b703fd73b1"
+              "value": "797fae856a7cab2ee2b7e6f40093ee6c"
             },
             {
               "name": "x-frame-options",
@@ -266,7 +266,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb54nuq"
+              "value": "bigweb41nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -274,15 +274,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb5nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb3nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.985079"
+              "value": "1.084736"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -295,8 +295,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:37:58.354Z",
-        "time": 1102,
+        "startedDateTime": "2026-08-12T17:19:42.558Z",
+        "time": 1122,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -304,15 +304,15 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1102
+          "wait": 1122
         }
       },
       {
-        "_id": "9a5e658f0d0a058094a6e42b0d434639",
+        "_id": "25d4e0ad227d3880c6a7ab4e4a231a23",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 598,
+          "bodySize": 600,
           "cookies": [],
           "headers": [
             {
@@ -333,7 +333,7 @@
             },
             {
               "name": "content-length",
-              "value": 598
+              "value": 600
             }
           ],
           "headersSize": 389,
@@ -342,7 +342,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112554635\",\"amount\":100}"
+            "text": "{\"type\":\"damage\",\"email_evidence_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"invoice_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"supporting_documentation_attachments\":[\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAeUlEQVR42mP8//8/AwAI/AL+4Q7AIAAAAABJRU5ErkJggg==\"],\"description\":\"Test description\",\"contact_email\":\"test@example.com\",\"tracking_code\":\"9400100208303112624024\",\"amount\":\"100\"}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/v2/claims"
@@ -352,7 +352,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1156,
-            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d351a0bbdac649659fd2b99bbb1f205e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f7f29061db654ac69fc819998e3fd161.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ac9ac3d89689483880a6360de40c1422.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:59Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:59Z\"}],\"id\":\"clm_0a47629cfde04d2084f115f9a9acbb6a\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_2100ec36795247e58306e0a2585b6028\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:59Z\",\"tracking_code\":\"9400100208303112554635\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:59Z\"}"
+            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6004b795e20b4017aa68a1b90a6d09e6.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/8524ce2e5f014df68f1684a4a5095a2e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/a2347a9da9134ef28aedba6c84684a3c.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:43Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:43Z\"}],\"id\":\"clm_0a4911d20fde48e99dc5e91b295943db\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_655fcc189c14446eb51d3b28df6b4cdb\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:43Z\",\"tracking_code\":\"9400100208303112624024\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:43Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -406,7 +406,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf7e0e306b703fd75b7"
+              "value": "797fae856a7cab2fe2b7e6f40093f066"
             },
             {
               "name": "x-frame-options",
@@ -414,7 +414,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb64nuq"
+              "value": "bigweb41nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -422,15 +422,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb3nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.793984"
+              "value": "1.024591"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -443,8 +443,8 @@
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:37:59.458Z",
-        "time": 926,
+        "startedDateTime": "2026-08-12T17:19:43.682Z",
+        "time": 1064,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -452,11 +452,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 926
+          "wait": 1064
         }
       },
       {
-        "_id": "bf746ddf8929d7e67492dcdaaeb9626f",
+        "_id": "fe574233898a0701dd02a641fcc3ebac",
         "_order": 0,
         "cache": {},
         "request": {
@@ -484,14 +484,14 @@
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [],
-          "url": "https://api.easypost.com/v2/claims/clm_0a47629cfde04d2084f115f9a9acbb6a"
+          "url": "https://api.easypost.com/v2/claims/clm_0a4911d20fde48e99dc5e91b295943db"
         },
         "response": {
           "bodySize": 1156,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 1156,
-            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d351a0bbdac649659fd2b99bbb1f205e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f7f29061db654ac69fc819998e3fd161.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ac9ac3d89689483880a6360de40c1422.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:59Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:59Z\"}],\"id\":\"clm_0a47629cfde04d2084f115f9a9acbb6a\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_2100ec36795247e58306e0a2585b6028\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:59Z\",\"tracking_code\":\"9400100208303112554635\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:59Z\"}"
+            "text": "{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6004b795e20b4017aa68a1b90a6d09e6.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/8524ce2e5f014df68f1684a4a5095a2e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/a2347a9da9134ef28aedba6c84684a3c.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:43Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:43Z\"}],\"id\":\"clm_0a4911d20fde48e99dc5e91b295943db\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_655fcc189c14446eb51d3b28df6b4cdb\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:43Z\",\"tracking_code\":\"9400100208303112624024\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:43Z\"}"
           },
           "cookies": [],
           "headers": [
@@ -545,7 +545,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf8e0e306b703fd771f"
+              "value": "797fae856a7cab30e2b7e6f40093f21f"
             },
             {
               "name": "x-frame-options",
@@ -553,7 +553,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb59nuq"
+              "value": "bigweb42nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -561,15 +561,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb4nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.043408"
+              "value": "0.040853"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -582,8 +582,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:00.385Z",
-        "time": 149,
+        "startedDateTime": "2026-08-12T17:19:44.748Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -591,7 +591,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 149
+          "wait": 84
         }
       }
     ],

--- a/test/cassettes/Claim-Service_1417924316/retrieves-all-claim-objects_2221815381/recording.har
+++ b/test/cassettes/Claim-Service_1417924316/retrieves-all-claim-objects_2221815381/recording.har
@@ -44,11 +44,11 @@
           "url": "https://api.easypost.com/v2/claims?page_size=5"
         },
         "response": {
-          "bodySize": 5934,
+          "bodySize": 6059,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 5934,
-            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d351a0bbdac649659fd2b99bbb1f205e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f7f29061db654ac69fc819998e3fd161.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ac9ac3d89689483880a6360de40c1422.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:59Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:59Z\"}],\"id\":\"clm_0a47629cfde04d2084f115f9a9acbb6a\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_2100ec36795247e58306e0a2585b6028\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:59Z\",\"tracking_code\":\"9400100208303112554635\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:59Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/413febfc9c35407eae93c3bb6d8a1199.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ff6d8ce3b8614e86b2a1424a8f42c91c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/31ac5f9c9dff4df5a1aadaa4954abe18.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:57Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:57Z\"}],\"id\":\"clm_0a47e54f6408419ab0a8dba3c2ea3b1f\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_bfa2e974c4ef4473ba18294c06897915\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:57Z\",\"tracking_code\":\"9400100208303112554581\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:57Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f5d18e2007704ddcb4d4ddb717c696b9.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/fa4363c304954724bfdb2c7f638f59fe.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c3dad41ecf0142c6be67ea49a19a927d.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:21Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T15:30:23Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:21Z\"}],\"id\":\"clm_0a4713566db144ea889a10389bc44092\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_c3409ed13dcb482b855100a40733258f\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_7c828adc37c242da9ebc4a6bf454762f\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T15:30:23Z\",\"tracking_code\":\"9400100208303112553492\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:22Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/32d365e501db4d7c94d90a41253ed04c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d0fba9062f8f45c78fa8eee3968baad2.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/937243c025834c45a5bd5414c0f9cf15.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:18Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:18Z\"}],\"id\":\"clm_0a4781d84c534278ab04ca49cf521203\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_35fdfa9c571546e3902ef5df9863a4ce\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_eac998b7e06842b4a4ced35ac996d542\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:30:18Z\",\"tracking_code\":\"9400100208303112553430\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:18Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/bd15c9e1d39a47f982bf925e08326fa9.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f753d697bc704aa086f1b9272a5b0541.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/3b79a64a520746e3b337dd69dccebda6.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:15Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:15Z\"}],\"id\":\"clm_0a47e68c0ff048da8e30a3df740d1f3d\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_eefd72614bd948ef9ea8cfa6a73d55b8\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_c5b48e85ebe141b7a8cfe91de3603c80\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:30:15Z\",\"tracking_code\":\"9400100208303112553362\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:15Z\"}],\"has_more\":true}"
+            "size": 6059,
+            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6004b795e20b4017aa68a1b90a6d09e6.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/8524ce2e5f014df68f1684a4a5095a2e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/a2347a9da9134ef28aedba6c84684a3c.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:43Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:43Z\"}],\"id\":\"clm_0a4911d20fde48e99dc5e91b295943db\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_655fcc189c14446eb51d3b28df6b4cdb\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:43Z\",\"tracking_code\":\"9400100208303112624024\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:43Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f757002ac89a48859b0b6ee1156ab3ae.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f100eb11cc9745bab454b2d02a7fc682.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/b268e68d30e54e45896a43ef6b6f9a88.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:41Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:41Z\"}],\"id\":\"clm_0a49547e475c45a4bc02e7ea375d1fc4\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_749b9818c26e4a329a6d2ee9385e6203\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:41Z\",\"tracking_code\":\"9400100208303112624017\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:41Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/2b5132d59e3842e493301fb6323c0a13.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/e0493d2bac2d47069e2f97cade6f6feb.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/96b668b7091945959d6a4d1ecd20d6a8.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:15:22Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-08-12T17:15:23Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:15:22Z\"}],\"id\":\"clm_0a49ebb656dc4cab8fc5a41abae49fb2\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a4f9f896ea4046639341f167e559ba33\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-08-12T17:15:23Z\",\"tracking_code\":\"9400100208303112554710\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:15:23Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6ecf5a9e4bd34158962459449d330e21.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/99570c40cd4249e88ecce290ba54f5a0.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/10f6510ed9534a27b87befa6c1cddcc0.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:12:37Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-08-12T17:12:38Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:12:37Z\"}],\"id\":\"clm_0a49290d90be48829392a8f812059470\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_91879495871a40a7b7d1e321637ec9e9\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_eb66ed135502483dbdbc2ad548bbdd44\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-08-12T17:12:38Z\",\"tracking_code\":\"9400100208303112623843\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:12:38Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/fe3ab31f98304ee6b934c057477907b1.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/27c0275baa104492a437733177596916.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/50d9d932853947e790a2365c474b4530.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:12:34Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:12:34Z\"}],\"id\":\"clm_0a49803bad424f3d94dcbebd272f70ab\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a3af2159831f4d4aac4bad428fb8ba52\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4504e2afb0cf48a8b931bc6ed55dfca4\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:12:34Z\",\"tracking_code\":\"9400100208303112623782\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:12:34Z\"}],\"has_more\":true}"
           },
           "cookies": [],
           "headers": [
@@ -93,6 +93,10 @@
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
@@ -102,7 +106,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf8e0e306b703fd7769"
+              "value": "797fae856a7cab30e2b7e6f40093f246"
             },
             {
               "name": "x-frame-options",
@@ -110,7 +114,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb42nuq"
+              "value": "bigweb32nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -118,29 +122,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb3nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb6nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.085913"
+              "value": "0.080358"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 723,
+          "headersSize": 741,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:00.539Z",
-        "time": 206,
+        "startedDateTime": "2026-08-12T17:19:44.842Z",
+        "time": 121,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +152,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 206
+          "wait": 121
         }
       }
     ],

--- a/test/cassettes/Claim-Service_1417924316/retrieves-next-page-of-claims_131645032/recording.har
+++ b/test/cassettes/Claim-Service_1417924316/retrieves-next-page-of-claims_131645032/recording.har
@@ -44,11 +44,11 @@
           "url": "https://api.easypost.com/v2/claims?page_size=5"
         },
         "response": {
-          "bodySize": 5934,
+          "bodySize": 6059,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 5934,
-            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d351a0bbdac649659fd2b99bbb1f205e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f7f29061db654ac69fc819998e3fd161.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ac9ac3d89689483880a6360de40c1422.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:59Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:59Z\"}],\"id\":\"clm_0a47629cfde04d2084f115f9a9acbb6a\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_2100ec36795247e58306e0a2585b6028\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:59Z\",\"tracking_code\":\"9400100208303112554635\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:59Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/413febfc9c35407eae93c3bb6d8a1199.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ff6d8ce3b8614e86b2a1424a8f42c91c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/31ac5f9c9dff4df5a1aadaa4954abe18.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:57Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:57Z\"}],\"id\":\"clm_0a47e54f6408419ab0a8dba3c2ea3b1f\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_bfa2e974c4ef4473ba18294c06897915\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:57Z\",\"tracking_code\":\"9400100208303112554581\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:57Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f5d18e2007704ddcb4d4ddb717c696b9.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/fa4363c304954724bfdb2c7f638f59fe.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c3dad41ecf0142c6be67ea49a19a927d.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:21Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T15:30:23Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:21Z\"}],\"id\":\"clm_0a4713566db144ea889a10389bc44092\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_c3409ed13dcb482b855100a40733258f\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_7c828adc37c242da9ebc4a6bf454762f\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T15:30:23Z\",\"tracking_code\":\"9400100208303112553492\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:22Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/32d365e501db4d7c94d90a41253ed04c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d0fba9062f8f45c78fa8eee3968baad2.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/937243c025834c45a5bd5414c0f9cf15.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:18Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:18Z\"}],\"id\":\"clm_0a4781d84c534278ab04ca49cf521203\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_35fdfa9c571546e3902ef5df9863a4ce\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_eac998b7e06842b4a4ced35ac996d542\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:30:18Z\",\"tracking_code\":\"9400100208303112553430\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:18Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/bd15c9e1d39a47f982bf925e08326fa9.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f753d697bc704aa086f1b9272a5b0541.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/3b79a64a520746e3b337dd69dccebda6.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:15Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:15Z\"}],\"id\":\"clm_0a47e68c0ff048da8e30a3df740d1f3d\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_eefd72614bd948ef9ea8cfa6a73d55b8\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_c5b48e85ebe141b7a8cfe91de3603c80\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:30:15Z\",\"tracking_code\":\"9400100208303112553362\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:15Z\"}],\"has_more\":true}"
+            "size": 6059,
+            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6004b795e20b4017aa68a1b90a6d09e6.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/8524ce2e5f014df68f1684a4a5095a2e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/a2347a9da9134ef28aedba6c84684a3c.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:43Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:43Z\"}],\"id\":\"clm_0a4911d20fde48e99dc5e91b295943db\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_655fcc189c14446eb51d3b28df6b4cdb\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_dddfb11b28a34d2cb80a0b0e3b5b2dd8\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:43Z\",\"tracking_code\":\"9400100208303112624024\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:43Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f757002ac89a48859b0b6ee1156ab3ae.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/f100eb11cc9745bab454b2d02a7fc682.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/b268e68d30e54e45896a43ef6b6f9a88.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:19:41Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:19:41Z\"}],\"id\":\"clm_0a49547e475c45a4bc02e7ea375d1fc4\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_749b9818c26e4a329a6d2ee9385e6203\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_1b1a38c00cf4494992d4f7da97ee2dde\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:19:41Z\",\"tracking_code\":\"9400100208303112624017\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:19:41Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/2b5132d59e3842e493301fb6323c0a13.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/e0493d2bac2d47069e2f97cade6f6feb.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/96b668b7091945959d6a4d1ecd20d6a8.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:15:22Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-08-12T17:15:23Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:15:22Z\"}],\"id\":\"clm_0a49ebb656dc4cab8fc5a41abae49fb2\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a4f9f896ea4046639341f167e559ba33\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-08-12T17:15:23Z\",\"tracking_code\":\"9400100208303112554710\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:15:23Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/6ecf5a9e4bd34158962459449d330e21.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/99570c40cd4249e88ecce290ba54f5a0.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/10f6510ed9534a27b87befa6c1cddcc0.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:12:37Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-08-12T17:12:38Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:12:37Z\"}],\"id\":\"clm_0a49290d90be48829392a8f812059470\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_91879495871a40a7b7d1e321637ec9e9\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_eb66ed135502483dbdbc2ad548bbdd44\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-08-12T17:12:38Z\",\"tracking_code\":\"9400100208303112623843\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:12:38Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/fe3ab31f98304ee6b934c057477907b1.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/27c0275baa104492a437733177596916.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/50d9d932853947e790a2365c474b4530.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:12:34Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:12:34Z\"}],\"id\":\"clm_0a49803bad424f3d94dcbebd272f70ab\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a3af2159831f4d4aac4bad428fb8ba52\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4504e2afb0cf48a8b931bc6ed55dfca4\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:12:34Z\",\"tracking_code\":\"9400100208303112623782\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:12:34Z\"}],\"has_more\":true}"
           },
           "cookies": [],
           "headers": [
@@ -93,6 +93,10 @@
               "value": "easypost"
             },
             {
+              "name": "x-canary",
+              "value": "direct"
+            },
+            {
               "name": "x-content-type-options",
               "value": "nosniff"
             },
@@ -102,7 +106,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf8e0e306b703fd77cf"
+              "value": "797fae856a7cab31e2b7e6f40093f282"
             },
             {
               "name": "x-frame-options",
@@ -110,7 +114,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb63nuq"
+              "value": "bigweb43nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -118,29 +122,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb6nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb4nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.062052"
+              "value": "0.097576"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 723,
+          "headersSize": 741,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:00.748Z",
-        "time": 179,
+        "startedDateTime": "2026-08-12T17:19:44.970Z",
+        "time": 139,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,11 +152,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 179
+          "wait": 139
         }
       },
       {
-        "_id": "7ad50db4a164b4335811f2d0e5252f77",
+        "_id": "2ea1e686a6208bc5a2440aa3edbae9d6",
         "_order": 0,
         "cache": {},
         "request": {
@@ -186,17 +190,17 @@
             },
             {
               "name": "before_id",
-              "value": "clm_0a47e68c0ff048da8e30a3df740d1f3d"
+              "value": "clm_0a49803bad424f3d94dcbebd272f70ab"
             }
           ],
-          "url": "https://api.easypost.com/v2/claims?page_size=5&before_id=clm_0a47e68c0ff048da8e30a3df740d1f3d"
+          "url": "https://api.easypost.com/v2/claims?page_size=5&before_id=clm_0a49803bad424f3d94dcbebd272f70ab"
         },
         "response": {
           "bodySize": 6059,
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 6059,
-            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/78ee32babefd4db5a8cb734b97a6ddaa.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/2aa9422d21824359b3a7078350978887.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/380603293135406dad599be26432f6dc.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:26:30Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T15:26:32Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:26:30Z\"}],\"id\":\"clm_0a47a13232784399a5e95b4bc236a25b\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_be90b9fbcf7748f797e39c2e562ebc6a\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_6ceb058b62fa49f3977ad36c8c6b4bfa\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T15:26:32Z\",\"tracking_code\":\"9400100208303112553218\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:26:31Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/42bce29f63384678ae641f0773d246b3.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d462baf9cfc24560afd7bf5413460047.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/5891bdd8cf004935ad0e4be1dc1811dc.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:26:27Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:26:27Z\"}],\"id\":\"clm_0a4708189556433a8a38ee5ab346c421\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_ea7d9ebb67944c838a0cb8015a29fa5a\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_f0ba056616c0430c830ce34b2dee9fb3\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:26:27Z\",\"tracking_code\":\"9400100208303112553133\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:26:27Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/b3f62ecc58e14f219d333152723b9767.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/746fd0ce211046f09e2956e849eea9ad.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/98df0c8412f74e0ca3dc7bc8190400c6.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:26:24Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:26:24Z\"}],\"id\":\"clm_0a47bae8658c439797cc82a70666c957\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_dbe94623df124baf88d2026eb9da2e54\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_b48109dcc08e44deac3ff0afd3cf7fb9\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:26:24Z\",\"tracking_code\":\"9400100208303112553096\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:26:24Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/43df74242b984f348905cfc85b4c8710.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/31e901c8146b4ed4b0a555da5b2df65a.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/a284d7a78c5844079b295a047182f080.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:24:37Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T15:24:38Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:24:37Z\"}],\"id\":\"clm_0a47b30ef30f4fb1ada1820ee9480d94\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_4fc0e55dd0f3402098fc2b6f43972e2f\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_fc6bab8e48e442818cf1ab2e9df5884a\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T15:24:38Z\",\"tracking_code\":\"9400100208303112552921\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:24:38Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/53f58a62befc44ed861af1a38aa30bcd.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/272b367bd18d4a41bed3704e06eab010.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/07afd07def4f47e4a8f29b6e3fb07e73.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:24:33Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:24:33Z\"}],\"id\":\"clm_0a4727ebd4d34044843c875e4dfadd34\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_ad87ae8069074c6aaf3941327e1527f7\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_f176e785ba4d4906af863531d098bf6e\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T15:24:33Z\",\"tracking_code\":\"9400100208303112552846\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:24:33Z\"}],\"has_more\":true}"
+            "text": "{\"claims\":[{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/cc91f77250f44bc3a1a633bf64ad177b.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/d9c7397fb6c84340a2738f2e19ce749d.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260812/e76a3ee706ba42369712ce21531a2dd5.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-08-12T17:12:31Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-08-12T17:12:31Z\"}],\"id\":\"clm_0a49218af78041ee8341cf352a19850f\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_445525faf2fb4fb3b13594596b550492\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_43c8dd8e85e04174893902975cc9fb53\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-08-12T17:12:31Z\",\"tracking_code\":\"9400100208303112623737\",\"type\":\"damage\",\"updated_at\":\"2026-08-12T17:12:31Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ccfac6e689cc46578318a9f0212aadcc.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c7ae37dc4a354e7f8291976465f902cb.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/7c8cafebfd0e45fe84b42d050d334543.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:38:02Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T17:38:04Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:38:02Z\"}],\"id\":\"clm_0a47a5cd7ff04f95acafd6fe0c8944da\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_a4f9f896ea4046639341f167e559ba33\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4aad9f0ee06340409912a8efed97e13e\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T17:38:04Z\",\"tracking_code\":\"9400100208303112554710\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:38:03Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/d351a0bbdac649659fd2b99bbb1f205e.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f7f29061db654ac69fc819998e3fd161.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ac9ac3d89689483880a6360de40c1422.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:59Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:59Z\"}],\"id\":\"clm_0a47629cfde04d2084f115f9a9acbb6a\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_2100ec36795247e58306e0a2585b6028\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_4ee2293eaf6b4befb9d9a7266a51c437\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:59Z\",\"tracking_code\":\"9400100208303112554635\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:59Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/413febfc9c35407eae93c3bb6d8a1199.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/ff6d8ce3b8614e86b2a1424a8f42c91c.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/31ac5f9c9dff4df5a1aadaa4954abe18.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T17:37:57Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T17:37:57Z\"}],\"id\":\"clm_0a47e54f6408419ab0a8dba3c2ea3b1f\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_bfa2e974c4ef4473ba18294c06897915\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_e603c5acbb3448658f18d5c5b2d25997\",\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"status_timestamp\":\"2026-07-30T17:37:57Z\",\"tracking_code\":\"9400100208303112554581\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T17:37:57Z\"},{\"approved_amount\":null,\"attachments\":[\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/f5d18e2007704ddcb4d4ddb717c696b9.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/fa4363c304954724bfdb2c7f638f59fe.png\",\"https://easypost-files.s3-us-west-2.amazonaws.com/insurance/20260730/c3dad41ecf0142c6be67ea49a19a927d.png\"],\"check_delivery_address\":null,\"contact_email\":\"test@example.com\",\"created_at\":\"2026-07-30T15:30:21Z\",\"description\":\"Test description\",\"history\":[{\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"timestamp\":\"2026-07-30T15:30:23Z\"},{\"status\":\"submitted\",\"status_detail\":\"Claim was created.\",\"timestamp\":\"2026-07-30T15:30:21Z\"}],\"id\":\"clm_0a4713566db144ea889a10389bc44092\",\"insurance_amount\":\"100.00\",\"insurance_id\":\"ins_c3409ed13dcb482b855100a40733258f\",\"mode\":\"test\",\"object\":\"Claim\",\"payment_method\":\"easypost_wallet\",\"payout_recipient\":null,\"recipient_name\":null,\"reference\":null,\"requested_amount\":\"100.00\",\"salvage_value\":null,\"shipment_id\":\"shp_7c828adc37c242da9ebc4a6bf454762f\",\"status\":\"cancelled\",\"status_detail\":\"Claim cancellation was requested.\",\"status_timestamp\":\"2026-07-30T15:30:23Z\",\"tracking_code\":\"9400100208303112553492\",\"type\":\"damage\",\"updated_at\":\"2026-07-30T15:30:22Z\"}],\"has_more\":true}"
           },
           "cookies": [],
           "headers": [
@@ -250,7 +254,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "76795b516a6b8bf9e0e306b703fd7827"
+              "value": "797fae856a7cab31e2b7e6f40093f2bb"
             },
             {
               "name": "x-frame-options",
@@ -258,7 +262,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb36nuq"
+              "value": "bigweb57nuq"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -266,15 +270,15 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb4nuq 1bff4a8790, extlb2nuq e8c67c6320"
+              "value": "intlb5nuq d4a20a271b, extlb1nuq 1318c68dc0"
             },
             {
               "name": "x-runtime",
-              "value": "0.083027"
+              "value": "0.082339"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608112128-93a53ffd35-main"
             },
             {
               "name": "x-xss-protection",
@@ -287,8 +291,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2026-07-30T17:38:00.931Z",
-        "time": 196,
+        "startedDateTime": "2026-08-12T17:19:45.112Z",
+        "time": 122,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -296,7 +300,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 196
+          "wait": 122
         }
       }
     ],

--- a/test/services/claim.test.ts
+++ b/test/services/claim.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';

--- a/test/services/claim.test.ts
+++ b/test/services/claim.test.ts
@@ -4,16 +4,21 @@ import { expect } from 'vitest';
 import EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';
 import Claim from '../../src/models/claim';
+import type ClaimServiceFactory from '../../src/services/claim_service';
+import type ShipmentServiceFactory from '../../src/services/shipment_service';
 import Fixture from '../helpers/fixture';
 import * as setupPolly from '../helpers/setup_polly';
 
 /** @typedef {import("../../types/EasyPost").default} Client */
 
+type ClaimTestCreateInput = Parameters<ReturnType<typeof ClaimServiceFactory>['create']>[0];
+type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFactory>['create']>[0];
+
 const CLAIM_AMOUNT = 100;
 
 /** @param {Client} client */
 const buyTestShipment = async (client) => {
-  const shipment = await client.Shipment.create(Fixture.fullShipment());
+  const shipment = await client.Shipment.create(Fixture.fullShipment() as ShipmentTestCreateInput);
   const rate = shipment.lowestRate();
 
   return client.Shipment.buy(shipment.id, rate, CLAIM_AMOUNT);
@@ -23,9 +28,9 @@ const buyTestShipment = async (client) => {
 const createTestClaim = async (client) => {
   const shipment = await buyTestShipment(client);
 
-  const claimData = Fixture.basicClaim();
+  const claimData = Fixture.basicClaim() as ClaimTestCreateInput;
   claimData.tracking_code = shipment.tracking_code;
-  claimData.amount = CLAIM_AMOUNT;
+  claimData.amount = String(CLAIM_AMOUNT);
 
   return client.Claim.create(claimData);
 };

--- a/test/services/event.test.ts
+++ b/test/services/event.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable func-names */
 import fs from 'fs';
 import { resolve } from 'path';
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import Event from '../../src/models/event';
@@ -138,8 +138,9 @@ describe('Event Service', function () {
       expect(true).to.equal(false);
     } catch (error) {
       expect(error).to.be.an.instanceOf(NotFoundError);
-      expect(error.code).to.equal('PAYLOAD.NOT_FOUND');
-      expect(error.statusCode).to.equal(404);
+      const knownError = error as { code?: string; statusCode?: number };
+      expect(knownError.code).to.equal('PAYLOAD.NOT_FOUND');
+      expect(knownError.statusCode).to.equal(404);
     }
 
     // Remove the webhook once we are done testing

--- a/test/services/event.test.ts
+++ b/test/services/event.test.ts
@@ -6,10 +6,15 @@ import { expect } from 'vitest';
 import EasyPostClient from '../../src/easypost';
 import Event from '../../src/models/event';
 import Payload from '../../src/models/payload';
+import type BatchServiceFactory from '../../src/services/batch_service';
+import type ShipmentServiceFactory from '../../src/services/shipment_service';
 import Fixture from '../helpers/fixture';
 import * as setupPolly from '../helpers/setup_polly';
 import NotFoundError from '../../src/errors/api/not_found_error';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';
+
+type BatchTestCreateInput = Parameters<ReturnType<typeof BatchServiceFactory>['create']>[0];
+type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFactory>['create']>[0];
 
 describe('Event Service', function () {
   const getPolly = setupPolly.setupPollyTests();
@@ -73,8 +78,8 @@ describe('Event Service', function () {
 
     // Create a batch to trigger an event
     await client.Batch.create({
-      shipments: [Fixture.oneCallBuyShipment()],
-    });
+      shipments: [Fixture.oneCallBuyShipment() as ShipmentTestCreateInput],
+    } as BatchTestCreateInput);
 
     if (
       !fs.existsSync(
@@ -111,8 +116,8 @@ describe('Event Service', function () {
 
     // Create a batch to trigger an event
     await client.Batch.create({
-      shipments: [Fixture.oneCallBuyShipment()],
-    });
+      shipments: [Fixture.oneCallBuyShipment() as ShipmentTestCreateInput],
+    } as BatchTestCreateInput);
 
     if (
       !fs.existsSync(

--- a/test/services/insurance.test.ts
+++ b/test/services/insurance.test.ts
@@ -26,7 +26,9 @@ describe('Insurance Service', function () {
   });
 
   it('creates an insurance object', async function () {
-    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment() as ShipmentTestCreateInput);
+    const shipment = await client.Shipment.create(
+      Fixture.oneCallBuyShipment() as ShipmentTestCreateInput,
+    );
 
     const insuranceData = Fixture.basicInsurance() as InsuranceTestCreateInput;
     insuranceData.tracking_code = shipment.tracking_code;
@@ -39,7 +41,9 @@ describe('Insurance Service', function () {
   });
 
   it('retrieves an insurance object', async function () {
-    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment() as ShipmentTestCreateInput);
+    const shipment = await client.Shipment.create(
+      Fixture.oneCallBuyShipment() as ShipmentTestCreateInput,
+    );
 
     const insuranceData = Fixture.basicInsurance() as InsuranceTestCreateInput;
     insuranceData.tracking_code = shipment.tracking_code;

--- a/test/services/insurance.test.ts
+++ b/test/services/insurance.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';

--- a/test/services/insurance.test.ts
+++ b/test/services/insurance.test.ts
@@ -4,8 +4,13 @@ import { expect } from 'vitest';
 import EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';
 import Insurance from '../../src/models/insurance';
+import type InsuranceServiceFactory from '../../src/services/insurance_service';
+import type ShipmentServiceFactory from '../../src/services/shipment_service';
 import Fixture from '../helpers/fixture';
 import * as setupPolly from '../helpers/setup_polly';
+
+type InsuranceTestCreateInput = Parameters<ReturnType<typeof InsuranceServiceFactory>['create']>[0];
+type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFactory>['create']>[0];
 
 describe('Insurance Service', function () {
   const getPolly = setupPolly.setupPollyTests();
@@ -21,9 +26,9 @@ describe('Insurance Service', function () {
   });
 
   it('creates an insurance object', async function () {
-    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment());
+    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment() as ShipmentTestCreateInput);
 
-    const insuranceData = Fixture.basicInsurance();
+    const insuranceData = Fixture.basicInsurance() as InsuranceTestCreateInput;
     insuranceData.tracking_code = shipment.tracking_code;
 
     const insurance = await client.Insurance.create(insuranceData);
@@ -34,9 +39,9 @@ describe('Insurance Service', function () {
   });
 
   it('retrieves an insurance object', async function () {
-    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment());
+    const shipment = await client.Shipment.create(Fixture.oneCallBuyShipment() as ShipmentTestCreateInput);
 
-    const insuranceData = Fixture.basicInsurance();
+    const insuranceData = Fixture.basicInsurance() as InsuranceTestCreateInput;
     insuranceData.tracking_code = shipment.tracking_code;
 
     const insurance = await client.Insurance.create(insuranceData);
@@ -78,7 +83,7 @@ describe('Insurance Service', function () {
   });
 
   it('refunds a standalone insurance', async function () {
-    const insuranceData = Fixture.basicInsurance();
+    const insuranceData = Fixture.basicInsurance() as InsuranceTestCreateInput;
     insuranceData.tracking_code = 'EZ1000000001';
 
     const insurance = await client.Insurance.create(insuranceData);

--- a/test/services/tracker.test.ts
+++ b/test/services/tracker.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable func-names */
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';

--- a/test/services/webhook.test.ts
+++ b/test/services/webhook.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect } from 'vitest';
 
 import EasyPostClient from '../../src/easypost';
 import SignatureVerificationError from '../../src/errors/general/signature_verification_error';


### PR DESCRIPTION
## Summary
- Convert Group D services to TypeScript: Claim, Event, Insurance, Tracker, and Webhook.
- Keep behavior parity while migrating service modules to `.ts`.

## Validation
- npm run typescript
- npm run build
- Targeted Group D service tests
