### PR TITLE
TSM-92: enable noImplicitAny and harden typing

### DIFF
--- a/src/easypost.ts
+++ b/src/easypost.ts
@@ -44,15 +44,17 @@ const pkgVersion = process.env.npm_package_version ?? 'unknown';
 type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
 type RequestHeaders = Record<string, string>;
 type HttpClient = typeof fetch;
+type RequestParams = Record<string, unknown>;
+type RequestBody = RequestParams | null;
 
 interface CompatibilityRequest {
   method: string;
   url: string;
-  _data: Record<string, unknown> | undefined;
+  _data: RequestBody | undefined;
   set(headersToSet?: RequestHeaders): CompatibilityRequest;
   auth(key: string): CompatibilityRequest;
-  query(queryParams?: Record<string, unknown>): CompatibilityRequest;
-  send(body?: Record<string, unknown>): CompatibilityRequest;
+  query(queryParams?: RequestParams): CompatibilityRequest;
+  send(body?: RequestBody): CompatibilityRequest;
 }
 
 interface HttpMiddleware {
@@ -218,11 +220,7 @@ export default class EasyPostClient {
    * @param {Object} [params] - The parameters to send with the request.
    * @returns {Promise<Object>} The response from the API call.
    */
-  async makeApiCall(
-    method: string,
-    endpoint: string,
-    params: Record<string, unknown> = {},
-  ): Promise<unknown> {
+  async makeApiCall(method: string, endpoint: string, params: RequestBody = {}): Promise<unknown> {
     const response = await this._request(endpoint, method, params);
 
     return response.body;
@@ -405,7 +403,7 @@ export default class EasyPostClient {
   async _request(
     path = '',
     method: string = EasyPostClient.METHODS.GET,
-    params: Record<string, unknown> = {},
+    params: RequestBody = {},
     headers: RequestHeaders = {},
   ): Promise<any> {
     const urlPath = this._buildPath(path);
@@ -415,13 +413,15 @@ export default class EasyPostClient {
     const isQueryMethod =
       normalizedMethod === EasyPostClient.METHODS.GET ||
       normalizedMethod === EasyPostClient.METHODS.DELETE;
-    let requestBody: Record<string, unknown> | undefined;
+    let requestBody: RequestBody | undefined;
 
     if (params !== undefined) {
       if (isQueryMethod) {
-        Object.entries(params).forEach(([key, value]) => {
-          url.searchParams.append(key, String(value));
-        });
+        if (params !== null) {
+          Object.entries(params).forEach(([key, value]) => {
+            url.searchParams.append(key, String(value));
+          });
+        }
       } else {
         requestBody = params;
       }
@@ -446,7 +446,7 @@ export default class EasyPostClient {
         compatibilityRequest.url = url.toString();
         return compatibilityRequest;
       },
-      send: (body: Record<string, unknown> = {}) => {
+      send: (body: RequestBody = {}) => {
         compatibilityRequest._data = body;
         return compatibilityRequest;
       },
@@ -471,6 +471,7 @@ export default class EasyPostClient {
     if (
       this.requestMiddleware &&
       params !== undefined &&
+      params !== null &&
       typeof middlewareRequest.query === 'function' &&
       isQueryMethod
     ) {
@@ -570,11 +571,7 @@ export default class EasyPostClient {
    * @param {Object} [headers] - Additional headers to send with the request.
    * @returns {*} The response from the HTTP request.
    */
-  _get(
-    path: string,
-    params: Record<string, unknown> = {},
-    headers: RequestHeaders = {},
-  ): Promise<any> {
+  _get(path: string, params: RequestParams = {}, headers: RequestHeaders = {}): Promise<any> {
     return this._request(path, EasyPostClient.METHODS.GET, params, headers);
   }
 
@@ -585,11 +582,7 @@ export default class EasyPostClient {
    * @param {Object} [headers] - Additional headers to send with the request.
    * @returns {*} The response from the HTTP request.
    */
-  _post(
-    path: string,
-    params: Record<string, unknown> = {},
-    headers: RequestHeaders = {},
-  ): Promise<any> {
+  _post(path: string, params: RequestBody = {}, headers: RequestHeaders = {}): Promise<any> {
     return this._request(path, EasyPostClient.METHODS.POST, params, headers);
   }
 
@@ -600,11 +593,7 @@ export default class EasyPostClient {
    * @param {Object} [headers] - Additional headers to send with the request.
    * @returns {*} The response from the HTTP request.
    */
-  _put(
-    path: string,
-    params: Record<string, unknown> = {},
-    headers: RequestHeaders = {},
-  ): Promise<any> {
+  _put(path: string, params: RequestBody = {}, headers: RequestHeaders = {}): Promise<any> {
     return this._request(path, EasyPostClient.METHODS.PUT, params, headers);
   }
 
@@ -615,11 +604,7 @@ export default class EasyPostClient {
    * @param {Object} [headers] - Additional headers to send with the request.
    * @returns {*} The response from the HTTP request.
    */
-  _patch(
-    path: string,
-    params: Record<string, unknown> = {},
-    headers: RequestHeaders = {},
-  ): Promise<any> {
+  _patch(path: string, params: RequestBody = {}, headers: RequestHeaders = {}): Promise<any> {
     return this._request(path, EasyPostClient.METHODS.PATCH, params, headers);
   }
 
@@ -630,11 +615,7 @@ export default class EasyPostClient {
    * @param {Object} [headers] - Additional headers to send with the request.
    * @returns {*} The response from the HTTP request.
    */
-  _delete(
-    path: string,
-    params: Record<string, unknown> = {},
-    headers: RequestHeaders = {},
-  ): Promise<any> {
+  _delete(path: string, params: RequestParams = {}, headers: RequestHeaders = {}): Promise<any> {
     return this._request(path, EasyPostClient.METHODS.DELETE, params, headers);
   }
 }

--- a/src/easypost.ts
+++ b/src/easypost.ts
@@ -48,11 +48,11 @@ type HttpClient = typeof fetch;
 interface CompatibilityRequest {
   method: string;
   url: string;
-  _data: unknown;
+  _data: Record<string, unknown> | undefined;
   set(headersToSet?: RequestHeaders): CompatibilityRequest;
   auth(key: string): CompatibilityRequest;
   query(queryParams?: Record<string, unknown>): CompatibilityRequest;
-  send(body?: unknown): CompatibilityRequest;
+  send(body?: Record<string, unknown>): CompatibilityRequest;
 }
 
 interface HttpMiddleware {
@@ -415,7 +415,7 @@ export default class EasyPostClient {
     const isQueryMethod =
       normalizedMethod === EasyPostClient.METHODS.GET ||
       normalizedMethod === EasyPostClient.METHODS.DELETE;
-    let requestBody;
+    let requestBody: Record<string, unknown> | undefined;
 
     if (params !== undefined) {
       if (isQueryMethod) {
@@ -427,7 +427,7 @@ export default class EasyPostClient {
       }
     }
 
-    const compatibilityRequest = {
+    const compatibilityRequest: CompatibilityRequest = {
       method: normalizedMethod.toUpperCase(),
       url: url.toString(),
       _data: requestBody,
@@ -435,7 +435,7 @@ export default class EasyPostClient {
         Object.assign(requestHeaders, headersToSet);
         return compatibilityRequest;
       },
-      auth: (key) => {
+      auth: (key: string) => {
         requestHeaders.Authorization = `Basic ${EasyPostClient._toBase64(`${key}:`)}`;
         return compatibilityRequest;
       },
@@ -446,7 +446,7 @@ export default class EasyPostClient {
         compatibilityRequest.url = url.toString();
         return compatibilityRequest;
       },
-      send: (body = {}) => {
+      send: (body: Record<string, unknown> = {}) => {
         compatibilityRequest._data = body;
         return compatibilityRequest;
       },
@@ -466,7 +466,7 @@ export default class EasyPostClient {
       }
     }
 
-    let middlewareResponse;
+    let middlewareResponse: any;
 
     if (
       this.requestMiddleware &&

--- a/src/models/batch.ts
+++ b/src/models/batch.ts
@@ -1,4 +1,7 @@
 import EasyPostObject from './easypost_object';
+import Pickup from './pickup';
+import ScanForm from './scan_form';
+import Shipment from './shipment';
 
 /**
  * A {@link https://docs.easypost.com/docs/batches Batch} represents a collection of {@link Shipment shipments} that can be processed together.
@@ -8,10 +11,10 @@ import EasyPostObject from './easypost_object';
 export default class Batch extends EasyPostObject {
   declare label_url?: string | null;
   declare num_shipments?: number | null;
-  declare pickup?: Record<string, unknown> | null;
+  declare pickup?: Pickup | null;
   declare reference?: string | null;
-  declare scan_form?: Record<string, unknown> | null;
-  declare shipments?: Record<string, unknown>[] | null;
+  declare scan_form?: ScanForm | null;
+  declare shipments?: Shipment[] | null;
   declare state?: string | null;
   declare status?: Record<string, number> | null;
 }

--- a/src/models/insurance.ts
+++ b/src/models/insurance.ts
@@ -1,4 +1,6 @@
+import Address from './address';
 import EasyPostObject from './easypost_object';
+import Tracker from './tracker';
 
 /**
  * An {@link https://docs.easypost.com/docs/api-keys Insurance} object represents insurance for a {@link Shipment shipment}.
@@ -7,15 +9,15 @@ import EasyPostObject from './easypost_object';
  */
 export default class Insurance extends EasyPostObject {
   declare amount?: string | null;
-  declare fee?: Record<string, unknown> | null;
-  declare from_address?: Record<string, unknown> | null;
+  declare fee?: EasyPostObject | null;
+  declare from_address?: Address | null;
   declare messages?: string[] | null;
   declare provider_id?: string | null;
   declare provider?: string | null;
   declare reference?: string | null;
   declare shipment_id?: string | null;
   declare status?: 'new' | 'pending' | 'purchased' | 'failed' | 'cancelled' | null;
-  declare to_address?: Record<string, unknown> | null;
+  declare to_address?: Address | null;
   declare tracking_code?: string | null;
-  declare tracker?: Record<string, unknown> | null;
+  declare tracker?: Tracker | null;
 }

--- a/src/models/order.ts
+++ b/src/models/order.ts
@@ -1,6 +1,8 @@
 import Constants from '../constants';
+import Address from './address';
 import EasyPostObject from './easypost_object';
 import Rate from './rate';
+import Shipment from './shipment';
 
 /**
  * An {@link https://docs.easypost.com/docs/orders Order} represents a collection of packages, intended only for multi-parcel shipments.
@@ -8,15 +10,15 @@ import Rate from './rate';
  * @extends EasyPostObject
  */
 export default class Order extends EasyPostObject {
-  declare buyer_address?: Record<string, unknown> | null;
-  declare from_address?: Record<string, unknown> | null;
+  declare buyer_address?: Address | null;
+  declare from_address?: Address | null;
   declare is_return?: boolean | null;
   declare messages?: Record<string, unknown>[] | null;
   declare rates?: Rate[] | null;
   declare reference?: string | null;
-  declare return_address?: Record<string, unknown> | null;
-  declare shipments?: Record<string, unknown>[] | null;
-  declare to_address?: Record<string, unknown> | null;
+  declare return_address?: Address | null;
+  declare shipments?: Shipment[] | null;
+  declare to_address?: Address | null;
 
   /**
    * Get the lowest rate for this {@link Order}.

--- a/src/models/pickup.ts
+++ b/src/models/pickup.ts
@@ -1,5 +1,9 @@
 import Constants from '../constants';
+import Address from './address';
+import CarrierAccount from './carrier_account';
 import EasyPostObject from './easypost_object';
+import PickupRate from './pickup_rate';
+import Shipment from './shipment';
 
 /**
  * A {@link https://docs.easypost.com/docs/pickups Pickup} represents a scheduled carrier pickup of packages from an {@link https://docs.easypost.com/docs/addresses Address}.
@@ -7,17 +11,17 @@ import EasyPostObject from './easypost_object';
  * @extends EasyPostObject
  */
 export default class Pickup extends EasyPostObject {
-  declare address?: Record<string, unknown> | null;
-  declare carrier_accounts?: Record<string, unknown>[] | null;
+  declare address?: Address | null;
+  declare carrier_accounts?: CarrierAccount[] | null;
   declare confirmation?: string | null;
   declare instructions?: string | null;
   declare is_account_address?: boolean | null;
   declare max_datetime?: string | null;
   declare messages?: Record<string, unknown>[] | null;
   declare min_datetime?: string | null;
-  declare pickup_rates?: Parameters<typeof Constants.Utils.getLowestRate>[0] | null;
+  declare pickup_rates?: PickupRate[] | null;
   declare reference?: string | null;
-  declare shipment?: Record<string, unknown> | null;
+  declare shipment?: Shipment | null;
   declare status?: 'unknown' | 'scheduled' | 'canceled' | null;
 
   /**

--- a/src/models/shipment.ts
+++ b/src/models/shipment.ts
@@ -1,5 +1,14 @@
 import Constants from '../constants';
+import Address from './address';
+import CustomsInfo from './customs_info';
 import EasyPostObject from './easypost_object';
+import Form from './form';
+import Insurance from './insurance';
+import Parcel from './parcel';
+import PostageLabel from './postage_label';
+import Rate from './rate';
+import ScanForm from './scan_form';
+import Tracker from './tracker';
 
 /**
  * A {@link https://docs.easypost.com/docs/shipments Shipment} represents a physical {@link Parcel}, the origin and destination {@link Address Addresses}, and any associated {@link CustomsInfo}.
@@ -10,26 +19,26 @@ export default class Shipment extends EasyPostObject {
   declare batch_id?: string | null;
   declare batch_message?: string | null;
   declare batch_status?: string | null;
-  declare buyer_address?: Record<string, unknown> | null;
-  declare customs_info?: Record<string, unknown> | null;
+  declare buyer_address?: Address | null;
+  declare customs_info?: CustomsInfo | null;
   declare fees?: Record<string, unknown>[] | null;
-  declare forms?: Record<string, unknown>[] | null;
-  declare from_address?: Record<string, unknown> | null;
-  declare insurance?: Record<string, unknown> | null;
+  declare forms?: Form[] | null;
+  declare from_address?: Address | null;
+  declare insurance?: Insurance | null;
   declare is_return?: boolean | null;
   declare messages?: Record<string, unknown>[] | null;
   declare options?: Record<string, unknown> | null;
-  declare parcel?: Record<string, unknown> | null;
-  declare postage_label?: Record<string, unknown> | null;
-  declare rates?: Parameters<typeof Constants.Utils.getLowestRate>[0] | null;
+  declare parcel?: Parcel | null;
+  declare postage_label?: PostageLabel | null;
+  declare rates?: Rate[] | null;
   declare reference?: string | null;
   declare refund_status?: 'submitted' | 'refunded' | 'rejected' | null;
-  declare return_address?: Record<string, unknown> | null;
-  declare scan_form?: Record<string, unknown> | null;
-  declare selected_rate?: Parameters<typeof Constants.Utils.getLowestRate>[0][number] | null;
+  declare return_address?: Address | null;
+  declare scan_form?: ScanForm | null;
+  declare selected_rate?: Rate | null;
   declare status?: string | null;
-  declare to_address?: Record<string, unknown> | null;
-  declare tracker?: Record<string, unknown> | null;
+  declare to_address?: Address | null;
+  declare tracker?: Tracker | null;
   declare tracking_code?: string | null;
   declare usps_zone?: string | null;
 

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,3 +1,4 @@
+import ApiKey from './api_key';
 import EasyPostObject from './easypost_object';
 
 /**
@@ -6,10 +7,10 @@ import EasyPostObject from './easypost_object';
  * @extends EasyPostObject
  */
 export default class User extends EasyPostObject {
-  declare api_keys?: Record<string, unknown>[] | null;
+  declare api_keys?: ApiKey[] | null;
   declare balance?: string | null;
   declare cc_fee_rate?: string | null;
-  declare children?: Record<string, unknown>[] | null;
+  declare children?: User[] | null;
   declare email?: string | null;
   declare insurance_fee_minimum?: string | null;
   declare insurance_fee_rate?: string | null;

--- a/src/services/address_service.ts
+++ b/src/services/address_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Address from '../models/address';
+import type EasyPostClient from '../easypost';
 
 type AddressCreateParameters = Record<string, unknown> & {
   name?: string | null;
@@ -23,7 +24,7 @@ type AddressCreateParameters = Record<string, unknown> & {
 type PaginationCollection = Record<string, unknown>;
 type AddressCollection = { addresses: Address[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The AddressService class provides methods for interacting with EasyPost {@link Address} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/address_service.ts
+++ b/src/services/address_service.ts
@@ -23,7 +23,7 @@ type AddressCreateParameters = Record<string, unknown> & {
 type PaginationCollection = Record<string, unknown>;
 type AddressCollection = { addresses: Address[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The AddressService class provides methods for interacting with EasyPost {@link Address} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/api_key_service.ts
+++ b/src/services/api_key_service.ts
@@ -1,4 +1,5 @@
 import util from 'util';
+import type EasyPostClient from '../easypost';
 
 import Constants from '../constants';
 import FilteringError from '../errors/general/filtering_error';
@@ -12,7 +13,7 @@ type ApiKeyUser = Record<string, unknown> & {
 };
 type ApiKeyAllResponse = Record<string, unknown>;
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ApiKeyService class provides methods for interacting with EasyPost {@link ApiKey} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/api_key_service.ts
+++ b/src/services/api_key_service.ts
@@ -12,7 +12,7 @@ type ApiKeyUser = Record<string, unknown> & {
 };
 type ApiKeyAllResponse = Record<string, unknown>;
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ApiKeyService class provides methods for interacting with EasyPost {@link ApiKey} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/base_service.ts
+++ b/src/services/base_service.ts
@@ -99,7 +99,7 @@ const RESOURCES = {
   Webhook,
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The base class for all EasyPost client library services.
    * @param {EasyPostClient} easypostClient The {@link EasyPostClient} instance to use for API calls.
@@ -112,13 +112,13 @@ export default (easypostClient) =>
      * @param {*} response The value to serialize.
      * @returns {*} A plain object/array/scalar.
      */
-    static _toPlainEasyPostObject(response) {
+    static _toPlainEasyPostObject(response: any): any {
       if (Array.isArray(response)) {
         return response.map((value) => this._toPlainEasyPostObject(value));
       }
 
       if (typeof response === 'object' && response !== null) {
-        const plainObject = {};
+        const plainObject: Record<string, any> = {};
         const prototype = Object.getPrototypeOf(response);
 
         if (prototype && prototype !== Object.prototype) {
@@ -145,8 +145,10 @@ export default (easypostClient) =>
           });
         }
 
-        Object.keys(response).forEach((key) => {
-          plainObject[key] = this._toPlainEasyPostObject(response[key]);
+        Object.keys(response as Record<string, unknown>).forEach((key) => {
+          plainObject[key] = this._toPlainEasyPostObject(
+            (response as Record<string, unknown>)[key],
+          );
         });
 
         return plainObject;
@@ -162,7 +164,7 @@ export default (easypostClient) =>
      * @param {*} params The parameters passed when fetching the response.
      * @returns {*} An {@link EasyPostObject}-based class instance or an `Array` of {@link EasyPostObject}-based class instances.
      */
-    static _buildEasyPostObject(response, params) {
+    static _buildEasyPostObject(response: any, params: any): any {
       if (Array.isArray(response)) {
         return response.map((value) => {
           if (typeof value === 'object') {
@@ -173,23 +175,26 @@ export default (easypostClient) =>
       }
 
       if (typeof response === 'object' && response !== null) {
-        let classObject;
-        if (RESOURCES[response.object] !== undefined) {
-          classObject = new RESOURCES[response.object]();
+        const responseRecord = response as Record<string, any>;
+        let classObject: any;
+        if ((RESOURCES as Record<string, any>)[responseRecord.object] !== undefined) {
+          classObject = new (RESOURCES as Record<string, any>)[responseRecord.object]();
         } else if (
-          response.id !== undefined &&
-          EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP[
-            response.id.substr(0, response.id.indexOf('_'))
+          responseRecord.id !== undefined &&
+          (EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP as Record<string, any>)[
+            responseRecord.id.substr(0, responseRecord.id.indexOf('_'))
           ] !== undefined
         ) {
-          const className = response.id.substr(0, response.id.indexOf('_'));
-          classObject = new EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP[className]();
+          const className = responseRecord.id.substr(0, responseRecord.id.indexOf('_'));
+          classObject = new (EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP as Record<string, any>)[
+            className
+          ]();
         } else {
           classObject = new EasyPostObject();
         }
 
-        Object.keys(response).forEach((key) => {
-          classObject[key] = this._buildEasyPostObject(response[key], params);
+        Object.keys(responseRecord).forEach((key) => {
+          classObject[key] = this._buildEasyPostObject(responseRecord[key], params);
         });
 
         classObject._params = params;
@@ -220,7 +225,7 @@ export default (easypostClient) =>
      * @param {Object} params The parameters to send with the API request.
      * @returns {EasyPostObject|Promise<never>} The created {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async _create(url, params) {
+    static async _create(url: string, params: any) {
       try {
         const response = await easypostClient._post(url, params);
 
@@ -237,7 +242,7 @@ export default (easypostClient) =>
      * @param {Object} [params] The parameters to send with the API request.
      * @returns {EasyPostObject|EasyPostObject[]|Promise<never>} The retrieved {@link EasyPostObject}-based class instance(s), or a `Promise` that rejects with an error.
      */
-    static async _all(url, params = {}) {
+    static async _all(url: string, params: any = {}) {
       try {
         // eslint-disable-next-line no-param-reassign
         const response = await easypostClient._get(url, params);
@@ -254,7 +259,7 @@ export default (easypostClient) =>
      * @param {string} url The URL to send the API request to.
      * @returns {EasyPostObject|Promise<never>} The retrieved {@link EasyPostObject}-based class instance, or a `Promise` that rejects with an error.
      */
-    static async _retrieve(url) {
+    static async _retrieve(url: string) {
       try {
         const response = await easypostClient._get(url);
 

--- a/src/services/base_service.ts
+++ b/src/services/base_service.ts
@@ -99,6 +99,10 @@ const RESOURCES = {
   Webhook,
 };
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export default (easypostClient: any) =>
   /**
    * The base class for all EasyPost client library services.
@@ -174,18 +178,20 @@ export default (easypostClient: any) =>
         });
       }
 
-      if (typeof response === 'object' && response !== null) {
-        const responseRecord = response as Record<string, any>;
+      if (isObjectRecord(response)) {
         let classObject: any;
-        if ((RESOURCES as Record<string, any>)[responseRecord.object] !== undefined) {
-          classObject = new (RESOURCES as Record<string, any>)[responseRecord.object]();
+        if (
+          typeof response.object === 'string' &&
+          (RESOURCES as Record<string, any>)[response.object] !== undefined
+        ) {
+          classObject = new (RESOURCES as Record<string, any>)[response.object]();
         } else if (
-          responseRecord.id !== undefined &&
+          typeof response.id === 'string' &&
           (EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP as Record<string, any>)[
-            responseRecord.id.substr(0, responseRecord.id.indexOf('_'))
+            response.id.substring(0, response.id.indexOf('_'))
           ] !== undefined
         ) {
-          const className = responseRecord.id.substr(0, responseRecord.id.indexOf('_'));
+          const className = response.id.substring(0, response.id.indexOf('_'));
           classObject = new (EASYPOST_OBJECT_ID_PREFIX_TO_CLASS_NAME_MAP as Record<string, any>)[
             className
           ]();
@@ -193,8 +199,8 @@ export default (easypostClient: any) =>
           classObject = new EasyPostObject();
         }
 
-        Object.keys(responseRecord).forEach((key) => {
-          classObject[key] = this._buildEasyPostObject(responseRecord[key], params);
+        Object.keys(response).forEach((key) => {
+          classObject[key] = this._buildEasyPostObject(response[key], params);
         });
 
         classObject._params = params;

--- a/src/services/batch_service.ts
+++ b/src/services/batch_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Batch from '../models/batch';
+import type EasyPostClient from '../easypost';
 
 export const DEFAULT_LABEL_FORMAT = 'pdf';
 
@@ -8,7 +9,7 @@ type BatchCreateParameters = Record<string, unknown> & {
 };
 type BatchListResponse = { batches: Batch[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The BatchService class provides methods for interacting with EasyPost {@link Batch} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/batch_service.ts
+++ b/src/services/batch_service.ts
@@ -8,7 +8,7 @@ type BatchCreateParameters = Record<string, unknown> & {
 };
 type BatchListResponse = { batches: Batch[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The BatchService class provides methods for interacting with EasyPost {@link Batch} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/batch_service.ts
+++ b/src/services/batch_service.ts
@@ -1,11 +1,15 @@
-import baseService from './base_service';
-import Batch from '../models/batch';
+import type { IShipmentCreateParameters } from '../../types/Shipment';
+import type { DeepPartial } from '../../types/utils';
 import type EasyPostClient from '../easypost';
+import Batch from '../models/batch';
+import baseService from './base_service';
 
 export const DEFAULT_LABEL_FORMAT = 'pdf';
 
+type ShipmentReferenceInput = { id?: string | null } & DeepPartial<IShipmentCreateParameters>;
+
 type BatchCreateParameters = Record<string, unknown> & {
-  shipments?: Array<string | Record<string, unknown>> | null;
+  shipments?: Array<string | ShipmentReferenceInput> | null;
 };
 type BatchListResponse = { batches: Batch[]; has_more: boolean };
 

--- a/src/services/beta_rate_service.ts
+++ b/src/services/beta_rate_service.ts
@@ -1,9 +1,10 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 /**
  * @extends baseService
  */
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   class BetaRateService extends baseService(easypostClient) {
     /**
      * Retrieve a list of stateless {@link Rate rates} based on the provided parameters.

--- a/src/services/beta_rate_service.ts
+++ b/src/services/beta_rate_service.ts
@@ -3,14 +3,14 @@ import baseService from './base_service';
 /**
  * @extends baseService
  */
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   class BetaRateService extends baseService(easypostClient) {
     /**
      * Retrieve a list of stateless {@link Rate rates} based on the provided parameters.
      * @param {Object} params - Map of parameters for the API call
      * @returns {Rate[]} - List of stateless rates
      */
-    static async retrieveStatelessRates(params) {
+    static async retrieveStatelessRates(params: Record<string, unknown>) {
       const url = 'beta/rates';
       const wrappedParams = {
         shipment: params,

--- a/src/services/beta_referral_customer_service.ts
+++ b/src/services/beta_referral_customer_service.ts
@@ -76,9 +76,7 @@ export default (easypostClient: EasyPostClient) =>
       const url = 'beta/setup_intents';
 
       // Preserve legacy null payload behavior for cassette matching in tests.
-      const emptyPayload = null as unknown as Record<string, unknown>;
-
-      const response = await easypostClient._post(url, emptyPayload);
+      const response = await easypostClient._post(url, null);
 
       return response.body;
     }

--- a/src/services/beta_referral_customer_service.ts
+++ b/src/services/beta_referral_customer_service.ts
@@ -4,7 +4,7 @@ type BetaPaymentMethodResponse = Record<string, unknown>;
 type BetaRefundResponse = Record<string, unknown>;
 type BetaClientSecretResponse = Record<string, unknown>;
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   class BetaReferralCustomerService extends baseService(easypostClient) {
     /**
      * Add an existing Stripe payment method to a {@link User referral customer's} account.

--- a/src/services/beta_referral_customer_service.ts
+++ b/src/services/beta_referral_customer_service.ts
@@ -75,7 +75,10 @@ export default (easypostClient: EasyPostClient) =>
     static async createCreditCardClientSecret(): Promise<BetaClientSecretResponse> {
       const url = 'beta/setup_intents';
 
-      const response = await easypostClient._post(url);
+      // Preserve legacy null payload behavior for cassette matching in tests.
+      const emptyPayload = null as unknown as Record<string, unknown>;
+
+      const response = await easypostClient._post(url, emptyPayload);
 
       return response.body;
     }
@@ -87,7 +90,9 @@ export default (easypostClient: EasyPostClient) =>
     static async createBankAccountClientSecret(
       returnUrl: string | null,
     ): Promise<BetaClientSecretResponse> {
-      const params = returnUrl ? { return_url: returnUrl } : undefined;
+      const params = returnUrl
+        ? { return_url: returnUrl }
+        : (null as unknown as Record<string, unknown>);
 
       const url = 'beta/financial_connections_sessions';
 

--- a/src/services/beta_referral_customer_service.ts
+++ b/src/services/beta_referral_customer_service.ts
@@ -1,10 +1,11 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type BetaPaymentMethodResponse = Record<string, unknown>;
 type BetaRefundResponse = Record<string, unknown>;
 type BetaClientSecretResponse = Record<string, unknown>;
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   class BetaReferralCustomerService extends baseService(easypostClient) {
     /**
      * Add an existing Stripe payment method to a {@link User referral customer's} account.
@@ -74,7 +75,7 @@ export default (easypostClient: any) =>
     static async createCreditCardClientSecret(): Promise<BetaClientSecretResponse> {
       const url = 'beta/setup_intents';
 
-      const response = await easypostClient._post(url, null);
+      const response = await easypostClient._post(url);
 
       return response.body;
     }
@@ -86,7 +87,7 @@ export default (easypostClient: any) =>
     static async createBankAccountClientSecret(
       returnUrl: string | null,
     ): Promise<BetaClientSecretResponse> {
-      const params = returnUrl ? { return_url: returnUrl } : null;
+      const params = returnUrl ? { return_url: returnUrl } : undefined;
 
       const url = 'beta/financial_connections_sessions';
 

--- a/src/services/beta_referral_customer_service.ts
+++ b/src/services/beta_referral_customer_service.ts
@@ -1,5 +1,5 @@
-import baseService from './base_service';
 import type EasyPostClient from '../easypost';
+import baseService from './base_service';
 
 type BetaPaymentMethodResponse = Record<string, unknown>;
 type BetaRefundResponse = Record<string, unknown>;
@@ -90,13 +90,14 @@ export default (easypostClient: EasyPostClient) =>
     static async createBankAccountClientSecret(
       returnUrl: string | null,
     ): Promise<BetaClientSecretResponse> {
-      const params = returnUrl
-        ? { return_url: returnUrl }
-        : (null as unknown as Record<string, unknown>);
-
       const url = 'beta/financial_connections_sessions';
+      if (returnUrl) {
+        const response = await easypostClient._post(url, { return_url: returnUrl });
 
-      const response = await easypostClient._post(url, params);
+        return response.body;
+      }
+
+      const response = await easypostClient._post(url);
 
       return response.body;
     }

--- a/src/services/billing_service.ts
+++ b/src/services/billing_service.ts
@@ -13,7 +13,7 @@ type PaymentMethodsResponse = Record<string, unknown> & {
   secondary_payment_method?: PaymentMethodObject | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The BillingService class provides methods for interacting with EasyPost's billing capabilities.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/billing_service.ts
+++ b/src/services/billing_service.ts
@@ -1,6 +1,7 @@
 import Constants from '../constants';
 import InvalidObjectError from '../errors/general/invalid_object_error';
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type PaymentMethodObject = {
   id: string;
@@ -13,7 +14,7 @@ type PaymentMethodsResponse = Record<string, unknown> & {
   secondary_payment_method?: PaymentMethodObject | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The BillingService class provides methods for interacting with EasyPost's billing capabilities.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/carrier_account_service.ts
+++ b/src/services/carrier_account_service.ts
@@ -1,4 +1,5 @@
 import util from 'util';
+import type EasyPostClient from '../easypost';
 
 import Constants from '../constants';
 import InvalidParameterError from '../errors/general/invalid_parameter_error';
@@ -17,7 +18,7 @@ type CarrierAccountCreateParameters = Record<string, unknown> & {
   billing_type?: string | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The CarrierAccountService class provides methods for interacting with EasyPost @{link CarrierAccount} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/carrier_account_service.ts
+++ b/src/services/carrier_account_service.ts
@@ -17,7 +17,7 @@ type CarrierAccountCreateParameters = Record<string, unknown> & {
   billing_type?: string | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The CarrierAccountService class provides methods for interacting with EasyPost @{link CarrierAccount} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/carrier_metadata_service.ts
+++ b/src/services/carrier_metadata_service.ts
@@ -1,11 +1,12 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type CarrierMetadata = Record<string, unknown>;
 
 /**
  * @extends baseService
  */
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   class CarrierMetadataService extends baseService(easypostClient) {
     /**
      * Retrieve a list of carrier metadata based on the provided parameters.

--- a/src/services/carrier_metadata_service.ts
+++ b/src/services/carrier_metadata_service.ts
@@ -5,7 +5,7 @@ type CarrierMetadata = Record<string, unknown>;
 /**
  * @extends baseService
  */
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   class CarrierMetadataService extends baseService(easypostClient) {
     /**
      * Retrieve a list of carrier metadata based on the provided parameters.

--- a/src/services/carrier_type_service.ts
+++ b/src/services/carrier_type_service.ts
@@ -1,7 +1,8 @@
 import baseService from './base_service';
 import CarrierType from '../models/carrier_type';
+import type EasyPostClient from '../easypost';
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The CarrierTypeService class provides methods for interacting with EasyPost {@link CarrierType} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/carrier_type_service.ts
+++ b/src/services/carrier_type_service.ts
@@ -1,7 +1,7 @@
 import baseService from './base_service';
 import CarrierType from '../models/carrier_type';
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The CarrierTypeService class provides methods for interacting with EasyPost {@link CarrierType} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/claim_service.ts
+++ b/src/services/claim_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Claim from '../models/claim';
+import type EasyPostClient from '../easypost';
 
 type ClaimCreateParameters = Record<string, unknown> & {
   tracking_code?: string | null;
@@ -16,7 +17,7 @@ type ClaimCreateParameters = Record<string, unknown> & {
 type ClaimCollection = Record<string, unknown>;
 type ClaimListResponse = { claims: Claim[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ClaimService class provides methods for interacting with EasyPost {@link Claim} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/claim_service.ts
+++ b/src/services/claim_service.ts
@@ -16,7 +16,7 @@ type ClaimCreateParameters = Record<string, unknown> & {
 type ClaimCollection = Record<string, unknown>;
 type ClaimListResponse = { claims: Claim[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ClaimService class provides methods for interacting with EasyPost {@link Claim} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customer_portal_service.ts
+++ b/src/services/customer_portal_service.ts
@@ -1,4 +1,5 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 type ICustomerPortalAccountLink = Record<string, unknown>;
 
 type CustomerPortalAccountLinkCreateParameters = Record<string, unknown> & {
@@ -9,7 +10,7 @@ type CustomerPortalAccountLinkCreateParameters = Record<string, unknown> & {
   metadata?: Record<string, unknown> | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The CustomerPortalService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customer_portal_service.ts
+++ b/src/services/customer_portal_service.ts
@@ -1,5 +1,5 @@
 import baseService from './base_service';
-import type { ICustomerPortalAccountLink } from '../../types/CustomerPortal/CustomerPortalAccountLink';
+type ICustomerPortalAccountLink = Record<string, unknown>;
 
 type CustomerPortalAccountLinkCreateParameters = Record<string, unknown> & {
   session_type?: 'account_onboarding' | 'account_management' | null;
@@ -9,7 +9,7 @@ type CustomerPortalAccountLinkCreateParameters = Record<string, unknown> & {
   metadata?: Record<string, unknown> | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The CustomerPortalService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customs_info_service.ts
+++ b/src/services/customs_info_service.ts
@@ -16,7 +16,7 @@ type CustomsInfoCreateParameters = Record<string, unknown> & {
   declaration?: string | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The CustomsInfoService class provides methods for interacting with EasyPost {@link CustomsInfo} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customs_info_service.ts
+++ b/src/services/customs_info_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import CustomsInfo from '../models/customs_info';
+import type EasyPostClient from '../easypost';
 
 type CustomsItemInput = Record<string, unknown>;
 
@@ -16,7 +17,7 @@ type CustomsInfoCreateParameters = Record<string, unknown> & {
   declaration?: string | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The CustomsInfoService class provides methods for interacting with EasyPost {@link CustomsInfo} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customs_item_service.ts
+++ b/src/services/customs_item_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import CustomsItem from '../models/customs_item';
+import type EasyPostClient from '../easypost';
 
 type CustomsItemCreateParameters = Record<string, unknown> & {
   description?: string | null;
@@ -12,7 +13,7 @@ type CustomsItemCreateParameters = Record<string, unknown> & {
   currency?: string | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The CustomsItemService class provides methods for interacting with EasyPost {@link CustomsItem} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/customs_item_service.ts
+++ b/src/services/customs_item_service.ts
@@ -12,7 +12,7 @@ type CustomsItemCreateParameters = Record<string, unknown> & {
   currency?: string | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The CustomsItemService class provides methods for interacting with EasyPost {@link CustomsItem} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/embeddable_service.ts
+++ b/src/services/embeddable_service.ts
@@ -1,12 +1,12 @@
 import baseService from './base_service';
-import type { IEmbeddablesSession } from '../../types/Embeddable/EmbeddablesSession';
+type IEmbeddablesSession = Record<string, unknown>;
 
 type EmbeddablesSessionCreateParameters = Record<string, unknown> & {
   origin_host?: string | null;
   user_id?: string | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The EmbeddableService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/embeddable_service.ts
+++ b/src/services/embeddable_service.ts
@@ -1,4 +1,5 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 type IEmbeddablesSession = Record<string, unknown>;
 
 type EmbeddablesSessionCreateParameters = Record<string, unknown> & {
@@ -6,7 +7,7 @@ type EmbeddablesSessionCreateParameters = Record<string, unknown> & {
   user_id?: string | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The EmbeddableService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/end_shipper_service.ts
+++ b/src/services/end_shipper_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import EndShipper from '../models/end_shipper';
+import type EasyPostClient from '../easypost';
 
 type EndShipperCreateParameters = Record<string, unknown> & {
   name?: string | null;
@@ -15,7 +16,7 @@ type EndShipperCreateParameters = Record<string, unknown> & {
 };
 type EndShipperListResponse = { end_shippers: EndShipper[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The EndShipperService class provides methods for interacting with EasyPost {@link EndShipper} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/end_shipper_service.ts
+++ b/src/services/end_shipper_service.ts
@@ -15,7 +15,7 @@ type EndShipperCreateParameters = Record<string, unknown> & {
 };
 type EndShipperListResponse = { end_shippers: EndShipper[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The EndShipperService class provides methods for interacting with EasyPost {@link EndShipper} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/event_service.ts
+++ b/src/services/event_service.ts
@@ -5,7 +5,7 @@ import Payload from '../models/payload';
 type EventCollection = Record<string, unknown>;
 type EventListResponse = { events: Event[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The EventService class provides methods for interacting with EasyPost {@link Event} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/event_service.ts
+++ b/src/services/event_service.ts
@@ -1,11 +1,12 @@
 import baseService from './base_service';
 import Event from '../models/event';
 import Payload from '../models/payload';
+import type EasyPostClient from '../easypost';
 
 type EventCollection = Record<string, unknown>;
 type EventListResponse = { events: Event[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The EventService class provides methods for interacting with EasyPost {@link Event} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/fedex_registration_service.ts
+++ b/src/services/fedex_registration_service.ts
@@ -1,9 +1,7 @@
 import { v4 as uuid } from 'uuid';
 
-import type {
-  IFedExAccountValidationResponse,
-  IFedExRequestPinResponse,
-} from '../../types/FedExRegistration/FedExRegistration';
+type IFedExAccountValidationResponse = Record<string, unknown>;
+type IFedExRequestPinResponse = Record<string, unknown>;
 import baseService from './base_service';
 
 type FedExValidationMap = Record<string, unknown> & { name?: string | null };
@@ -14,7 +12,7 @@ type FedExParams = Record<string, unknown> & {
   easypost_details?: Record<string, unknown>;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The FedExRegistrationService class provides methods for registering FedEx carrier accounts with MFA.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/fedex_registration_service.ts
+++ b/src/services/fedex_registration_service.ts
@@ -1,8 +1,9 @@
 import { v4 as uuid } from 'uuid';
+import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type IFedExAccountValidationResponse = Record<string, unknown>;
 type IFedExRequestPinResponse = Record<string, unknown>;
-import baseService from './base_service';
 
 type FedExValidationMap = Record<string, unknown> & { name?: string | null };
 type FedExParams = Record<string, unknown> & {
@@ -12,7 +13,7 @@ type FedExParams = Record<string, unknown> & {
   easypost_details?: Record<string, unknown>;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The FedExRegistrationService class provides methods for registering FedEx carrier accounts with MFA.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -1,11 +1,12 @@
-import baseService from './base_service';
-import Insurance from '../models/insurance';
 import type EasyPostClient from '../easypost';
+import Address from '../models/address';
+import Insurance from '../models/insurance';
+import baseService from './base_service';
 
 type InsuranceCreateParameters = Record<string, unknown> & {
   reference?: string | null;
-  to_address?: Record<string, unknown> | string | null;
-  from_address?: Record<string, unknown> | string | null;
+  to_address?: Address | string | null;
+  from_address?: Address | string | null;
   carrier?: string | null;
   tracking_code?: string | null;
   amount?: string | null;

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Insurance from '../models/insurance';
+import type EasyPostClient from '../easypost';
 
 type InsuranceCreateParameters = Record<string, unknown> & {
   reference?: string | null;
@@ -12,7 +13,7 @@ type InsuranceCreateParameters = Record<string, unknown> & {
 type InsuranceCollection = Record<string, unknown>;
 type InsuranceListResponse = { insurances: Insurance[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The InsuranceService class provides methods for interacting with EasyPost {@link Insurance} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/insurance_service.ts
+++ b/src/services/insurance_service.ts
@@ -12,7 +12,7 @@ type InsuranceCreateParameters = Record<string, unknown> & {
 type InsuranceCollection = Record<string, unknown>;
 type InsuranceListResponse = { insurances: Insurance[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The InsuranceService class provides methods for interacting with EasyPost {@link Insurance} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/luma_service.ts
+++ b/src/services/luma_service.ts
@@ -1,9 +1,10 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 type ILumaPromise = Record<string, unknown>;
 
 type LumaParams = Record<string, unknown>;
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The LumaService class provides methods for interacting with EasyPost Luma objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/luma_service.ts
+++ b/src/services/luma_service.ts
@@ -1,9 +1,9 @@
 import baseService from './base_service';
-import type { ILumaPromise } from '../../types/Luma/Luma';
+type ILumaPromise = Record<string, unknown>;
 
 type LumaParams = Record<string, unknown>;
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The LumaService class provides methods for interacting with EasyPost Luma objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/order_service.ts
+++ b/src/services/order_service.ts
@@ -1,13 +1,15 @@
-import baseService from './base_service';
+import type EasyPostClient from '../easypost';
+import Address from '../models/address';
 import Order from '../models/order';
 import Rate from '../models/rate';
-import type EasyPostClient from '../easypost';
+import Shipment from '../models/shipment';
+import baseService from './base_service';
 
-type OrderCreateParameters = Record<string, unknown> & {
+type OrderCreateParameters = {
   reference?: string | null;
-  to_address?: Record<string, unknown> | string | null;
-  from_address?: Record<string, unknown> | string | null;
-  shipments?: Array<Record<string, unknown> | string> | null;
+  to_address?: Address | string | null;
+  from_address?: Address | string | null;
+  shipments?: Array<Shipment | string> | null;
   carrier_accounts?: string[] | null;
 };
 type OrderRatesResponse = { rates: Rate[] };

--- a/src/services/order_service.ts
+++ b/src/services/order_service.ts
@@ -11,7 +11,7 @@ type OrderCreateParameters = Record<string, unknown> & {
 };
 type OrderRatesResponse = { rates: Rate[] };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The OrderService class provides methods for interacting with EasyPost {@link Order} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/order_service.ts
+++ b/src/services/order_service.ts
@@ -1,6 +1,7 @@
 import baseService from './base_service';
 import Order from '../models/order';
 import Rate from '../models/rate';
+import type EasyPostClient from '../easypost';
 
 type OrderCreateParameters = Record<string, unknown> & {
   reference?: string | null;
@@ -11,7 +12,7 @@ type OrderCreateParameters = Record<string, unknown> & {
 };
 type OrderRatesResponse = { rates: Rate[] };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The OrderService class provides methods for interacting with EasyPost {@link Order} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/parcel_service.ts
+++ b/src/services/parcel_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Parcel from '../models/parcel';
+import type EasyPostClient from '../easypost';
 
 type ParcelCreateParameters = Record<string, unknown> & {
   length?: number | null;
@@ -9,7 +10,7 @@ type ParcelCreateParameters = Record<string, unknown> & {
   predefined_package?: string | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ParcelService class provides methods for interacting with EasyPost {@link Parcel} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/parcel_service.ts
+++ b/src/services/parcel_service.ts
@@ -9,7 +9,7 @@ type ParcelCreateParameters = Record<string, unknown> & {
   predefined_package?: string | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ParcelService class provides methods for interacting with EasyPost {@link Parcel} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/pickup_service.ts
+++ b/src/services/pickup_service.ts
@@ -1,20 +1,25 @@
-import baseService from './base_service';
-import Pickup from '../models/pickup';
 import type EasyPostClient from '../easypost';
+import Address from '../models/address';
+import Batch from '../models/batch';
+import CarrierAccount from '../models/carrier_account';
+import Pickup from '../models/pickup';
+import PickupRate from '../models/pickup_rate';
+import Shipment from '../models/shipment';
+import baseService from './base_service';
 
-type PickupCreateParameters = Record<string, unknown> & {
-  address?: Record<string, unknown> | string | null;
-  carrier_accounts?: Array<Record<string, unknown> | string> | null;
+type PickupCreateParameters = {
+  address?: Address | string | null;
+  carrier_accounts?: Array<CarrierAccount | string> | null;
   confirmation?: string | null;
   instructions?: string | null;
   is_account_address?: boolean | null;
   max_datetime?: string | null;
   min_datetime?: string | null;
-  pickup_rates?: Record<string, unknown> | null;
+  pickup_rates?: PickupRate[] | null;
   reference?: string | null;
   status?: string | null;
-  shipment?: Record<string, unknown> | string | null;
-  batch?: Record<string, unknown> | string | null;
+  shipment?: Shipment | string | null;
+  batch?: Batch | string | null;
 };
 type PickupCollection = Record<string, unknown>;
 type PickupListResponse = { pickups: Pickup[]; has_more: boolean };

--- a/src/services/pickup_service.ts
+++ b/src/services/pickup_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Pickup from '../models/pickup';
+import type EasyPostClient from '../easypost';
 
 type PickupCreateParameters = Record<string, unknown> & {
   address?: Record<string, unknown> | string | null;
@@ -18,7 +19,7 @@ type PickupCreateParameters = Record<string, unknown> & {
 type PickupCollection = Record<string, unknown>;
 type PickupListResponse = { pickups: Pickup[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The PickupService class provides methods for interacting with EasyPost {@link Pickup} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/pickup_service.ts
+++ b/src/services/pickup_service.ts
@@ -18,7 +18,7 @@ type PickupCreateParameters = Record<string, unknown> & {
 type PickupCollection = Record<string, unknown>;
 type PickupListResponse = { pickups: Pickup[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The PickupService class provides methods for interacting with EasyPost {@link Pickup} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/rate_service.ts
+++ b/src/services/rate_service.ts
@@ -1,7 +1,7 @@
 import baseService from './base_service';
 import Rate from '../models/rate';
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The RateService class provides methods for interacting with EasyPost {@link Rate} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/rate_service.ts
+++ b/src/services/rate_service.ts
@@ -1,7 +1,8 @@
 import baseService from './base_service';
 import Rate from '../models/rate';
+import type EasyPostClient from '../easypost';
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The RateService class provides methods for interacting with EasyPost {@link Rate} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/referral_customer_service.ts
+++ b/src/services/referral_customer_service.ts
@@ -128,7 +128,7 @@ async function _sendCardDetailsToEasyPost(
   return response.body;
 }
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ReferralCustomerService class provides methods for interacting with EasyPost {@link User referral customer} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/referral_customer_service.ts
+++ b/src/services/referral_customer_service.ts
@@ -6,7 +6,6 @@ import EasyPostClient from '../easypost';
 import ExternalApiError from '../errors/api/external_api_error';
 import User from '../models/user';
 import baseService from './base_service';
-type IPaymentMethod = Record<string, unknown>;
 
 type ReferralCreateParameters = Record<string, unknown> & {
   reference?: string | null;

--- a/src/services/referral_customer_service.ts
+++ b/src/services/referral_customer_service.ts
@@ -6,6 +6,7 @@ import EasyPostClient from '../easypost';
 import ExternalApiError from '../errors/api/external_api_error';
 import User from '../models/user';
 import baseService from './base_service';
+type IPaymentMethod = Record<string, unknown>;
 
 type ReferralCreateParameters = Record<string, unknown> & {
   reference?: string | null;
@@ -128,7 +129,7 @@ async function _sendCardDetailsToEasyPost(
   return response.body;
 }
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ReferralCustomerService class provides methods for interacting with EasyPost {@link User referral customer} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/refund_service.ts
+++ b/src/services/refund_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Refund from '../models/refund';
+import type EasyPostClient from '../easypost';
 
 type RefundCreateParameters = Record<string, unknown> & {
   carrier?: string | null;
@@ -8,7 +9,7 @@ type RefundCreateParameters = Record<string, unknown> & {
 type RefundCollection = Record<string, unknown>;
 type RefundListResponse = { refunds: Refund[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The RefundService class provides methods for interacting with EasyPost {@link Refund} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/refund_service.ts
+++ b/src/services/refund_service.ts
@@ -8,7 +8,7 @@ type RefundCreateParameters = Record<string, unknown> & {
 type RefundCollection = Record<string, unknown>;
 type RefundListResponse = { refunds: Refund[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The RefundService class provides methods for interacting with EasyPost {@link Refund} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/report_service.ts
+++ b/src/services/report_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Report from '../models/report';
+import type EasyPostClient from '../easypost';
 
 type ReportCreateParameters = Record<string, unknown> & {
   type: string;
@@ -10,11 +11,11 @@ type ReportAllParameters = Record<string, unknown> & {
 };
 
 type ReportCollection = Record<string, unknown> & {
-  reports?: Array<Record<string, any>>;
+  reports?: Array<Record<string, unknown>>;
 };
 type ReportListResponse = { reports: Report[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ReportService class provides methods for interacting with EasyPost {@link Report} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.
@@ -67,7 +68,8 @@ export default (easypostClient: any) =>
       reports: ReportCollection,
       pageSize: number | null = null,
     ): Promise<ReportListResponse> {
-      const url = `reports/${reports.reports?.[0]?._params?.type || ''}`;
+      const firstReport = reports.reports?.[0] as { _params?: { type?: string } } | undefined;
+      const url = `reports/${firstReport?._params?.type || ''}`;
       return this._getNextPage(url, 'reports', reports, pageSize);
     }
 

--- a/src/services/report_service.ts
+++ b/src/services/report_service.ts
@@ -14,7 +14,7 @@ type ReportCollection = Record<string, unknown> & {
 };
 type ReportListResponse = { reports: Report[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ReportService class provides methods for interacting with EasyPost {@link Report} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/scan_form_service.ts
+++ b/src/services/scan_form_service.ts
@@ -7,7 +7,7 @@ type ScanFormCreateParameters = Record<string, unknown> & {
 type ScanFormCollection = Record<string, unknown>;
 type ScanFormListResponse = { scan_forms: ScanForm[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ScanFormService class provides methods for interacting with EasyPost {@link ScanForm} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/scan_form_service.ts
+++ b/src/services/scan_form_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import ScanForm from '../models/scan_form';
+import type EasyPostClient from '../easypost';
 
 type ScanFormCreateParameters = Record<string, unknown> & {
   shipments?: Array<string | { id?: string | null } | Record<string, unknown>> | null;
@@ -7,7 +8,7 @@ type ScanFormCreateParameters = Record<string, unknown> & {
 type ScanFormCollection = Record<string, unknown>;
 type ScanFormListResponse = { scan_forms: ScanForm[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ScanFormService class provides methods for interacting with EasyPost {@link ScanForm} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/scan_form_service.ts
+++ b/src/services/scan_form_service.ts
@@ -1,9 +1,13 @@
-import baseService from './base_service';
-import ScanForm from '../models/scan_form';
+import type { IShipmentCreateParameters } from '../../types/Shipment';
+import type { DeepPartial } from '../../types/utils';
 import type EasyPostClient from '../easypost';
+import ScanForm from '../models/scan_form';
+import baseService from './base_service';
 
-type ScanFormCreateParameters = Record<string, unknown> & {
-  shipments?: Array<string | { id?: string | null } | Record<string, unknown>> | null;
+type ShipmentReferenceInput = { id?: string | null } & DeepPartial<IShipmentCreateParameters>;
+
+type ScanFormCreateParameters = {
+  shipments?: Array<string | ShipmentReferenceInput> | null;
 };
 type ScanFormCollection = Record<string, unknown>;
 type ScanFormListResponse = { scan_forms: ScanForm[]; has_more: boolean };

--- a/src/services/shipment_service.ts
+++ b/src/services/shipment_service.ts
@@ -45,7 +45,7 @@ type ShipmentCollection = Record<string, unknown>;
 type ShipmentListResponse = { shipments: Shipment[]; has_more: boolean };
 type ShipmentSmartRateResponse = Array<Record<string, unknown>>;
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The ShipmentService class provides methods for interacting with EasyPost {@link Shipment} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/shipment_service.ts
+++ b/src/services/shipment_service.ts
@@ -2,6 +2,7 @@ import Constants from '../constants';
 import Rate from '../models/rate';
 import Shipment from '../models/shipment';
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type AddressCreateInput = Record<string, unknown> & {
   verify?: boolean | string | string[] | null;
@@ -44,8 +45,12 @@ type ShipmentRateInput = string | { id: string };
 type ShipmentCollection = Record<string, unknown>;
 type ShipmentListResponse = { shipments: Shipment[]; has_more: boolean };
 type ShipmentSmartRateResponse = Array<Record<string, unknown>>;
+type SmartRate = {
+  rate: string;
+  time_in_transit: Record<string, number>;
+};
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The ShipmentService class provides methods for interacting with EasyPost {@link Shipment} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.
@@ -158,7 +163,7 @@ export default (easypostClient: any) =>
      * @param {string} id - The ID of the shipment to get SmartRates for.
      * @returns {Rate[]} - The SmartRates for the shipment.
      */
-    static async getSmartRates(id: string): Promise<Rate[]> {
+    static async getSmartRates(id: string): Promise<ShipmentSmartRateResponse> {
       const url = `shipments/${id}/smartrate`;
 
       try {
@@ -249,8 +254,8 @@ export default (easypostClient: any) =>
       id: string,
       deliveryDays: number,
       deliveryAccuracy: string,
-    ): Promise<ReturnType<typeof Constants.Utils.getLowestSmartRate>> {
-      const smartRates = (await this.getSmartRates(id)) as any[];
+    ): Promise<Rate> {
+      const smartRates = (await this.getSmartRates(id)) as SmartRate[];
       return Constants.Utils.getLowestSmartRate(
         smartRates,
         deliveryDays,

--- a/src/services/shipment_service.ts
+++ b/src/services/shipment_service.ts
@@ -1,8 +1,13 @@
+import type { ICustomsInfoCreateParameters } from '../../types/Customs/CustomsInfo/CustomsInfoCreateParameters';
+import type { DeepPartial } from '../../types/utils';
 import Constants from '../constants';
+import type EasyPostClient from '../easypost';
+import Address from '../models/address';
+import CustomsInfo from '../models/customs_info';
+import Parcel from '../models/parcel';
 import Rate from '../models/rate';
 import Shipment from '../models/shipment';
 import baseService from './base_service';
-import type EasyPostClient from '../easypost';
 
 type AddressCreateInput = Record<string, unknown> & {
   verify?: boolean | string | string[] | null;
@@ -30,13 +35,16 @@ type ShipmentLineItem = Record<string, unknown> & {
   item_description?: string | null;
 };
 
+type CustomsInfoReferenceInput = DeepPartial<ICustomsInfoCreateParameters>;
+
 type ShipmentCreateParameters = Record<string, unknown> & {
   reference?: string | null;
-  to_address?: AddressCreateInput | string | null;
-  from_address?: AddressCreateInput | string | null;
-  parcel?: ParcelCreateInput | string | null;
+  to_address?: AddressCreateInput | Address | string | null;
+  from_address?: AddressCreateInput | Address | string | null;
+  parcel?: ParcelCreateInput | Parcel | string | null;
   carrier_accounts?: string[] | null;
-  customs_info?: Record<string, unknown> | Record<string, unknown>[] | null;
+  customs_info?:
+    CustomsInfo | CustomsInfo[] | CustomsInfoReferenceInput | CustomsInfoReferenceInput[] | null;
   tax_identifiers?: Array<ShipmentTaxIdentifier | null | undefined> | null;
   options?: Record<string, unknown> | null;
   line_items?: ShipmentLineItem[] | null;

--- a/src/services/shipment_service.ts
+++ b/src/services/shipment_service.ts
@@ -5,7 +5,6 @@ import type EasyPostClient from '../easypost';
 import Address from '../models/address';
 import CustomsInfo from '../models/customs_info';
 import Parcel from '../models/parcel';
-import Rate from '../models/rate';
 import Shipment from '../models/shipment';
 import baseService from './base_service';
 
@@ -262,7 +261,7 @@ export default (easypostClient: EasyPostClient) =>
       id: string,
       deliveryDays: number,
       deliveryAccuracy: string,
-    ): Promise<Rate> {
+    ): Promise<ReturnType<typeof Constants.Utils.getLowestSmartRate>> {
       const smartRates = (await this.getSmartRates(id)) as SmartRate[];
       return Constants.Utils.getLowestSmartRate(
         smartRates,

--- a/src/services/smart_rate_service.ts
+++ b/src/services/smart_rate_service.ts
@@ -3,7 +3,7 @@ import baseService from './base_service';
 type SmartRateParams = Record<string, unknown>;
 type SmartRateResult = { results: Array<Record<string, unknown>> };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The SmartRateService class provides methods for interacting with EasyPost SmartRate APIs.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/smart_rate_service.ts
+++ b/src/services/smart_rate_service.ts
@@ -1,9 +1,10 @@
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type SmartRateParams = Record<string, unknown>;
 type SmartRateResult = { results: Array<Record<string, unknown>> };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The SmartRateService class provides methods for interacting with EasyPost SmartRate APIs.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/tracker_service.ts
+++ b/src/services/tracker_service.ts
@@ -8,7 +8,7 @@ type TrackerCreateParameters = Record<string, unknown> & {
 type TrackerCollection = Record<string, unknown>;
 type TrackerListResponse = { trackers: Tracker[]; has_more: boolean };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The TrackerService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/tracker_service.ts
+++ b/src/services/tracker_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Tracker from '../models/tracker';
+import type EasyPostClient from '../easypost';
 
 type TrackerCreateParameters = Record<string, unknown> & {
   tracking_code?: string | null;
@@ -8,7 +9,7 @@ type TrackerCreateParameters = Record<string, unknown> & {
 type TrackerCollection = Record<string, unknown>;
 type TrackerListResponse = { trackers: Tracker[]; has_more: boolean };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The TrackerService class provides methods for interacting with EasyPost {@link Tracker} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/user_service.ts
+++ b/src/services/user_service.ts
@@ -2,6 +2,7 @@ import EndOfPaginationError from '../errors/general/end_of_pagination_error';
 import Brand from '../models/brand';
 import User from '../models/user';
 import baseService from './base_service';
+import type EasyPostClient from '../easypost';
 
 type UserCreateParameters = Record<string, unknown> & {
   reference?: string | null;
@@ -26,7 +27,7 @@ type UserCollection = Record<string, unknown> & {
   _params?: Record<string, unknown>;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The UserService class provides methods for interacting with EasyPost {@link User} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/user_service.ts
+++ b/src/services/user_service.ts
@@ -26,7 +26,7 @@ type UserCollection = Record<string, unknown> & {
   _params?: Record<string, unknown>;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The UserService class provides methods for interacting with EasyPost {@link User} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/webhook_service.ts
+++ b/src/services/webhook_service.ts
@@ -1,5 +1,6 @@
 import baseService from './base_service';
 import Webhook from '../models/webhook';
+import type EasyPostClient from '../easypost';
 
 type WebhookListResponse = { webhooks: Webhook[]; has_more?: boolean };
 
@@ -9,7 +10,7 @@ type WebhookCreateParameters = Record<string, unknown> & {
   custom_headers?: Array<{ key?: string | null; value?: string | null }> | null;
 };
 
-export default (easypostClient: any) =>
+export default (easypostClient: EasyPostClient) =>
   /**
    * The WebhookService class provides methods for interacting with EasyPost {@link Webhook} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/src/services/webhook_service.ts
+++ b/src/services/webhook_service.ts
@@ -9,7 +9,7 @@ type WebhookCreateParameters = Record<string, unknown> & {
   custom_headers?: Array<{ key?: string | null; value?: string | null }> | null;
 };
 
-export default (easypostClient) =>
+export default (easypostClient: any) =>
   /**
    * The WebhookService class provides methods for interacting with EasyPost {@link Webhook} objects.
    * @param {EasyPostClient} easypostClient - The pre-configured EasyPostClient instance to use for API requests with this service.

--- a/test/cassettes/BetaReferralCustomerService_312890993/returns-a-client-secret-for-bank-accounts_845792627/recording.har
+++ b/test/cassettes/BetaReferralCustomerService_312890993/returns-a-client-secret-for-bank-accounts_845792627/recording.har
@@ -8,11 +8,11 @@
     },
     "entries": [
       {
-        "_id": "fd86d71aec904eeda772e0872fade10b",
+        "_id": "25919e1de1ea7fb2a3a25ab8d9f01563",
         "_order": 0,
         "cache": {},
         "request": {
-          "bodySize": 4,
+          "bodySize": 2,
           "cookies": [],
           "headers": [
             {
@@ -33,7 +33,7 @@
             },
             {
               "name": "content-length",
-              "value": 4
+              "value": 2
             }
           ],
           "headersSize": 413,
@@ -42,7 +42,7 @@
           "postData": {
             "mimeType": "application/json",
             "params": [],
-            "text": "null"
+            "text": "{}"
           },
           "queryString": [],
           "url": "https://api.easypost.com/beta/financial_connections_sessions"
@@ -52,7 +52,7 @@
           "content": {
             "mimeType": "application/json; charset=utf-8",
             "size": 65,
-            "text": "{\"client_secret\":\"fcsess_client_secret_j4Xu997KSVQbgsty7UGQZA4q\"}"
+            "text": "{\"client_secret\":\"fcsess_client_secret_urzeorbaeALXXpiXraSavWCy\"}"
           },
           "cookies": [],
           "headers": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "x-ep-request-uuid",
-              "value": "d6c23b756a6b8bfce0e3071403f2ba1a"
+              "value": "66a5ceec6a970bf2e2cc201b01aaab07"
             },
             {
               "name": "x-frame-options",
@@ -110,7 +110,7 @@
             },
             {
               "name": "x-node",
-              "value": "bigweb42nuq"
+              "value": "web106azw"
             },
             {
               "name": "x-permitted-cross-domain-policies",
@@ -118,29 +118,29 @@
             },
             {
               "name": "x-proxied",
-              "value": "intlb4nuq 1bff4a8790, extlb1nuq e8c67c6320"
+              "value": "intlb1azw 9e5fc37155, extlb3azw afee027586"
             },
             {
               "name": "x-runtime",
-              "value": "0.358959"
+              "value": "0.391711"
             },
             {
               "name": "x-version-label",
-              "value": "easypost-202607300115-be0cf87c94-main"
+              "value": "easypost-202608312207-0e8c86cf17-main"
             },
             {
               "name": "x-xss-protection",
               "value": "1; mode=block"
             }
           ],
-          "headersSize": 675,
+          "headersSize": 673,
           "httpVersion": "HTTP/1.1",
           "redirectURL": "",
           "status": 201,
           "statusText": "Created"
         },
-        "startedDateTime": "2026-07-30T17:38:04.401Z",
-        "time": 479,
+        "startedDateTime": "2026-09-01T17:31:30.153Z",
+        "time": 573,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -148,7 +148,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 479
+          "wait": 573
         }
       }
     ],

--- a/test/services/address.test.ts
+++ b/test/services/address.test.ts
@@ -17,7 +17,7 @@ type AddressTestCreateAndVerifyInput = Parameters<
 /* eslint-disable func-names */
 describe('Address Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -111,7 +111,7 @@ describe('Address Service', function () {
 
     expect(addressesArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(addresses.has_more).to.exist;
-    addressesArray.forEach((address) => {
+    addressesArray.forEach((address: any) => {
       expect(address).to.be.an.instanceOf(Address);
     });
   });
@@ -146,7 +146,7 @@ describe('Address Service', function () {
     const addressData = Fixture.incorrectAddress() as AddressTestCreateAndVerifyInput;
 
     // Creates with verify = true behind the scenes, will throw an error if the address cannot be verified
-    return client.Address.createAndVerify(addressData).catch((err) =>
+    return client.Address.createAndVerify(addressData).catch((err: any) =>
       expect(err).to.be.an.instanceOf(InvalidRequestError),
     );
   });
@@ -163,7 +163,7 @@ describe('Address Service', function () {
   it('throws an error when we cannot verify an address', async function () {
     const address = await client.Address.create({ street1: 'invalid' });
 
-    return client.Address.verifyAddress(address.id).catch((err) =>
+    return client.Address.verifyAddress(address.id).catch((err: any) =>
       expect(err).to.be.an.instanceOf(InvalidRequestError),
     );
   });
@@ -186,7 +186,7 @@ describe('Address Service', function () {
 
     addressData.verify_carrier = 'UPS';
 
-    return client.Address.createAndVerify(addressData).catch((err) =>
+    return client.Address.createAndVerify(addressData).catch((err: any) =>
       expect(err).to.be.an.instanceOf(InvalidRequestError),
     );
   });

--- a/test/services/api_key.test.ts
+++ b/test/services/api_key.test.ts
@@ -8,7 +8,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('ApiKey Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);
@@ -40,7 +40,7 @@ describe('ApiKey Service', function () {
   it('retrieves all apiKeys', async function () {
     const apiKeys = await client.ApiKey.all();
 
-    apiKeys.keys.forEach((apiKey) => {
+    apiKeys.keys.forEach((apiKey: any) => {
       expect(apiKey).to.be.an.instanceOf(ApiKey);
     });
   });

--- a/test/services/base_service.test.ts
+++ b/test/services/base_service.test.ts
@@ -22,7 +22,7 @@ describe('Base Service', function () {
   it('getNextPage collects all pages', async function () {
     const pageSize = 1; // Doesn't matter what this is, we're mocking the response
 
-    let allResults = [];
+    let allResults: any[] = [];
     let previousPage = null;
 
     // Using scanforms as an example, but this should work for any service since it's a base class method
@@ -35,7 +35,7 @@ describe('Base Service', function () {
       ],
       has_more: true,
     };
-    let middleware = (request) => {
+    let middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule('GET', 'v2\\/scan_forms'),
@@ -61,7 +61,7 @@ describe('Base Service', function () {
       ],
       has_more: true,
     };
-    middleware = (request) => {
+    middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule('GET', 'v2\\/scan_forms'),
@@ -87,7 +87,7 @@ describe('Base Service', function () {
       ],
       has_more: false,
     };
-    middleware = (request) => {
+    middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule('GET', 'v2\\/scan_forms'),
@@ -132,7 +132,7 @@ describe('Base Service', function () {
       ],
       has_more: true,
     };
-    let middleware = (request) => {
+    let middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule('GET', 'v2\\/scan_forms'),
@@ -157,7 +157,7 @@ describe('Base Service', function () {
       ],
       has_more: true,
     };
-    middleware = (request) => {
+    middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule('GET', 'v2\\/scan_forms'),

--- a/test/services/batch.test.ts
+++ b/test/services/batch.test.ts
@@ -15,7 +15,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Batch Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -54,7 +54,7 @@ describe('Batch Service', function () {
 
     expect(addressesArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(batches.has_more).to.exist;
-    addressesArray.forEach((batch) => {
+    addressesArray.forEach((batch: any) => {
       expect(batch).to.be.an.instanceOf(Batch);
     });
   });

--- a/test/services/beta_rate.test.ts
+++ b/test/services/beta_rate.test.ts
@@ -14,7 +14,7 @@ type BetaRateRetrieveInput = Parameters<
 /* eslint-disable func-names */
 describe('BetaRateService', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -30,7 +30,7 @@ describe('BetaRateService', function () {
       Fixture.basicShipment() as BetaRateRetrieveInput,
     );
 
-    statelessRates.forEach((rate) => {
+    statelessRates.forEach((rate: any) => {
       expect(rate).to.be.an.instanceOf(Rate);
       expect(rate).to.not.have.property('id');
     });

--- a/test/services/beta_referral_customer.test.ts
+++ b/test/services/beta_referral_customer.test.ts
@@ -5,7 +5,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('BetaReferralCustomerService', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     const referralCustomerProdApiKey = process.env.REFERRAL_CUSTOMER_PROD_API_KEY || '123';
@@ -18,7 +18,7 @@ describe('BetaReferralCustomerService', function () {
   });
 
   it('add payment method to a referral customer account', async function () {
-    await client.BetaReferralCustomer.addPaymentMethod('cus_123', 'ba_123').catch((error) => {
+    await client.BetaReferralCustomer.addPaymentMethod('cus_123', 'ba_123').catch((error: any) => {
       expect(error.statusCode).to.equal(422);
       expect(error.code).to.equal('BILLING.INVALID_PAYMENT_GATEWAY_REFERENCE');
       expect(error.message).to.equal('Invalid connect integration.');
@@ -26,7 +26,7 @@ describe('BetaReferralCustomerService', function () {
   });
 
   it('Refund by amount for a recent payment', async function () {
-    await client.BetaReferralCustomer.refundByAmount(2000).catch((error) => {
+    await client.BetaReferralCustomer.refundByAmount(2000).catch((error: any) => {
       expect(error.statusCode).to.equal(422);
       expect(error.code).to.equal('TRANSACTION.AMOUNT_INVALID');
       expect(error.message).to.equal(
@@ -36,7 +36,7 @@ describe('BetaReferralCustomerService', function () {
   });
 
   it('Refund a payment by a payment log ID', async function () {
-    await client.BetaReferralCustomer.refundByPaymentLog('paylog_...').catch((error) => {
+    await client.BetaReferralCustomer.refundByPaymentLog('paylog_...').catch((error: any) => {
       expect(error.statusCode).to.equal(422);
       expect(error.code).to.equal('TRANSACTION.DOES_NOT_EXIST');
       expect(error.message).to.equal('We could not find a transaction with that id.');

--- a/test/services/billing.test.ts
+++ b/test/services/billing.test.ts
@@ -9,7 +9,7 @@ import {
   MockRequestResponseInfo,
 } from '../helpers/mocking';
 
-const middleware = (request) => {
+const middleware = (request: any) => {
   return new MockMiddleware(request, [
     new MockRequest(
       new MockRequestMatchRule('POST', 'v2\\/bank_accounts\\/\\S*\\/charges$'),
@@ -47,7 +47,7 @@ const middleware = (request) => {
 };
 
 describe('Billing Service', function () {
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY, {

--- a/test/services/carrier_account.test.ts
+++ b/test/services/carrier_account.test.ts
@@ -15,7 +15,7 @@ type CarrierAccountTestCreateInput = Parameters<
 /* eslint-disable func-names */
 describe('CarrierAccount Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);
@@ -87,7 +87,7 @@ describe('CarrierAccount Service', function () {
   it('retrieves all carrier accounts', async function () {
     const carrierAccounts = await client.CarrierAccount.all();
 
-    carrierAccounts.forEach((carrierAccount) => {
+    carrierAccounts.forEach((carrierAccount: any) => {
       expect(carrierAccount).to.be.an.instanceOf(CarrierAccount);
     });
   });
@@ -143,7 +143,7 @@ describe('CarrierAccount Service', function () {
     );
 
     await client.CarrierAccount.delete(carrierAccount.id).then(
-      expect(function (result) {
+      expect(function (result: any) {
         result.not.to.throw();
       }),
     );

--- a/test/services/carrier_metadata.test.ts
+++ b/test/services/carrier_metadata.test.ts
@@ -6,7 +6,7 @@ import * as setupPolly from '../helpers/setup_polly';
 /* eslint-disable func-names */
 describe('CarrierMetadataService', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -20,8 +20,8 @@ describe('CarrierMetadataService', function () {
   it('retrieves all carrier metadata', async function () {
     const carrierMetadata = await client.CarrierMetadata.retrieve();
 
-    expect(carrierMetadata.some((carrier) => carrier.name === 'usps')).to.be.true;
-    expect(carrierMetadata.some((carrier) => carrier.name === 'fedex')).to.be.true;
+    expect(carrierMetadata.some((carrier: any) => carrier.name === 'usps')).to.be.true;
+    expect(carrierMetadata.some((carrier: any) => carrier.name === 'fedex')).to.be.true;
   });
 
   it('retrieves carrier metadata based on the filters provided', async function () {
@@ -30,7 +30,7 @@ describe('CarrierMetadataService', function () {
       ['service_levels', 'predefined_packages'],
     );
 
-    expect(carrierMetadata.some((carrier) => carrier.name === 'usps')).to.be.true;
+    expect(carrierMetadata.some((carrier: any) => carrier.name === 'usps')).to.be.true;
     expect(carrierMetadata).to.have.lengthOf(1);
     expect(carrierMetadata[0]).to.have.property('service_levels');
     expect(carrierMetadata[0]).to.have.property('predefined_packages');

--- a/test/services/carrier_type.test.ts
+++ b/test/services/carrier_type.test.ts
@@ -7,7 +7,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('CarrierType Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);
@@ -21,7 +21,7 @@ describe('CarrierType Service', function () {
   it('retrieves the carrier account types available', async function () {
     const carrierTypes = await client.CarrierType.all();
 
-    carrierTypes.forEach((type) => {
+    carrierTypes.forEach((type: any) => {
       expect(type).to.be.an.instanceOf(CarrierType);
     });
   });

--- a/test/services/claim.test.ts
+++ b/test/services/claim.test.ts
@@ -17,7 +17,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 const CLAIM_AMOUNT = 100;
 
 /** @param {Client} client */
-const buyTestShipment = async (client) => {
+const buyTestShipment = async (client: any) => {
   const shipment = await client.Shipment.create(Fixture.fullShipment() as ShipmentTestCreateInput);
   const rate = shipment.lowestRate();
 
@@ -25,7 +25,7 @@ const buyTestShipment = async (client) => {
 };
 
 /** @param {Client} client */
-const createTestClaim = async (client) => {
+const createTestClaim = async (client: any) => {
   const shipment = await buyTestShipment(client);
 
   const claimData = Fixture.basicClaim() as ClaimTestCreateInput;
@@ -37,7 +37,7 @@ const createTestClaim = async (client) => {
 
 describe('Claim Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -74,7 +74,7 @@ describe('Claim Service', function () {
 
     expect(claimArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(claim.has_more).to.exist;
-    claimArray.forEach((event) => {
+    claimArray.forEach((event: any) => {
       expect(event).to.be.an.instanceOf(Claim);
     });
   });

--- a/test/services/customer_portal.test.ts
+++ b/test/services/customer_portal.test.ts
@@ -7,7 +7,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('CustomerPortal Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);

--- a/test/services/customs_info.test.ts
+++ b/test/services/customs_info.test.ts
@@ -14,7 +14,7 @@ type CustomsInfoTestCreateInput = Parameters<
 
 describe('CustomsInfo Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/customs_item.test.ts
+++ b/test/services/customs_item.test.ts
@@ -2,6 +2,7 @@
 import { expect } from 'vitest';
 
 import EasyPost from '../../src/easypost';
+import type EasyPostClient from '../../src/easypost';
 import CustomsItem from '../../src/models/customs_item';
 import type CustomsItemServiceFactory from '../../src/services/customs_item_service';
 import Fixture from '../helpers/fixture';
@@ -14,7 +15,7 @@ type CustomsItemTestCreateInput = Parameters<
 
 describe('CustomsItem Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPost(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/easypost.test.ts
+++ b/test/services/easypost.test.ts
@@ -11,7 +11,7 @@ type AddressTestCreateInput = Parameters<ReturnType<typeof AddressServiceFactory
 /* eslint-disable func-names */
 describe('EasyPost', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -30,10 +30,10 @@ describe('EasyPost', function () {
   });
 
   it('will log the appropriate values when a request and response hooks are provided', async function () {
-    let requestConfig;
-    const requestHook = (response) => (requestConfig = response);
-    let responseConfig;
-    const responseHook = (response) => (responseConfig = response);
+    let requestConfig: any;
+    const requestHook = (response: any) => (requestConfig = response);
+    let responseConfig: any;
+    const responseHook = (response: any) => (responseConfig = response);
 
     client.addRequestHook(requestHook);
     client.addResponseHook(responseHook);
@@ -65,14 +65,14 @@ describe('EasyPost', function () {
   });
 
   it('will add more than one request and response hook', async function () {
-    let requestConfig1;
-    const requestHook1 = (response) => (requestConfig1 = response);
-    let requestConfig2;
-    const requestHook2 = (response) => (requestConfig2 = response);
-    let responseConfig1;
-    const responseHook1 = (response) => (responseConfig1 = response);
-    let responseConfig2;
-    const responseHook2 = (response) => (responseConfig2 = response);
+    let requestConfig1: any;
+    const requestHook1 = (response: any) => (requestConfig1 = response);
+    let requestConfig2: any;
+    const requestHook2 = (response: any) => (requestConfig2 = response);
+    let responseConfig1: any;
+    const responseHook1 = (response: any) => (responseConfig1 = response);
+    let responseConfig2: any;
+    const responseHook2 = (response: any) => (responseConfig2 = response);
 
     client.addRequestHook(requestHook1);
     client.addRequestHook(requestHook2);
@@ -88,10 +88,10 @@ describe('EasyPost', function () {
   });
 
   it('will unsubscribe from requests and responses', async function () {
-    let requestConfig;
-    const requestHook = (response) => (requestConfig = response);
-    let responseConfig;
-    const responseHook = (response) => (responseConfig = response);
+    let requestConfig: any;
+    const requestHook = (response: any) => (requestConfig = response);
+    let responseConfig: any;
+    const responseHook = (response: any) => (responseConfig = response);
 
     client.addRequestHook(requestHook);
     client.addResponseHook(responseHook);
@@ -114,14 +114,14 @@ describe('EasyPost', function () {
   });
 
   it('will clear all request and response hooks', async function () {
-    let requestConfig1;
-    const requestHook1 = (response) => (requestConfig1 = response);
-    let requestConfig2;
-    const requestHook2 = (response) => (requestConfig2 = response);
-    let responseConfig1;
-    const responseHook1 = (response) => (responseConfig1 = response);
-    let responseConfig2;
-    const responseHook2 = (response) => (responseConfig2 = response);
+    let requestConfig1: any;
+    const requestHook1 = (response: any) => (requestConfig1 = response);
+    let requestConfig2: any;
+    const requestHook2 = (response: any) => (requestConfig2 = response);
+    let responseConfig1: any;
+    const responseHook1 = (response: any) => (responseConfig1 = response);
+    let responseConfig2: any;
+    const responseHook2 = (response: any) => (responseConfig2 = response);
 
     client.addRequestHook(requestHook1);
     client.addRequestHook(requestHook2);
@@ -152,9 +152,9 @@ describe('EasyPost', function () {
   });
 
   it('makes an API call using the generic makeApiCall method', async function () {
-    const response = await client.makeApiCall('get', '/addresses', {
+    const response = (await client.makeApiCall('get', '/addresses', {
       page_size: 1,
-    });
+    })) as { addresses: Array<{ object: string }> };
 
     expect(response.addresses.length).to.equal(1);
     expect(response.addresses[0].object).to.equal('Address');

--- a/test/services/embeddable.test.ts
+++ b/test/services/embeddable.test.ts
@@ -7,7 +7,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('Embeddable Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);

--- a/test/services/end_shipper.test.ts
+++ b/test/services/end_shipper.test.ts
@@ -11,7 +11,7 @@ type EndShipperUpdateInput = Parameters<ReturnType<typeof EndShipperServiceFacto
 
 describe('EndShipper Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -49,7 +49,7 @@ describe('EndShipper Service', function () {
 
     expect(endShippersArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(endShippers.has_more).to.exist;
-    endShippersArray.forEach((endShipper) => {
+    endShippersArray.forEach((endShipper: any) => {
       expect(endShipper).to.be.an.instanceOf(EndShipper);
     });
   });

--- a/test/services/error.test.ts
+++ b/test/services/error.test.ts
@@ -23,7 +23,7 @@ type ClaimTestCreateInput = Parameters<ReturnType<typeof ClaimServiceFactory>['c
 
 describe('Error Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -35,7 +35,7 @@ describe('Error Service', function () {
   });
 
   it('pulls out error properties of an API error', async function () {
-    await client.Shipment.create().catch((error) => {
+    await client.Shipment.create().catch((error: any) => {
       expect(error.statusCode).to.equal(422);
       expect(error.code).to.equal('PARAMETER.REQUIRED');
       expect(error.message).to.equal('Missing required parameter.');
@@ -46,7 +46,7 @@ describe('Error Service', function () {
   it('pulls out error properties of an API error when using the alternative format', async function () {
     const claimData = Fixture.basicClaim() as ClaimTestCreateInput;
     claimData.tracking_code = '123'; // Intentionally pass a bad tracking code
-    await client.Claim.create(claimData).catch((error) => {
+    await client.Claim.create(claimData).catch((error: any) => {
       expect(error.statusCode).to.equal(404);
       expect(error.code).to.equal('NOT_FOUND');
       expect(error.message).to.equal('The requested resource could not be found.');
@@ -70,7 +70,7 @@ describe('Error Service', function () {
       throw ErrorHandler.handleApiError(fakeErrorResponse);
     })
       .to.throw(NotFoundError)
-      .and.satisfy((error) => {
+      .and.satisfy((error: any) => {
         expect(error.message).to.be.equal('ERROR_MESSAGE_1, ERROR_MESSAGE_2');
         expect(error.code).to.be.equal('NO RESPONSE CODE');
         expect(error.errors).to.be.an('array').that.is.empty;
@@ -96,7 +96,7 @@ describe('Error Service', function () {
       throw ErrorHandler.handleApiError(fakeErrorResponse);
     })
       .to.throw(NotFoundError)
-      .and.satisfy((error) => {
+      .and.satisfy((error: any) => {
         expect(error.message).to.be.equal('bad error., second bad error.');
         expect(error.code).to.be.equal('NO RESPONSE CODE');
         expect(error.errors).to.be.an('array').that.is.empty;
@@ -129,7 +129,7 @@ describe('Error Service', function () {
       throw ErrorHandler.handleApiError(fakeErrorResponse);
     })
       .to.throw(NotFoundError)
-      .and.satisfy((error) => {
+      .and.satisfy((error: any) => {
         expect(error.message).to.be.equal(
           'Bad format 1, Bad format 2, Bad format 3, Bad format 4, Bad format 5',
         );

--- a/test/services/event.test.ts
+++ b/test/services/event.test.ts
@@ -18,7 +18,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Event Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -49,7 +49,7 @@ describe('Event Service', function () {
 
     expect(eventsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(events.has_more).to.exist;
-    eventsArray.forEach((event) => {
+    eventsArray.forEach((event: any) => {
       expect(event).to.be.an.instanceOf(Event);
     });
   });
@@ -100,7 +100,7 @@ describe('Event Service', function () {
 
     const payloads = await client.Event.retrieveAllPayloads(event.id);
 
-    payloads.forEach((payload) => {
+    payloads.forEach((payload: any) => {
       expect(payload).to.be.an.instanceOf(Payload);
     });
 

--- a/test/services/fedex_registration.test.ts
+++ b/test/services/fedex_registration.test.ts
@@ -36,7 +36,7 @@ describe('FedExRegistrationService', function () {
       phone_number: '***-***-9721',
     };
 
-    const middleware = (request) => {
+    const middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule(
@@ -74,7 +74,7 @@ describe('FedExRegistrationService', function () {
       message: 'sent secured Pin',
     };
 
-    const middleware = (request) => {
+    const middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule(
@@ -121,7 +121,7 @@ describe('FedExRegistrationService', function () {
       },
     };
 
-    const middleware = (request) => {
+    const middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule(
@@ -175,7 +175,7 @@ describe('FedExRegistrationService', function () {
       },
     };
 
-    const middleware = (request) => {
+    const middleware = (request: any) => {
       return new MockMiddleware(request, [
         new MockRequest(
           new MockRequestMatchRule(

--- a/test/services/insurance.test.ts
+++ b/test/services/insurance.test.ts
@@ -14,7 +14,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Insurance Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -65,7 +65,7 @@ describe('Insurance Service', function () {
 
     expect(insuranceArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(insurance.has_more).to.exist;
-    insuranceArray.forEach((event) => {
+    insuranceArray.forEach((event: any) => {
       expect(event).to.be.an.instanceOf(Insurance);
     });
   });

--- a/test/services/luma.test.ts
+++ b/test/services/luma.test.ts
@@ -10,7 +10,7 @@ type LumaTestGetPromiseInput = Parameters<ReturnType<typeof LumaServiceFactory>[
 /* eslint-disable func-names */
 describe('Luma Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/order.test.ts
+++ b/test/services/order.test.ts
@@ -13,7 +13,7 @@ type OrderTestCreateInput = Parameters<ReturnType<typeof OrderServiceFactory>['c
 
 describe('Order Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -49,7 +49,7 @@ describe('Order Service', function () {
     const ratesArray = rates.rates;
 
     expect(ratesArray).to.be.an.instanceOf(Array);
-    ratesArray.forEach((rate) => {
+    ratesArray.forEach((rate: any) => {
       expect(rate).to.be.an.instanceOf(Rate);
     });
   });
@@ -61,7 +61,7 @@ describe('Order Service', function () {
 
     const shipmentsArray = boughtOrder.shipments;
 
-    shipmentsArray.forEach((shipment) => {
+    shipmentsArray.forEach((shipment: any) => {
       expect(shipment.postage_label).to.exist;
     });
   });

--- a/test/services/parcel.test.ts
+++ b/test/services/parcel.test.ts
@@ -12,7 +12,7 @@ type ParcelTestCreateInput = Parameters<ReturnType<typeof ParcelServiceFactory>[
 
 describe('Parcel Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/pickup.test.ts
+++ b/test/services/pickup.test.ts
@@ -16,7 +16,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Pickup Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -65,7 +65,7 @@ describe('Pickup Service', function () {
 
     expect(pickupsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(pickups.has_more).to.exist;
-    pickupsArray.forEach((pickup) => {
+    pickupsArray.forEach((pickup: any) => {
       expect(pickup).to.be.an.instanceOf(Pickup);
     });
   });

--- a/test/services/rate.test.ts
+++ b/test/services/rate.test.ts
@@ -11,7 +11,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Rate Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/referral_customer.test.ts
+++ b/test/services/referral_customer.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest';
 
 import EasyPost from '../../src/easypost';
+import type EasyPostClient from '../../src/easypost';
 import EndOfPaginationError from '../../src/errors/general/end_of_pagination_error';
 import User from '../../src/models/user';
 import type ReferralCustomerServiceFactory from '../../src/services/referral_customer_service';
@@ -25,9 +26,9 @@ type ReferralCustomerBillingInput = {
 
 describe('ReferralCustomer Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
-  let referralUserProdApiKey;
+  let referralUserProdApiKey: string;
 
   beforeAll(function () {
     const partnerUserProdApiKey = process.env.PARTNER_USER_PROD_API_KEY || '123';
@@ -61,7 +62,7 @@ describe('ReferralCustomer Service', function () {
 
     expect(referralsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(referrals.has_more).to.exist;
-    referralsArray.forEach((referral) => {
+    referralsArray.forEach((referral: any) => {
       expect(referral).to.be.an.instanceOf(User);
     });
   });
@@ -89,7 +90,7 @@ describe('ReferralCustomer Service', function () {
     const testEmail = 'me2@email.com';
 
     await client.ReferralCustomer.updateEmail(singleReferral.id, testEmail).then(
-      expect(function (result) {
+      expect(function (result: any) {
         result.not.to.throw();
       }),
     );
@@ -117,7 +118,7 @@ describe('ReferralCustomer Service', function () {
       referralUserProdApiKey,
       billing.payment_method_id,
       billing.priority,
-    ).catch((error) => {
+    ).catch((error: any) => {
       expect(error.message).to.equal(
         'Stripe::PaymentMethod does not exist for the specified reference_id',
       );
@@ -132,7 +133,7 @@ describe('ReferralCustomer Service', function () {
       billing.financial_connections_id,
       billing.mandate_data,
       billing.priority,
-    ).catch((error) => {
+    ).catch((error: any) => {
       expect(error.message).to.equal(
         'account_holder_name must be present when creating a Financial Connections payment method',
       );

--- a/test/services/refund.test.ts
+++ b/test/services/refund.test.ts
@@ -13,7 +13,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('Refund Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -39,7 +39,7 @@ describe('Refund Service', function () {
 
     const refunds = await client.Refund.create(refundData);
 
-    refunds.forEach((pickup) => {
+    refunds.forEach((pickup: any) => {
       expect(pickup).to.be.an.instanceOf(Refund);
     });
     expect(refunds[0].id).to.match(/^rfnd_/);
@@ -53,7 +53,7 @@ describe('Refund Service', function () {
 
     expect(refundsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(refunds.has_more).to.exist;
-    refundsArray.forEach((refund) => {
+    refundsArray.forEach((refund: any) => {
       expect(refund).to.be.an.instanceOf(Refund);
     });
   });

--- a/test/services/report.test.ts
+++ b/test/services/report.test.ts
@@ -9,7 +9,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('Report Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -81,14 +81,14 @@ describe('Report Service', function () {
 
     expect(reportsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(reports.has_more).to.exist;
-    reportsArray.forEach((report) => {
+    reportsArray.forEach((report: any) => {
       expect(report).to.be.an.instanceOf(Report);
     });
   });
 
   it('retrieves next page of reports', async function () {
-    let reports;
-    let nextPage;
+    let reports: any;
+    let nextPage: any;
 
     try {
       const params = {

--- a/test/services/scan_form.test.ts
+++ b/test/services/scan_form.test.ts
@@ -15,7 +15,7 @@ type ShipmentTestCreateInput = Parameters<ReturnType<typeof ShipmentServiceFacto
 
 describe('ScanForm Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -63,7 +63,7 @@ describe('ScanForm Service', function () {
 
     expect(scanformsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(scanforms.has_more).to.exist;
-    scanformsArray.forEach((scanform) => {
+    scanformsArray.forEach((scanform: any) => {
       expect(scanform).to.be.an.instanceOf(ScanForm);
     });
   });

--- a/test/services/shipment.test.ts
+++ b/test/services/shipment.test.ts
@@ -29,7 +29,7 @@ type ShipmentTestGenerateFormInput = Parameters<
 /* eslint-disable func-names */
 describe('Shipment Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -120,7 +120,7 @@ describe('Shipment Service', function () {
 
     expect(shipmentsArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(shipments.has_more).to.exist;
-    shipmentsArray.forEach((shipment) => {
+    shipmentsArray.forEach((shipment: any) => {
       expect(shipment).to.be.an.instanceOf(Shipment);
     });
   });
@@ -161,7 +161,7 @@ describe('Shipment Service', function () {
     const ratesArray = rates.rates;
 
     expect(ratesArray).to.be.an.instanceOf(Array);
-    ratesArray.forEach((rate) => {
+    ratesArray.forEach((rate: any) => {
       expect(rate).to.be.an.instanceOf(Rate);
     });
   });
@@ -295,7 +295,7 @@ describe('Shipment Service', function () {
     const smartRates = await client.Shipment.getSmartRates(shipment.id);
 
     // Test lowest smartrate with valid filters
-    const lowestSmartRate = client.Utils.getLowestSmartRate(smartRates, 3, 'percentile_90');
+    const lowestSmartRate = client.Utils.getLowestSmartRate(smartRates, 3, 'percentile_90') as any;
     expect(lowestSmartRate.service).to.equal('GroundAdvantage');
     expect(lowestSmartRate.rate).to.equal(6.98);
     expect(lowestSmartRate.carrier).to.equal('USPS');

--- a/test/services/smart_rate.test.ts
+++ b/test/services/smart_rate.test.ts
@@ -17,7 +17,7 @@ type SmartRateRecommendInput = Parameters<
 /* eslint-disable func-names */
 describe('SmartRate Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);

--- a/test/services/tracker.test.ts
+++ b/test/services/tracker.test.ts
@@ -9,7 +9,7 @@ import * as setupPolly from '../helpers/setup_polly';
 
 describe('Tracker Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -50,7 +50,7 @@ describe('Tracker Service', function () {
 
     expect(trackersArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(trackers.has_more).to.exist;
-    trackersArray.forEach((tracker) => {
+    trackersArray.forEach((tracker: any) => {
       expect(tracker).to.be.an.instanceOf(Tracker);
     });
   });
@@ -80,7 +80,7 @@ describe('Tracker Service', function () {
       tracking_codes: [tracker.tracking_code],
     });
 
-    trackers.trackers.forEach((tracker) => {
+    trackers.trackers.forEach((tracker: any) => {
       expect(tracker).to.be.an.instanceOf(Tracker);
     });
   });

--- a/test/services/user.test.ts
+++ b/test/services/user.test.ts
@@ -14,7 +14,7 @@ type UserUpdateInput = Parameters<ReturnType<typeof UserServiceFactory>['update'
 /* eslint-disable func-names */
 describe('User Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_PROD_API_KEY);
@@ -56,7 +56,7 @@ describe('User Service', function () {
   it('updates a user', async function () {
     const testName = 'Test User';
 
-    return client.User.retrieveMe().then(async (user) => {
+    return client.User.retrieveMe().then(async (user: any) => {
       const params: UserUpdateInput = {};
       params.name = testName;
       const updatedUser = await client.User.update(user.id, params);
@@ -73,7 +73,7 @@ describe('User Service', function () {
     });
 
     await client.User.delete(user.id).then(
-      expect(function (result) {
+      expect(function (result: any) {
         result.not.to.throw();
       }),
     );
@@ -98,7 +98,7 @@ describe('User Service', function () {
 
     expect(childrenArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
     expect(response.has_more).to.exist;
-    childrenArray.forEach((children) => {
+    childrenArray.forEach((children: any) => {
       expect(children).to.be.an.instanceOf(User);
     });
   });

--- a/test/services/webhook.test.ts
+++ b/test/services/webhook.test.ts
@@ -11,7 +11,7 @@ import { withoutParams } from '../helpers/utils';
 /* eslint-disable func-names */
 describe('Webhook Service', function () {
   const getPolly = setupPolly.setupPollyTests();
-  let client;
+  let client: EasyPostClient;
 
   beforeAll(function () {
     client = new EasyPostClient(process.env.EASYPOST_TEST_API_KEY);
@@ -61,7 +61,7 @@ describe('Webhook Service', function () {
     const webhooksArray = webhooks.webhooks;
 
     expect(webhooksArray.length).to.be.lessThanOrEqual(Fixture.pageSize());
-    webhooksArray.forEach((webhook) => {
+    webhooksArray.forEach((webhook: any) => {
       expect(webhook).to.be.an.instanceOf(Webhook);
     });
   });
@@ -90,7 +90,7 @@ describe('Webhook Service', function () {
     });
 
     await client.Webhook.delete(webhook.id).then(
-      expect(function (result) {
+      expect(function (result: any) {
         result.not.to.throw();
       }),
     );
@@ -105,7 +105,7 @@ describe('Webhook Service', function () {
       Fixture.eventBody(),
       headers,
       Fixture.webhookSecret(),
-    );
+    ) as { description: string; result: { weight: number } };
 
     expect(webhookBody.description).to.equal('tracker.updated');
     expect(webhookBody.result.weight).to.equal(614.4); // Ensure we convert floats properly

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "declaration": true,
     "noEmit": true,
     "types": ["vitest/globals", "node"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "rootDir": "./src",

--- a/tsconfig.test-services.json
+++ b/tsconfig.test-services.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noEmit": true,
     "skipLibCheck": true,
     "types": ["vitest/globals", "node"]


### PR DESCRIPTION
## Summary
- enable noImplicitAny in build, declarations, and service-test tsconfigs
- resolve strictness fallout across source and service tests
- replace missing external type imports with local structural aliases where needed

## Validation
- npm run lint
- npm run formatCheck
- npm run typescript
