### PR TITLE
fix: remove styleguide symlink from examples repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Publish Stable Package
         if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 just install install-styleguide publish
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 just install publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
       - name: Publish Release Candidate Package
         if: ${{ github.event_name == 'release' && github.event.release.prerelease }}
-        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 just install install-styleguide publish-next
+        run: EASYPOST_TEST_API_KEY=123 EASYPOST_PROD_API_KEY=123 just install publish-next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_API_KEY }}
       - name: Upload assets to release

--- a/justfile
+++ b/justfile
@@ -27,10 +27,6 @@ init-examples-submodule:
     git submodule init
     git submodule update
 
-# Install the styleguide (Unix only)
-install-styleguide: init-examples-submodule
-    sh examples/symlink_directory_files.sh examples/style_guides/node .
-
 # Install project dependencies (Unix only)
 install: init-examples-submodule
     npm install


### PR DESCRIPTION
# Description

We previously used the shared JS styleguide but because it's now TS, we needed a repo-specific one. This was fixed on CI but not the release workflow which just failed when attempting to release.
<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
